### PR TITLE
fix(auth): move OIDC callback redirect from attached() to canLoad()

### DIFF
--- a/src/routes/auth-callback.html
+++ b/src/routes/auth-callback.html
@@ -1,6 +1,6 @@
 <div class="flex items-center justify-center min-h-screen">
   <div class="text-center">
-    <div if.bind="message" class="text-lg">${message}</div>
+    <div if.bind="!error" class="text-lg">Verifying authentication...</div>
     <div if.bind="error" class="text-red-500 font-bold whitespace-pre-wrap">${error}</div>
     <a if.bind="error" href="/" class="mt-4 block text-blue-500 underline"
       >Return Home</a

--- a/src/routes/auth-callback.ts
+++ b/src/routes/auth-callback.ts
@@ -1,4 +1,4 @@
-import { IRouter } from '@aurelia/router'
+import type { NavigationInstruction, Params, RouteNode } from '@aurelia/router'
 import { UserEmail } from '@buf/liverty-music_schema.bufbuild_es/liverty_music/entity/v1/user_pb.js'
 import { Code, ConnectError } from '@connectrpc/connect'
 import { ILogger, resolve } from 'aurelia'
@@ -12,71 +12,55 @@ interface AuthState {
 	isSignUp?: boolean
 }
 
+/**
+ * OIDC callback handler that processes the authorization code exchange
+ * and redirects to the appropriate destination.
+ *
+ * Uses canLoad() to return a NavigationInstruction, which the Aurelia Router
+ * handles internally within the transition pipeline. This avoids calling
+ * router.load() from attached(), which can hang because attached() fires
+ * during the _swap phase when _isNavigating is still true.
+ */
 export class AuthCallback {
-	public message = 'Verifying authentication...'
 	public error = ''
 
 	private readonly authService = resolve(IAuthService)
 	private readonly userService = resolve(IUserService)
-	private readonly router = resolve(IRouter)
 	private readonly logger = resolve(ILogger).scopeTo('AuthCallback')
 
-	constructor() {
-		this.logger.info('Constructor called')
-	}
-
-	/**
-	 * Navigate after the component is attached to the DOM.
-	 *
-	 * Aurelia's `loading()` hook runs while a navigation is still in progress.
-	 * Calling `router.load()` from within `loading()` silently blocks because
-	 * the router is already mid-transition.  Moving the logic to `attached()`
-	 * ensures the current navigation has settled before we trigger a new one.
-	 */
-	public async attached(): Promise<void> {
-		this.logger.info('Attached, starting auth callback processing...')
+	public async canLoad(
+		_params: Params,
+		_next: RouteNode,
+	): Promise<boolean | NavigationInstruction> {
+		this.logger.info('Processing OIDC callback...')
 		try {
-			this.logger.info('Calling handleCallback...')
 			const user = await this.authService.handleCallback()
 			this.logger.info('handleCallback success!')
 
-			// Check if this was a sign-up flow
 			const state = user.state as AuthState | undefined
 			if (state?.isSignUp) {
 				this.logger.info('Sign-up detected, provisioning user in backend')
 				await this.provisionUser(user.profile.email)
-				await this.router.load('/onboarding/discover')
-			} else {
-				await this.router.load('/dashboard')
+				return '/onboarding/discover'
 			}
+
+			return '/dashboard'
 		} catch (err) {
 			this.logger.error('Auth callback error:', err)
 
-			// If we are already authenticated (e.g. valid session exists), ignore the error and redirect
 			if (this.authService.isAuthenticated) {
 				this.logger.warn(
 					'User is already authenticated. Redirecting despite callback error...',
 				)
-				try {
-					await this.router.load('/dashboard')
-				} catch (redirectErr) {
-					this.logger.error(
-						'Post-auth redirect also failed, falling back to dashboard',
-						{ error: redirectErr },
-					)
-					this.error =
-						'Authentication succeeded but navigation failed. Please go to the dashboard manually.'
-					this.message = ''
-				}
-				return
+				return '/dashboard'
 			}
 
+			// Let the component render with the error message
 			this.error = `Login failed: ${err instanceof Error ? err.message : String(err)}`
-			this.message = ''
+			return true
 		}
 	}
 
-	// Call Create RPC with error handling
 	private async provisionUser(email: string | undefined): Promise<void> {
 		if (!email) {
 			this.logger.error('User email is missing, cannot provision user')
@@ -89,7 +73,6 @@ export class AuthCallback {
 			})
 			this.logger.info('User provisioned successfully', { email })
 		} catch (err) {
-			// Handle ALREADY_EXISTS gracefully (treat as success)
 			if (err instanceof ConnectError && err.code === Code.AlreadyExists) {
 				this.logger.info('User already exists in backend, continuing...', {
 					email,
@@ -97,9 +80,6 @@ export class AuthCallback {
 				return
 			}
 
-			// Non-AlreadyExists errors must halt the auth flow. Silently continuing
-			// would leave the user without a backend record, causing all subsequent
-			// RPC calls to fail.
 			this.logger.error('Failed to provision user in backend', {
 				email,
 				error: err,

--- a/test/routes/auth-callback.spec.ts
+++ b/test/routes/auth-callback.spec.ts
@@ -1,4 +1,4 @@
-import { IRouter } from '@aurelia/router'
+import type { RouteNode } from '@aurelia/router'
 import { Registration } from 'aurelia'
 import { Code, ConnectError } from '@connectrpc/connect'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -20,7 +20,6 @@ describe('AuthCallback', () => {
 	let sut: AuthCallback
 	let mockAuth: ReturnType<typeof createMockAuth>
 	let mockUserService: ReturnType<typeof createMockUserService>
-	let mockRouter: { load: ReturnType<typeof vi.fn> }
 
 	beforeEach(() => {
 		mockAuth = createMockAuth({
@@ -28,28 +27,26 @@ describe('AuthCallback', () => {
 			ready: Promise.resolve(),
 		})
 		mockUserService = createMockUserService()
-		mockRouter = { load: vi.fn().mockResolvedValue(true) }
 
 		const container = createTestContainer(
 			Registration.instance(IAuthService, mockAuth as IAuthService),
 			Registration.instance(IUserService, mockUserService as IUserService),
-			Registration.instance(IRouter, mockRouter as IRouter),
 		)
 		container.register(AuthCallback)
 		sut = container.get(AuthCallback)
 	})
 
-	describe('attached', () => {
+	describe('canLoad', () => {
 		it('should redirect to discover on sign-up', async () => {
 			mockAuth.handleCallback = vi.fn().mockResolvedValue({
 				state: { isSignUp: true },
 				profile: { email: 'new@example.com' },
 			})
 
-			await sut.attached()
+			const result = await sut.canLoad({}, {} as RouteNode)
 
 			expect(mockUserService.client.create).toHaveBeenCalled()
-			expect(mockRouter.load).toHaveBeenCalledWith('/onboarding/discover')
+			expect(result).toBe('/onboarding/discover')
 		})
 
 		it('should redirect to dashboard on sign-in', async () => {
@@ -58,10 +55,10 @@ describe('AuthCallback', () => {
 				profile: { email: 'existing@example.com' },
 			})
 
-			await sut.attached()
+			const result = await sut.canLoad({}, {} as RouteNode)
 
 			expect(mockUserService.client.create).not.toHaveBeenCalled()
-			expect(mockRouter.load).toHaveBeenCalledWith('/dashboard')
+			expect(result).toBe('/dashboard')
 		})
 
 		it('should redirect to dashboard when state is undefined', async () => {
@@ -69,9 +66,9 @@ describe('AuthCallback', () => {
 				profile: { email: 'existing@example.com' },
 			})
 
-			await sut.attached()
+			const result = await sut.canLoad({}, {} as RouteNode)
 
-			expect(mockRouter.load).toHaveBeenCalledWith('/dashboard')
+			expect(result).toBe('/dashboard')
 		})
 
 		it('should redirect to dashboard on error if already authenticated', async () => {
@@ -80,9 +77,9 @@ describe('AuthCallback', () => {
 				.mockRejectedValue(new Error('callback error'))
 			mockAuth.isAuthenticated = true
 
-			await sut.attached()
+			const result = await sut.canLoad({}, {} as RouteNode)
 
-			expect(mockRouter.load).toHaveBeenCalledWith('/dashboard')
+			expect(result).toBe('/dashboard')
 			expect(sut.error).toBe('')
 		})
 
@@ -92,9 +89,9 @@ describe('AuthCallback', () => {
 				.mockRejectedValue(new Error('auth failed'))
 			mockAuth.isAuthenticated = false
 
-			await sut.attached()
+			const result = await sut.canLoad({}, {} as RouteNode)
 
-			expect(mockRouter.load).not.toHaveBeenCalled()
+			expect(result).toBe(true)
 			expect(sut.error).toBe('Login failed: auth failed')
 		})
 
@@ -107,9 +104,9 @@ describe('AuthCallback', () => {
 				.fn()
 				.mockRejectedValue(new ConnectError('exists', Code.AlreadyExists))
 
-			await sut.attached()
+			const result = await sut.canLoad({}, {} as RouteNode)
 
-			expect(mockRouter.load).toHaveBeenCalledWith('/onboarding/discover')
+			expect(result).toBe('/onboarding/discover')
 		})
 
 		it('should show error when provisionUser fails with non-AlreadyExists error', async () => {
@@ -121,9 +118,9 @@ describe('AuthCallback', () => {
 				.fn()
 				.mockRejectedValue(new Error('server error'))
 
-			await sut.attached()
+			const result = await sut.canLoad({}, {} as RouteNode)
 
-			expect(mockRouter.load).not.toHaveBeenCalled()
+			expect(result).toBe(true)
 			expect(sut.error).toBe('Login failed: server error')
 		})
 
@@ -133,10 +130,10 @@ describe('AuthCallback', () => {
 				profile: {},
 			})
 
-			await sut.attached()
+			const result = await sut.canLoad({}, {} as RouteNode)
 
 			expect(mockUserService.client.create).not.toHaveBeenCalled()
-			expect(mockRouter.load).toHaveBeenCalledWith('/onboarding/discover')
+			expect(result).toBe('/onboarding/discover')
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- Move OIDC callback processing from `attached()` to `canLoad()` lifecycle hook
- Return `NavigationInstruction` (route string) instead of calling `router.load()` imperatively
- Fixes Sign In flow hanging at "Verifying authentication..." after successful OIDC callback

## Root Cause

Calling `router.load()` from `attached()` is unsafe in Aurelia 2. The `attached()` hook fires during the router's `_swap` phase while `_isNavigating` is still `true`. The new navigation is queued as `_nextTr`, but `_runNextTransition()` may have already executed with `_nextTr === null`, causing the queued transition to be permanently orphaned.

The idiomatic Aurelia 2 pattern is to return a `NavigationInstruction` from `canLoad()`, which the router processes internally within the transition pipeline without race conditions.

## Test plan

- [ ] Sign In via passkey → should redirect to `/dashboard` (no hang)
- [ ] Sign Up → should provision user and redirect to `/onboarding/discover`
- [ ] Sign In when already authenticated → should redirect to `/dashboard`
- [ ] Failed callback → should display error message with "Return Home" link