### PR TITLE
feat(error-handling): add Connect error routing and toast severity

### DIFF
--- a/src/components/error-banner/error-banner.ts
+++ b/src/components/error-banner/error-banner.ts
@@ -29,7 +29,10 @@ export class ErrorBanner {
 
 		const now = Date.now()
 		if (now - this.lastReportTime < ErrorBanner.REPORT_COOLDOWN_MS) {
-			this.toastService.show('Please wait before reporting another issue')
+			this.toastService.show(
+				'Please wait before reporting another issue',
+				'warning',
+			)
 			return
 		}
 		this.lastReportTime = now

--- a/src/components/toast-notification/toast-notification.html
+++ b/src/components/toast-notification/toast-notification.html
@@ -4,9 +4,15 @@
   <div
     repeat.for="toast of toasts"
     role="status"
-    class="flex items-center gap-2 px-5 py-3 bg-gradient-to-r from-brand-primary to-brand-secondary backdrop-blur-sm text-white font-display font-semibold rounded-xl shadow-[var(--shadow-card-glow)] pointer-events-auto ${toast.visible ? 'animate-[bounce-in_400ms_ease-out_both]' : 'opacity-0 -translate-y-4 transition-[transform,opacity] duration-300'}"
+    class="flex items-center gap-2 px-5 py-3 bg-gradient-to-r ${severityClass(toast.severity)} backdrop-blur-sm text-white font-display font-semibold rounded-xl shadow-[var(--shadow-card-glow)] pointer-events-auto ${toast.visible ? 'animate-[bounce-in_400ms_ease-out_both]' : 'opacity-0 -translate-y-4 transition-[transform,opacity] duration-300'}"
   >
-    <icon-ticket></icon-ticket>
+    <icon-ticket if.bind="toast.severity === 'info'"></icon-ticket>
+    <svg if.bind="toast.severity === 'warning'" class="w-5 h-5 shrink-0" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 6a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 6zm0 9a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/>
+    </svg>
+    <svg if.bind="toast.severity === 'error'" class="w-5 h-5 shrink-0" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z" clip-rule="evenodd"/>
+    </svg>
     ${toast.message}
   </div>
 </div>

--- a/src/components/toast-notification/toast-notification.ts
+++ b/src/components/toast-notification/toast-notification.ts
@@ -1,9 +1,19 @@
 import { DI } from 'aurelia'
 
+export type ToastSeverity = 'info' | 'warning' | 'error'
+
 interface ToastItem {
 	id: number
 	message: string
+	severity: ToastSeverity
 	visible: boolean
+}
+
+/** CSS class mapping for toast severity levels. */
+const SEVERITY_CLASSES: Record<ToastSeverity, string> = {
+	info: 'from-brand-primary to-brand-secondary',
+	warning: 'from-amber-600 to-amber-500',
+	error: 'from-red-700 to-red-600',
 }
 
 export const IToastService = DI.createInterface<IToastService>(
@@ -17,9 +27,13 @@ export class ToastNotification {
 	public toasts: ToastItem[] = []
 	private nextId = 0
 
-	public show(message: string, durationMs = 2500): void {
+	public show(
+		message: string,
+		severity: ToastSeverity = 'info',
+		durationMs = 2500,
+	): void {
 		const id = this.nextId++
-		const toast: ToastItem = { id, message, visible: false }
+		const toast: ToastItem = { id, message, severity, visible: false }
 		this.toasts.push(toast)
 
 		// Trigger slide-in on next frame
@@ -34,5 +48,10 @@ export class ToastNotification {
 				this.toasts = this.toasts.filter((t) => t.id !== id)
 			}, 400)
 		}, durationMs)
+	}
+
+	/** Returns the gradient CSS classes for a toast's severity. */
+	public severityClass(severity: ToastSeverity): string {
+		return SEVERITY_CLASSES[severity]
 	}
 }

--- a/src/hooks/auth-hook.ts
+++ b/src/hooks/auth-hook.ts
@@ -26,7 +26,7 @@ export class AuthHook implements ILifecycleHooks<IRouteViewModel, 'canLoad'> {
 		await this.authService.ready
 
 		if (!this.authService.isAuthenticated) {
-			this.toastService.show('ログインが必要です')
+			this.toastService.show('ログインが必要です', 'warning')
 			return ''
 		}
 

--- a/src/routes/artist-discovery/artist-discovery-page.ts
+++ b/src/routes/artist-discovery/artist-discovery-page.ts
@@ -40,7 +40,10 @@ export class ArtistDiscoveryPage {
 		} catch (err) {
 			this.logger.error('Failed to load initial artists', { error: err })
 			this.loadFailed = true
-			this.toastService.show('Failed to load artists. Tap retry to try again.')
+			this.toastService.show(
+				'Failed to load artists. Tap retry to try again.',
+				'error',
+			)
 		}
 	}
 
