### PR TITLE
fix(build): use production mode for vite build to fix AUR3174

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,8 @@
 # Vite Environment Variables
 # These are embedded in the client bundle during build and visible in browser
+
+VITE_API_BASE_URL=https://api.dev.liverty-music.app
+
+# Zitadel Authentication
+VITE_ZITADEL_ISSUER=https://dev-svijfm.us1.zitadel.cloud
+VITE_ZITADEL_CLIENT_ID=358723495233859681

--- a/.env.development
+++ b/.env.development
@@ -1,9 +1,0 @@
-# Vite Environment Variables
-# Copy this file to .env for local development
-# These are embedded in the client bundle during build and visible in browser
-
-VITE_API_BASE_URL=https://api.dev.liverty-music.app
-
-# Zitadel Authentication
-VITE_ZITADEL_ISSUER=https://dev-svijfm.us1.zitadel.cloud
-VITE_ZITADEL_CLIENT_ID=358723495233859681

--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -9,6 +9,7 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - 'vite.config.ts'
+      - '.env'
       - 'Dockerfile'
       - 'Caddyfile'
       - '.github/workflows/push-image.yaml'
@@ -64,5 +65,3 @@ jobs:
           tags: ${{ env.IMAGE_URI }}:latest,${{ env.IMAGE_URI }}:${{ github.sha }},${{ env.IMAGE_URI }}:main
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: |
-            BUILD_MODE=${{ github.ref == 'refs/heads/main' && 'development' || 'production' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,8 @@ RUN npm ci
 # Copy source code (including .env files)
 COPY . .
 
-# Build the application with mode-specific env vars
-# ARG is available only during build time
-ARG BUILD_MODE=development
-RUN npm run build -- --mode ${BUILD_MODE}
+# Build the application
+RUN npm run build
 
 #----------------------------
 


### PR DESCRIPTION
## Summary

- Move env vars from `.env.development` to `.env`
- Delete `.env.development`
- Remove `BUILD_MODE` ARG from `Dockerfile` (defaults to production mode)
- Remove `build-args` from `push-image.yaml`, add `.env` to paths trigger

## Root Cause

`@aurelia/vite-plugin` does not inline HTML templates into JS chunks when building with `--mode development`. Lazy-imported route components receive an empty module object instead of component definition (name + template + register function), causing them to be registered as `unnamed-N`. The router then fails to resolve them → AUR3174.

| | `--mode development` | production (default) |
|---|---|---|
| Chunk content | Empty module object | `name` + inlined template HTML + `register()` |
| Router resolution | `unnamed-N` → AUR3174 | `welcome-page` → success |

## Verification

- Local `vite build` (production mode) + `vite preview` → welcome page renders, no AUR3174
- Local `vite build --mode development` + `vite preview` → AUR3174 reproduced

## Test plan

- [ ] CI passes (lint, typecheck, test)
- [ ] After deploy: `https://dev.liverty-music.app/` shows welcome page without AUR3174