### PR TITLE
fix(ci): add --comment flag to code-review plugin prompt

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,7 +38,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
- Add `--comment` flag to the `/code-review:code-review` prompt

## Background
The `code-review` plugin only posts GitHub PR comments when `--comment` is explicitly passed (plugin step 7). Without it, review results are printed to the CI terminal only and no comments appear on the PR.

## Test plan
- [ ] Open a new PR and verify Claude posts a review comment