### PR TITLE
feat(discover): pass tag parameter to ListTop for genre filtering

### DIFF
--- a/src/services/artist-discovery-service.ts
+++ b/src/services/artist-discovery-service.ts
@@ -50,9 +50,7 @@ export class ArtistDiscoveryService {
 		for (const f of this.followedArtists) {
 			this.seenArtistNames.add(f.name.toLowerCase())
 		}
-		// NOTE: `tag` field requires BSR proto publish (specification#73).
-		// Once ListTopRequest includes `tag`, add it to the request object.
-		const resp = await this.artistClient.listTop({ country })
+		const resp = await this.artistClient.listTop({ country, tag })
 		const bubbles = resp.artists
 			.map((a) => this.toBubble(a))
 			.filter((b) => !this.seenArtistNames.has(b.name.toLowerCase()))
@@ -71,8 +69,7 @@ export class ArtistDiscoveryService {
 		for (const f of this.followedArtists) {
 			this.seenArtistNames.add(f.name.toLowerCase())
 		}
-		// NOTE: `tag` field requires BSR proto publish (specification#73).
-		const resp = await this.artistClient.listTop({ country })
+		const resp = await this.artistClient.listTop({ country, tag })
 		const bubbles = resp.artists
 			.map((a) => this.toBubble(a))
 			.filter((b) => !this.seenArtistNames.has(b.name.toLowerCase()))


### PR DESCRIPTION
## Summary
- Pass `tag` parameter to `listTop()` in both `loadInitialArtists()` and `reloadWithTag()` methods
- Remove stale NOTE comments referencing blocked BSR proto publish (specification#73, published in v0.12.0)

## Context
Genre chip selection on the Discover page was visually functional but not actually filtering artists — the `tag` parameter was never passed to the API call. The backend and proto were already ready since v0.12.0.

## Test plan
- [ ] Select different genre chips (Rock, Pop, Anime, etc.) and verify different artists appear
- [ ] Verify "All" chip resets to unfiltered top artists
- [ ] Verify build passes (`npm run build`)