@@ -53,6 +56,7 @@ export class ArtistDiscoveryPage {
 			this.loadFailed = true
 			this.toastService.show(
 				'Still unable to load artists. Please try again later.',
+				'error',
 			)
 		}
 	}
@@ -96,6 +100,7 @@ export class ArtistDiscoveryPage {
 			})
 			this.toastService.show(
 				`Failed to follow ${artist.name}. Please try again.`,
+				'error',
 			)
 			return
 		}
@@ -125,7 +130,10 @@ export class ArtistDiscoveryPage {
 			artistName,
 			error: event.detail.error,
 		})
-		this.toastService.show(`Couldn't find similar artists for ${artistName}`)
+		this.toastService.show(
+			`Couldn't find similar artists for ${artistName}`,
+			'warning',
+		)
 	}
 
 	public async onViewSchedule(): Promise<void> {

--- a/src/routes/discover/discover-page.ts
+++ b/src/routes/discover/discover-page.ts
@@ -51,7 +51,7 @@ export class DiscoverPage {
 			await this.discoveryService.loadInitialArtists('Japan', '')
 		} catch (err) {
 			this.logger.error('Failed to load initial artists', err)
-			this.toastService.show('Failed to load discovery data')
+			this.toastService.show('Failed to load discovery data', 'error')
 		}
 	}
 
@@ -85,7 +85,7 @@ export class DiscoverPage {
 				this.dnaOrbCanvas.reloadBubbles(this.discoveryService.availableBubbles)
 			} catch (err) {
 				this.logger.error('Failed to clear genre tag', err)
-				this.toastService.show('Failed to reset discovery view')
+				this.toastService.show('Failed to reset discovery view', 'error')
 			} finally {
 				this.isLoadingTag = false
 			}
@@ -103,7 +103,7 @@ export class DiscoverPage {
 		} catch (err) {
 			this.activeTag = ''
 			this.logger.warn('Failed to load genre artists', err)
-			this.toastService.show(`Couldn't load ${tag} artists`)
+			this.toastService.show(`Couldn't load ${tag} artists`, 'error')
 		} finally {
 			this.isLoadingTag = false
 		}
@@ -151,7 +151,7 @@ export class DiscoverPage {
 			this.searchResults = results
 		} catch (err) {
 			this.logger.warn('Search failed', err)
-			this.toastService.show('Search failed, please try again')
+			this.toastService.show('Search failed, please try again', 'warning')
 			this.searchResults = []
 		} finally {
 			if (this.searchQuery.trim() === query) {
@@ -169,7 +169,19 @@ export class DiscoverPage {
 			artist: artist.name,
 		})
 
-		await this.discoveryService.followArtist(artist)
+		try {
+			await this.discoveryService.followArtist(artist)
+		} catch (err) {
+			this.logger.error('Failed to follow artist', {
+				artist: artist.name,
+				error: err,
+			})
+			this.toastService.show(
+				`Failed to follow ${artist.name}. Please try again.`,
+				'error',
+			)
+			return
+		}
 		if (this.abortController.signal.aborted) return
 
 		try {
@@ -190,7 +202,19 @@ export class DiscoverPage {
 			artist: artist.name,
 		})
 
-		await this.discoveryService.followArtist(artist)
+		try {
+			await this.discoveryService.followArtist(artist)
+		} catch (err) {
+			this.logger.error('Failed to follow artist from search', {
+				artist: artist.name,
+				error: err,
+			})
+			this.toastService.show(
+				`Failed to follow ${artist.name}. Please try again.`,
+				'error',
+			)
+			return
+		}
 		if (this.abortController.signal.aborted) return
 
 		try {
@@ -225,6 +249,7 @@ export class DiscoverPage {
 		})
 		this.toastService.show(
 			`Couldn't find similar artists for ${event.detail.artistName}`,
+			'warning',
 		)
 	}
 }

--- a/src/routes/onboarding-loading/loading-sequence.ts
+++ b/src/routes/onboarding-loading/loading-sequence.ts
@@ -109,6 +109,7 @@ export class LoadingSequence {
 				})
 				this.toastService.show(
 					`Some artist schedules couldn't be loaded (${result.failedCount}/${result.totalCount})`,
+					'warning',
 				)
 				break
 			case 'failed':

--- a/src/routes/settings/settings-page.ts
+++ b/src/routes/settings/settings-page.ts
@@ -72,7 +72,7 @@ export class SettingsPage {
 			await this.auth.signOut()
 		} catch (err) {
 			this.logger.error('Sign-out failed', { error: err })
-			this.toastService.show('Sign-out failed. Please try again.')
+			this.toastService.show('Sign-out failed. Please try again.', 'error')
 		}
 	}
 }

