### PR TITLE
fix(auth): prevent callback page hang after sign-up

### DIFF
--- a/src/routes/auth-callback.ts
+++ b/src/routes/auth-callback.ts
@@ -25,9 +25,16 @@ export class AuthCallback {
 		this.logger.info('Constructor called')
 	}
 
-	// biome-ignore lint/suspicious/noExplicitAny: Params are dynamic
-	public async loading(params: any): Promise<void> {
-		this.logger.info('Starting loading hook...', params)
+	/**
+	 * Navigate after the component is attached to the DOM.
+	 *
+	 * Aurelia's `loading()` hook runs while a navigation is still in progress.
+	 * Calling `router.load()` from within `loading()` silently blocks because
+	 * the router is already mid-transition.  Moving the logic to `attached()`
+	 * ensures the current navigation has settled before we trigger a new one.
+	 */
+	public async attached(): Promise<void> {
+		this.logger.info('Attached, starting auth callback processing...')
 		try {
 			this.logger.info('Calling handleCallback...')
 			const user = await this.authService.handleCallback()

--- a/test/routes/auth-callback.spec.ts
+++ b/test/routes/auth-callback.spec.ts
@@ -39,14 +39,14 @@ describe('AuthCallback', () => {
 		sut = container.get(AuthCallback)
 	})
 
-	describe('loading', () => {
+	describe('attached', () => {
 		it('should redirect to discover on sign-up', async () => {
 			mockAuth.handleCallback = vi.fn().mockResolvedValue({
 				state: { isSignUp: true },
 				profile: { email: 'new@example.com' },
 			})
 
-			await sut.loading({})
+			await sut.attached()
 
 			expect(mockUserService.client.create).toHaveBeenCalled()
 			expect(mockRouter.load).toHaveBeenCalledWith('/onboarding/discover')
@@ -58,7 +58,7 @@ describe('AuthCallback', () => {
 				profile: { email: 'existing@example.com' },
 			})
 
-			await sut.loading({})
+			await sut.attached()
 
 			expect(mockUserService.client.create).not.toHaveBeenCalled()
 			expect(mockRouter.load).toHaveBeenCalledWith('/dashboard')
@@ -69,7 +69,7 @@ describe('AuthCallback', () => {
 				profile: { email: 'existing@example.com' },
 			})
 
-			await sut.loading({})
+			await sut.attached()
 
 			expect(mockRouter.load).toHaveBeenCalledWith('/dashboard')
 		})
@@ -80,7 +80,7 @@ describe('AuthCallback', () => {
 				.mockRejectedValue(new Error('callback error'))
 			mockAuth.isAuthenticated = true
 
-			await sut.loading({})
+			await sut.attached()
 
 			expect(mockRouter.load).toHaveBeenCalledWith('/dashboard')
 			expect(sut.error).toBe('')
@@ -92,7 +92,7 @@ describe('AuthCallback', () => {
 				.mockRejectedValue(new Error('auth failed'))
 			mockAuth.isAuthenticated = false
 
-			await sut.loading({})
+			await sut.attached()
 
 			expect(mockRouter.load).not.toHaveBeenCalled()
 			expect(sut.error).toBe('Login failed: auth failed')
@@ -107,7 +107,7 @@ describe('AuthCallback', () => {
 				.fn()
 				.mockRejectedValue(new ConnectError('exists', Code.AlreadyExists))
 
-			await sut.loading({})
+			await sut.attached()
 
 			expect(mockRouter.load).toHaveBeenCalledWith('/onboarding/discover')
 		})
@@ -121,7 +121,7 @@ describe('AuthCallback', () => {
 				.fn()
 				.mockRejectedValue(new Error('server error'))
 
-			await sut.loading({})
+			await sut.attached()
 
 			expect(mockRouter.load).not.toHaveBeenCalled()
 			expect(sut.error).toBe('Login failed: server error')
@@ -133,7 +133,7 @@ describe('AuthCallback', () => {
 				profile: {},
 			})
 
-			await sut.loading({})
+			await sut.attached()
 
 			expect(mockUserService.client.create).not.toHaveBeenCalled()
 			expect(mockRouter.load).toHaveBeenCalledWith('/onboarding/discover')


### PR DESCRIPTION
## Summary
- SignUp後の callback ページで画面がストップする問題を修正
- `loading()` ライフサイクルフック内で `router.load()` を呼んでいたのが原因
- Aurelia の `loading()` はナビゲーション遷移中に実行されるため、その中で新しいナビゲーションを開始するとルーターがサイレントにブロックされる
- ロジックを `attached()` に移動することで、現在のナビゲーションが完了してから次のナビゲーションを発火するよう修正

## Root Cause
```
loading() runs DURING navigation transition
  └─ router.load() called here
       └─ Router already mid-transition → silently blocked → page hangs
```

## Fix
```
attached() runs AFTER navigation settles
  └─ router.load() called here
       └─ Router is idle → navigation succeeds ✅
```

## Test plan
- [x] All 8 existing unit tests pass (updated from `loading()` to `attached()`)
- [ ] Manual test: Sign up with new account → should redirect to `/onboarding/discover`
- [ ] Manual test: Sign in with existing account → should redirect to `/dashboard`