### PR TITLE
fix(router): use canLoad return value for auth redirect to fix AUR3174

### DIFF
--- a/src/services/onboarding-service.ts
+++ b/src/services/onboarding-service.ts
@@ -35,32 +35,40 @@ export class OnboardingService {
 	}
 
 	/**
-	 * Redirect user to the appropriate page based on onboarding status
+	 * Determine the appropriate redirect target based on onboarding status.
+	 * Returns a route path string suitable for use as a canLoad return value.
+	 * - Completed onboarding → 'dashboard'
+	 * - Not completed → 'onboarding/discover'
+	 */
+	public async getRedirectTarget(): Promise<string> {
+		const hasCompleted = await this.hasCompletedOnboarding()
+		if (hasCompleted) {
+			this.logger.info(
+				'User has completed onboarding, redirecting to dashboard',
+			)
+			return 'dashboard'
+		}
+		this.logger.info(
+			'User has not completed onboarding, redirecting to discovery',
+		)
+		return 'onboarding/discover'
+	}
+
+	/**
+	 * Redirect user to the appropriate page based on onboarding status.
+	 * Safe to call from loading hooks or user-initiated actions (not from canLoad).
 	 * - Completed onboarding → dashboard
 	 * - Not completed → artist discovery
 	 */
 	public async redirectBasedOnStatus(): Promise<void> {
-		// Wait for auth service to be ready
 		await this.authService.ready
 
-		// Only redirect if user is authenticated
 		if (!this.authService.isAuthenticated) {
 			this.logger.debug('User not authenticated, no redirect needed')
 			return
 		}
 
-		const hasCompleted = await this.hasCompletedOnboarding()
-
-		if (hasCompleted) {
-			this.logger.info(
-				'User has completed onboarding, redirecting to dashboard',
-			)
-			await this.router.load('dashboard')
-		} else {
-			this.logger.info(
-				'User has not completed onboarding, redirecting to discovery',
-			)
-			await this.router.load('onboarding/discover')
-		}
+		const target = await this.getRedirectTarget()
+		await this.router.load(target)
 	}
 }

--- a/src/welcome-page.ts
+++ b/src/welcome-page.ts
@@ -1,4 +1,4 @@
-import type { IRouteViewModel } from '@aurelia/router'
+import type { IRouteViewModel, NavigationInstruction } from '@aurelia/router'
 import { ILogger, resolve } from 'aurelia'
 import { IAuthService } from './services/auth-service'
 import { IOnboardingService } from './services/onboarding-service'
@@ -10,21 +10,20 @@ export class WelcomePage implements IRouteViewModel {
 
 	/**
 	 * Router lifecycle hook - called before the component is loaded
-	 * Prevents flash of unauthenticated content by checking auth status before rendering
+	 * Prevents flash of unauthenticated content by checking auth status before rendering.
+	 * Returns a redirect instruction instead of calling router.load() to avoid
+	 * re-entrant navigation while the viewport is not yet registered (AUR3174).
 	 */
-	async canLoad(): Promise<boolean> {
+	async canLoad(): Promise<NavigationInstruction | boolean> {
 		this.logger.debug('Checking if landing page can load')
 
 		// Wait for auth service to initialize
 		await this.authService.ready
 
-		// If user is authenticated, redirect and prevent landing page from loading
+		// If user is authenticated, return a redirect instruction
 		if (this.authService.isAuthenticated) {
-			this.logger.info(
-				'User is authenticated, redirecting based on onboarding status',
-			)
-			await this.onboardingService.redirectBasedOnStatus()
-			return false // Prevent landing page from loading
+			this.logger.info('User is authenticated, determining redirect target')
+			return await this.onboardingService.getRedirectTarget()
 		}
 
 		// User not authenticated, show landing page


### PR DESCRIPTION
## Summary

- `WelcomePage.canLoad` が `router.load()` をプログラム的に呼び出していたため、ビューポートがまだ登録されていない初期ナビゲーション中に再入ナビゲーションが発生し、認証済みユーザーで AUR3174 → 白画面となっていた
- Aurelia 2 の正しいパターンに従い、`canLoad` から `NavigationInstruction`（文字列パス）を `return` するよう修正
- `OnboardingService.getRedirectTarget()` を追加してリダイレクト先の決定ロジックを分離し、`redirectBasedOnStatus()` もこれを利用するよう整理

## Root Cause

```typescript
// BEFORE (anti-pattern) - causes AUR3174 for authenticated users
async canLoad(): Promise<boolean> {
  if (this.authService.isAuthenticated) {
    await this.onboardingService.redirectBasedOnStatus() // calls router.load() internally
    return false
  }
  return true
}

// AFTER (correct pattern per Aurelia 2 docs)
async canLoad(): Promise<NavigationInstruction | boolean> {
  if (this.authService.isAuthenticated) {
    return await this.onboardingService.getRedirectTarget() // returns 'dashboard' or 'onboarding/discover'
  }
  return true
}
```

## Reference

- [Aurelia 2 Docs: canLoad redirect pattern](https://docs.aurelia.io/getting-to-know-aurelia/aurelia-router/lifecycle-and-events/routing-lifecycle)
- Calling `router.load()` from inside `canLoad` is explicitly documented as an anti-pattern

## Test plan

- [ ] 未認証ユーザー: `https://dev.liverty-music.app/` にアクセス → ウェルカムページが表示される
- [ ] 認証済みユーザー（オンボーディング完了）: アクセス → dashboard にリダイレクト
- [ ] 認証済みユーザー（オンボーディング未完了）: アクセス → `onboarding/discover` にリダイレクト