### PR TITLE
fix(pwa): disable ServiceWorker registration in dev mode

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -72,8 +72,10 @@ Aurelia
 	.app(MyApp)
 	.start()
 
-// Register Service Worker for push notifications after Aurelia bootstrap
-if ('serviceWorker' in navigator) {
+// Register Service Worker for push notifications (production only).
+// In dev mode, vite-plugin-node-polyfills injects Buffer/global/process shims
+// into the SW bundle, which breaks ServiceWorker evaluation.
+if ('serviceWorker' in navigator && !import.meta.env.DEV) {
 	navigator.serviceWorker.register('/sw.js').catch((err) => {
 		console.warn('Service Worker registration failed:', err)
 	})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
       },
       manifest: false, // Use public/manifest.json directly
       devOptions: {
-        enabled: true,
+        enabled: false,
       },
     }),
   ],


### PR DESCRIPTION
## Summary
- Disable `vite-plugin-pwa` `devOptions.enabled` to prevent `dev-sw.js` generation in dev mode
- Skip manual SW registration in `main.ts` when `import.meta.env.DEV` is true
- Root cause: `vite-plugin-node-polyfills` injects `Buffer`/`global`/`process` shims into the dev SW bundle, which breaks `ServiceWorker` evaluation (SW scope has no `window`/`document`)

## Test plan
- [x] `npm start` → no "Something went wrong" dialog on `http://localhost:9000/`
- [x] Console has no ServiceWorker-related errors or warnings
- [ ] Production build (`npm run build`) still generates and registers `sw.js` correctly