### PR TITLE
feat(artist-discovery): wire ArtistService.Follow RPC on bubble tap

### DIFF
--- a/src/services/artist-discovery-service.ts
+++ b/src/services/artist-discovery-service.ts
@@ -62,8 +62,10 @@ export class ArtistDiscoveryService {
 		this.followedArtists.push(artist)
 		this.orbIntensity = Math.min(1, this.followedArtists.length / 20)
 
-		// TODO: Call backend ArtistService.Follow via Connect-RPC when TS clients are generated
-		// await artistClient.follow({ artistId: new ArtistId({ value: artist.id }) })
+		// Fire-and-forget: persist follow to backend without blocking UI
+		this.artistClient
+			.follow({ artistId: new ArtistId({ value: artist.id }) })
+			.catch((err) => this.logger.error('Failed to follow artist via RPC', err))
 
 		this.logger.info('Artist followed', {
 			followed: this.followedArtists.length,


### PR DESCRIPTION
## Description

Wire up the `ArtistService.Follow` RPC call in `followArtist()` using the database-assigned artist ID now returned by `ListTop`/`ListSimilar` after the backend artist-creation changes.

The call is fire-and-forget: local state updates immediately without blocking the UI, and any RPC error is logged silently.

## Type of Change

- [x] feat: A new feature

## Verification

### Automated Tests
- [x] `npm run lint` passed

### Manual Verification
- Bubble tap now triggers the Follow RPC with the artist's valid DB-assigned ID

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

close: #artist-creation