### PR TITLE
fix(templates): replace removed .call binding with .bind lambda

### DIFF
--- a/src/routes/dashboard.html
+++ b/src/routes/dashboard.html
@@ -85,5 +85,5 @@
 <!-- Region setup bottom sheet -->
 <region-setup-sheet
   view-model.ref="regionSheet"
-  on-region-selected.call="onRegionSelected($event)"
+  on-region-selected.bind="(region) => onRegionSelected(region)"
 ></region-setup-sheet>

--- a/src/routes/settings/settings-page.html
+++ b/src/routes/settings/settings-page.html
@@ -123,5 +123,5 @@
 <!-- Area Selector Bottom Sheet -->
 <area-selector-sheet
   view-model.ref="areaSheet"
-  on-area-selected.call="onAreaSelected($event)"
+  on-area-selected.bind="({ $event }) => onAreaSelected($event)"
 ></area-selector-sheet>


### PR DESCRIPTION
## Summary

- Replace `.call` binding command (removed in Aurelia 2) with `.bind` + lambda expressions in `dashboard.html` and `settings-page.html`
- This fixes the AUR0009 crash that prevents authenticated users from accessing the dashboard and settings pages

## Root Cause

Aurelia 2 (`2.0.0-rc.0`) removed the `.call` binding command entirely. Two templates still used it:
- `on-region-selected.call="..."` in dashboard
- `on-area-selected.call="..."` in settings

When the template compiler encounters `.call`, it tries to resolve `au:resource:binding-command:call` from the DI container, which doesn't exist, causing the AUR0009 error.

## Test plan

- [x] Reproduced the bug on https://dev.liverty-music.app/dashboard via Playwright
- [x] `vite build` passes successfully
- [ ] Verify dashboard loads without AUR0009 error after deploy
- [ ] Verify settings page area selector works after deploy

Closes #70