### PR TITLE
fix(auth): log auth state after assignment to reflect actual state

### DIFF
--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -65,11 +65,11 @@ export class AuthService {
 	}
 
 	private updateState(user: User | null): void {
+		this.user = user
 		this.logger.info('Auth state updated', {
 			isAuthenticated: this.isAuthenticated,
 			user: user?.profile.preferred_username,
 		})
-		this.user = user
 	}
 
 	public async signIn(): Promise<void> {


### PR DESCRIPTION
## Summary

- Fix misleading auth log that showed `isAuthenticated: false` alongside a valid user email
- Reorder `updateState()` to assign `this.user` before logging, so the log reflects actual post-update state

## Root Cause

In `AuthService.updateState()`, the log statement read `this.isAuthenticated` (a getter over `this.user`) **before** `this.user` was assigned. This produced a contradictory log entry — `isAuthenticated: false` with a valid email — even though the auth flow itself was correct.

```
Before: log(isAuthenticated=false) → this.user = user
After:  this.user = user → log(isAuthenticated=true)
```

No behavioral change to the auth flow — purely a logging fix.

Closes #76

## Test plan

- [x] `auth-service.spec.ts` — all 6 tests pass
- [ ] Verify on `dev.liverty-music.app` that console shows `isAuthenticated: true` when a valid user is present