### PR TITLE
fix(router): remove defaultShadowOptions to resolve blank page (AUR3174)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,11 +14,6 @@ export default defineConfig({
   plugins: [
     aurelia({
       useDev: true,
-      // The other possible Shadow DOM mode is 'closed'.
-      // If you turn on "closed" mode, there will be difficulty to perform e2e
-      // tests (such as Playwright). Because shadowRoot is not accessible through
-      // standard DOM APIs in "closed" mode.
-      defaultShadowOptions: { mode: 'open' },
     }),
     tailwindcss(),
     nodePolyfills(),


### PR DESCRIPTION
## Description

`vite.config.ts` の `defaultShadowOptions: { mode: 'open' }` を削除し、Aurelia ルーターのクラッシュ（AUR3174）を修正します。

### 問題

`defaultShadowOptions: { mode: 'open' }` を設定すると、Vite プラグインがすべての Aurelia カスタム要素を Shadow DOM モードでコンパイルします。この結果、`<my-app>` の Shadow DOM 内にある `<au-viewport>` が `RouteContext` への登録を `router.start()` より前に完了できず、`AUR3174: Failed to resolve VR(viewport:'default', ...)` エラーが発生し、ページが完全に白くなっていました。

### 原因

`defaultShadowOptions` は初期コミット時に Playwright e2e テスト互換性（closed モードでは `shadowRoot` にアクセス不可）を考慮して設定されましたが、実際には Light DOM でも Playwright は問題なく動作します。また `StyleConfiguration.shadowDOM()` も初期コミットからコメントアウトされており、Shadow DOM の設定が不完全な状態でした。

### 修正

`defaultShadowOptions` を削除し、Light DOM モードに戻します。

## Type of Change

- [x] fix: A bug fix

## Verification

### Automated Tests
- [x] `npm run lint` passed
- [ ] `npm run test` passed
- [ ] `npm run build` passed

### Manual Verification

- ローカル dev サーバー（port 9001）で `http://localhost:9001/` にアクセス
- ウェルカムページ（「大好きなあのバンドのライブ、もう二度と見逃さない。」）が正常表示
- Console に AUR3174 エラーなし
- Sign Up / Sign In ボタンが正常表示

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings