### PR TITLE
feat(auth): enforce passkey-only authentication via org scope

### DIFF
--- a/.env
+++ b/.env
@@ -6,3 +6,4 @@ VITE_API_BASE_URL=https://api.dev.liverty-music.app
 # Zitadel Authentication
 VITE_ZITADEL_ISSUER=https://dev-svijfm.us1.zitadel.cloud
 VITE_ZITADEL_CLIENT_ID=358723495233859681
+VITE_ZITADEL_ORG_ID=358672916038025519

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -12,7 +12,15 @@ const settings: UserManagerSettings = {
 	redirect_uri: `${window.location.origin}/auth/callback`,
 	post_logout_redirect_uri: window.location.origin,
 	response_type: 'code',
-	scope: 'openid profile email offline_access', // offline_access for refresh tokens
+	scope: [
+		'openid profile email offline_access',
+		// Include org scope so Zitadel applies the Org-level login policy (passkey only)
+		import.meta.env.VITE_ZITADEL_ORG_ID
+			? `urn:zitadel:iam:org:id:${import.meta.env.VITE_ZITADEL_ORG_ID}`
+			: '',
+	]
+		.filter(Boolean)
+		.join(' '),
 	// PKCE is standard/default for 'code' flow in newer oidc-client-ts versions
 	loadUserInfo: true,
 	// Use localStorage instead of sessionStorage for better compatibility with Playwright storageState


### PR DESCRIPTION
## Summary
- Add `VITE_ZITADEL_ORG_ID` env var and include `urn:zitadel:iam:org:id:{orgId}` in OIDC scope
- This ensures Zitadel applies the Org-level login policy (passkey only, no password, no external IDP) instead of falling back to Instance defaults

## Test plan
- [ ] Start dev server and click Sign In
- [ ] Verify Zitadel login page shows only loginname input (no password field)
- [ ] Verify no external IDP (Google) button is displayed
- [ ] Verify passkey authentication works end-to-end