--- a/src/services/connect-error-router.ts
+++ b/src/services/connect-error-router.ts
@@ -1,0 +1,61 @@
+import { Code, ConnectError, type Interceptor } from '@connectrpc/connect'
+import type { IAuthService } from './auth-service'
+
+/**
+ * Creates a Connect interceptor that handles Unauthenticated errors
+ * by attempting a silent token refresh and retrying the original request.
+ * If the refresh fails, the user is redirected to the landing page.
+ */
+export const createAuthRetryInterceptor = (auth: IAuthService): Interceptor => {
+	return (next) => async (req) => {
+		try {
+			return await next(req)
+		} catch (err) {
+			if (!(err instanceof ConnectError)) throw err
+			if (err.code !== Code.Unauthenticated) throw err
+
+			// Attempt silent token refresh via OIDC signinSilent
+			try {
+				const user = await auth.getUserManager().signinSilent()
+				if (user?.access_token) {
+					req.header.set('Authorization', `Bearer ${user.access_token}`)
+					return await next(req)
+				}
+			} catch {
+				// Silent refresh failed — redirect to login
+			}
+
+			// Clear auth state and redirect to landing page
+			await auth.getUserManager().removeUser()
+			window.location.href = '/welcome'
+			throw err
+		}
+	}
+}
+
+/**
+ * Creates a Connect interceptor that retries transient errors
+ * (Unavailable, DeadlineExceeded) with exponential backoff.
+ */
+export const createRetryInterceptor = (maxRetries = 3): Interceptor => {
+	const retryableCodes = new Set([Code.Unavailable, Code.DeadlineExceeded])
+
+	return (next) => async (req) => {
+		let lastError: unknown
+		for (let attempt = 0; attempt <= maxRetries; attempt++) {
+			try {
+				return await next(req)
+			} catch (err) {
+				lastError = err
+				if (!(err instanceof ConnectError)) throw err
+				if (!retryableCodes.has(err.code)) throw err
+				if (attempt === maxRetries) throw err
+
+				// Exponential backoff: 200ms, 400ms, 800ms
+				const delay = 200 * 2 ** attempt
+				await new Promise((resolve) => setTimeout(resolve, delay))
+			}
+		}
+		throw lastError
+	}
+}

--- a/src/services/grpc-transport.ts
+++ b/src/services/grpc-transport.ts
@@ -3,6 +3,10 @@ import { ConnectError } from '@connectrpc/connect'
 import { createConnectTransport } from '@connectrpc/connect-web'
 import { SpanStatusCode, trace } from '@opentelemetry/api'
 import type { IAuthService } from './auth-service'
+import {
+	createAuthRetryInterceptor,
+	createRetryInterceptor,
+} from './connect-error-router'
 
 const baseUrl = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080'
 
@@ -80,6 +84,11 @@ export const createTransport = (auth: IAuthService) => {
 
 	return createConnectTransport({
 		baseUrl,
-		interceptors: [otelInterceptor, authInterceptor],
+		interceptors: [
+			otelInterceptor,
+			authInterceptor,
+			createAuthRetryInterceptor(auth),
+			createRetryInterceptor(),
+		],
 	})
 }


### PR DESCRIPTION
## Description

Add cross-stack error handling improvements: Connect interceptors for code-specific error routing (auth retry, transient error retry with backoff), toast severity levels (info/warning/error) with visual differentiation, and fix unhandled follow errors in discover page.

## Type of Change

- [x] feat: A new feature

## Changes

### Connect Error Interceptors (`connect-error-router.ts`)
- **AuthRetryInterceptor**: On `Unauthenticated` error, attempts silent OIDC token refresh and retries the original request. Falls back to redirecting to `/welcome` if refresh fails.
- **RetryInterceptor**: Automatically retries `Unavailable` and `DeadlineExceeded` errors with exponential backoff (200ms → 400ms → 800ms, max 3 retries).

### Toast Severity Levels
- Added `ToastSeverity` type (`info` | `warning` | `error`) to `ToastService`
- Each severity has distinct gradient colors and icons:
  - `info` (default): brand gradient + ticket icon
  - `warning`: amber gradient + triangle icon
  - `error`: red gradient + circle-x icon
- Updated all existing callers to use appropriate severity

### Bug Fix: Unhandled Follow Errors
- Wrapped `followArtist()` calls in `discover-page.ts` (`onArtistSelected`, `onFollowFromSearch`) with try-catch + error toast
- Previously, failures caused `unhandledrejection` → Error Banner (heavy UX for transient errors)

## Verification

### Automated Tests
- [x] `npm run lint` passed (pre-existing unrelated warnings only)
- [ ] `npm run test` passed
- [ ] `npm run build` passed

### Manual Verification
- Verified TypeScript compilation with `tsc --noEmit` (no errors in modified files)
- Verified Biome formatting and linting passes for all modified files

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

close: liverty-music/specification#94