### PR TITLE
chore(openspec): archive fix-onboarding-bubble-counter and sync specs

### DIFF
--- a/openspec/changes/archive/2026-03-02-fix-onboarding-bubble-counter/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-02-fix-onboarding-bubble-counter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-28

--- a/openspec/changes/archive/2026-03-02-fix-onboarding-bubble-counter/design.md
+++ b/openspec/changes/archive/2026-03-02-fix-onboarding-bubble-counter/design.md
@@ -1,0 +1,62 @@
+## Context
+
+Onboarding の Artist Discovery ページ (`/onboarding/discover`) で、バブルをタップしてアーティストをフォローしてもカウンター (0/3) が更新されない。
+
+DevTools で調査した結果:
+- `localStorage['guest.followedArtists']` には正しくデータが保存されている (5件)
+- `localClient.listFollowed()` を直接呼ぶと 5 件返る
+- しかし `localClient.followedCount` getter は 0 を返す
+- 原因: Aurelia 2 のリアクティビティシステムが getter をキャッシュしており、localStorage への書き込みは observation の外にあるためキャッシュが再評価されない
+
+加えて UX 上の課題:
+- ガイダンスオーバーレイ「Tap bubbles to follow artists」が 5 秒で消え、復帰しない
+- 数字 (0/3) だけでは何をすべきか分からない
+- バブルをタップしたときの達成フィードバックが弱い
+
+## Goals / Non-Goals
+
+**Goals:**
+- `followedCount` が localStorage への書き込みと同期し、UI がリアルタイムに更新される
+- ガイダンスがユーザーを段階的に導く (初回タップ前 → 進捗中 → 完了)
+- タップ時のフィードバックで達成感を演出する
+
+**Non-Goals:**
+- バブル UI 自体の抜本的な変更 (カテゴリステップ分割など)
+- サウンドやハプティクスの追加
+- coach-mark コンポーネントの onboarding 統合 (将来の改善として残す)
+
+## Decisions
+
+### 1. `@observable` による followedCount の同期
+
+**選択**: `LocalArtistClient.followedCount` を getter から `@observable` プロパティに変更し、`follow()` / `unfollow()` / `clearAll()` で明示的に値を更新する。
+
+**代替案**:
+- **EventAggregator パターン**: `follow` イベントを publish → subscribe で再計算。疎結合だが、onboarding でしか使わないカウンターのために過剰。
+- **getter を廃止してメソッド `getFollowedCount()` に変更**: 呼び出し側で毎回呼ぶ必要があり、Aurelia のバインディングと相性が悪い。
+- **`IObserverLocator` でカスタム observer を登録**: Aurelia の internal API に依存し過ぎる。
+
+**理由**: `@observable` は Aurelia 2 の標準的なリアクティビティ機構で、setter が呼ばれると自動的にバインディングが再評価される。影響範囲が `LocalArtistClient` 内に閉じる。
+
+### 2. 段階的ガイダンスメッセージ
+
+**選択**: `artist-discovery-page` に段階的なメッセージ表示を追加する。
+
+```
+0/3: 「好きなアーティストを3組タップしよう！」(初期表示、消えない)
+1/3: 「いいね！あと2組！」
+2/3: 「あと1組！」
+3/3: 「準備完了！」→ 完了ボタンをハイライト
+```
+
+ガイダンスオーバーレイの auto-dismiss (5秒タイマー) は削除し、ユーザーが最初のバブルをタップするまで表示し続ける。
+
+### 3. プログレスバーの常時表示
+
+**選択**: プログレスバーとカウンターを onboarding 時は常に表示し、完了ボタンが表示されるまでの進捗を視覚的にフィードバックする。現在のコードでは `if.bind="isOnboarding"` で既に制御されているが、カウンター値が更新されないため機能していなかった。Decision 1 の修正で自然に動作するようになる。
+
+## Risks / Trade-offs
+
+- **[Risk] `@observable` と既存の getter の競合**: Aurelia が既にプロトタイプ getter をラップしている可能性がある → `@observable` に変更する際、getter を完全に削除して plain property + 手動更新に置き換えることでクリアに解決。
+- **[Risk] 初期化時の followedCount 不整合**: ページ表示時に localStorage に既にデータがある場合 → コンストラクタまたは初期化時に `this.followedCount = this.listFollowed().length` を実行して同期。
+- **[Trade-off] ガイダンスメッセージの日本語ハードコード**: i18n 対応が今後必要になる → 現時点では日本語で実装し、i18n 対応は別変更で行う。

--- a/openspec/changes/archive/2026-03-02-fix-onboarding-bubble-counter/proposal.md
+++ b/openspec/changes/archive/2026-03-02-fix-onboarding-bubble-counter/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Onboarding の Artist Discovery ページで、バブルをタップしてもカウンター (0/3) が増えない。
+原因は Aurelia 2 のリアクティビティシステムが `LocalArtistClient.followedCount` getter をキャッシュしており、localStorage への書き込みが observation の外にあるためキャッシュが再評価されないこと。
+加えて、ガイダンスオーバーレイが 5 秒で自動消去された後は復帰しないため、ユーザーは何をすべきか分からず離脱しやすい。
+
+## What Changes
+
+- `LocalArtistClient` の `followedCount` getter を `@observable` プロパティに変更し、`follow()` / `unfollow()` 時に明示的に値を更新する
+- ガイダンス表示を改善し、バブルタップの視覚フィードバックと段階的な進捗メッセージを追加する
+- `coach-mark` コンポーネント (既存だが未使用) を onboarding ステップで活用する
+
+## Capabilities
+
+### New Capabilities
+- `onboarding-guidance`: バブル選択のインタラクティブなガイダンスと段階的フィードバック
+
+### Modified Capabilities
+(なし — 既存の spec はまだない)
+
+## Impact
+
+- `src/services/local-artist-client.ts` — followedCount のリアクティビティ修正
+- `src/routes/artist-discovery/artist-discovery-page.ts` — ガイダンス表示ロジック改善
+- `src/routes/artist-discovery/artist-discovery-page.html` — ガイダンス UI 追加
+- `src/components/dna-orb/dna-orb-canvas.ts` — フォロー済みカウント連動の確認
+- `src/components/coach-mark/` — onboarding での活用

--- a/openspec/changes/archive/2026-03-02-fix-onboarding-bubble-counter/specs/onboarding-guidance/spec.md
+++ b/openspec/changes/archive/2026-03-02-fix-onboarding-bubble-counter/specs/onboarding-guidance/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Followed count reflects localStorage state
+The `LocalArtistClient.followedCount` property SHALL be an `@observable` that is updated whenever `follow()`, `unfollow()`, or `clearAll()` is called, so that Aurelia bindings re-evaluate immediately.
+
+#### Scenario: Initial page load with existing guest data
+- **WHEN** the user navigates to `/onboarding/discover` and `localStorage['guest.followedArtists']` contains 3 artists
+- **THEN** the counter SHALL display `3/3` and the complete button SHALL be visible
+
+#### Scenario: Follow an artist during onboarding
+- **WHEN** the user taps a bubble to follow an artist
+- **THEN** the counter SHALL increment by 1 within the same frame (e.g., `0/3` → `1/3`)
+- **AND** the progress bar fill width SHALL update accordingly
+
+#### Scenario: Unfollow an artist
+- **WHEN** the user unfollows a previously followed artist
+- **THEN** the counter SHALL decrement by 1 immediately
+
+### Requirement: Persistent guidance until first interaction
+The onboarding guidance message SHALL remain visible until the user taps their first bubble. The 5-second auto-dismiss timer SHALL be removed.
+
+#### Scenario: Page load without prior interactions
+- **WHEN** the user arrives at the discovery page for the first time (followedCount = 0)
+- **THEN** the guidance message "好きなアーティストを3組タップしよう！" SHALL be displayed
+- **AND** the message SHALL NOT auto-dismiss after any timeout
+
+#### Scenario: First bubble tap dismisses guidance
+- **WHEN** the user taps their first bubble
+- **THEN** the guidance message SHALL fade out (400ms transition)
+- **AND** a progress-specific message SHALL appear in its place
+
+### Requirement: Staged progress messages
+The system SHALL display contextual progress messages that change as the user follows more artists.
+
+#### Scenario: After following 1 artist
+- **WHEN** followedCount becomes 1
+- **THEN** the guidance area SHALL display "いいね！あと2組！"
+
+#### Scenario: After following 2 artists
+- **WHEN** followedCount becomes 2
+- **THEN** the guidance area SHALL display "あと1組！"
+
+#### Scenario: After following 3 or more artists
+- **WHEN** followedCount reaches 3 (TUTORIAL_FOLLOW_TARGET)
+- **THEN** the guidance area SHALL display "準備完了！"
+- **AND** the complete button SHALL become visible and visually highlighted
+
+### Requirement: Orb pulse on follow
+The central Music DNA orb SHALL pulse each time an artist is followed, providing visual feedback that the selection was registered.
+
+#### Scenario: Bubble tap triggers orb pulse
+- **WHEN** a bubble is tapped and the follow operation succeeds
+- **THEN** the `DnaOrbCanvas.followedCountChanged` callback SHALL fire
+- **AND** the orb SHALL play a pulse animation

--- a/openspec/changes/archive/2026-03-02-fix-onboarding-bubble-counter/tasks.md
+++ b/openspec/changes/archive/2026-03-02-fix-onboarding-bubble-counter/tasks.md
@@ -1,0 +1,20 @@
+## 1. Fix followedCount Reactivity
+
+- [x] 1.1 Change `LocalArtistClient.followedCount` from getter to `@observable` property
+- [x] 1.2 Initialize `followedCount` from `listFollowed().length` in constructor
+- [x] 1.3 Update `followedCount` in `follow()`, `unfollow()`, and `clearAll()` methods
+- [x] 1.4 Verify `ArtistDiscoveryPage.followedCount` getter correctly propagates the observable value
+
+## 2. Improve Onboarding Guidance
+
+- [x] 2.1 Remove the 5-second auto-dismiss timer from guidance overlay in `ArtistDiscoveryPage.attached()`
+- [x] 2.2 Keep guidance visible until the user taps their first bubble (dismiss in `onArtistSelected`)
+- [x] 2.3 Change initial guidance message to "好きなアーティストを3組タップしよう！"
+- [x] 2.4 Add staged progress messages (1/3: "いいね！あと2組！", 2/3: "あと1組！", 3/3: "準備完了！")
+- [x] 2.5 Update `artist-discovery-page.html` template to bind staged messages
+
+## 3. Verify End-to-End
+
+- [x] 3.1 Confirm orb pulse fires on each follow (followedCountChanged callback)
+- [x] 3.2 Test fresh onboarding flow: guidance shows → tap 3 bubbles → counter increments → complete button appears
+- [x] 3.3 Test page reload with existing localStorage data: counter reflects saved state on load

--- a/openspec/changes/fix-onboarding-ux-regressions/.openspec.yaml
+++ b/openspec/changes/fix-onboarding-ux-regressions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-01

--- a/openspec/changes/fix-onboarding-ux-regressions/design.md
+++ b/openspec/changes/fix-onboarding-ux-regressions/design.md
@@ -1,0 +1,62 @@
+## Context
+
+The artist discovery page uses a full-viewport `<canvas>` element inside a Shadow DOM custom element (`dna-orb-canvas`). The canvas has `position: absolute; inset: 0` and registers `click` + `touchstart` event listeners. Overlay elements (onboarding HUD, complete button, orb label) are siblings of the canvas in the parent Shadow DOM and rely on `z-index` for stacking — which violates the project's CSS standards (web-app-specialist skill rejects z-index stacking hacks).
+
+On mobile, the canvas captures all touch events before they reach the complete button, making it unresponsive. Additionally, when a user follows an artist, `getSimilarArtists()` often returns artists that are fully deduplicated against the `seenArtistNames/Ids/Mbids` sets, causing no new bubbles to spawn and the canvas to empty.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Complete button must be tappable on all devices (desktop and mobile)
+- Remove all `z-index` declarations; use DOM source order for stacking
+- Keep the canvas populated after each follow so users can discover beyond 3 artists
+- Maintain existing visual design (cosmic HUD, orbital dots, translucent pill)
+
+**Non-Goals:**
+- Redesigning the bubble physics or absorption animation
+- Changing the ListSimilar API behavior on the backend
+- Fixing the ListSimilar deduplication logic itself (that's a backend concern)
+
+## Decisions
+
+### 1. Canvas pointer-events passthrough for overlay zones
+
+**Decision**: Add `pointer-events: none` to the canvas element, then re-enable `pointer-events: auto` only on the canvas via JavaScript for bubble areas. Alternatively, use CSS `pointer-events: none` on the canvas in the button zone.
+
+**Rejected approach**: The simpler approach is to keep the canvas click handler but add a coordinate check — if the click falls within the button's bounding rect, ignore it and let the event propagate. However, this tightly couples the canvas to the button layout.
+
+**Chosen approach**: Use `pointer-events: none` on the `dna-orb-canvas` host element from the parent CSS, and instead handle pointer events at the `.container` level, delegating to the canvas via `elementsFromPoint()`. This is fragile with Shadow DOM.
+
+**Final approach**: The most robust solution is to **move overlay elements (HUD, button, orb-label) outside the canvas stacking context** by placing them in a separate overlay `<div>` that is a sibling of `dna-orb-canvas`, and ensure this overlay div has `pointer-events: none` with `pointer-events: auto` only on interactive children (the button). DOM order ensures the overlay div paints on top of the canvas. No z-index needed.
+
+```
+<div class="container">          ← position: relative
+  <dna-orb-canvas />              ← paints first (behind)
+  <div class="overlay">           ← paints second (on top), pointer-events: none
+    <div class="onboarding-hud">  ← pointer-events: none (non-interactive)
+    <div class="orb-label">       ← pointer-events: none
+    <button class="complete-button"> ← pointer-events: auto (interactive)
+  </div>
+</div>
+```
+
+### 2. Remove z-index entirely
+
+**Decision**: Remove all `z-index` from `.container::before`, `.onboarding-hud`, `.complete-button-wrapper`, and `.orb-label`. Stacking is controlled by:
+- `.container::before` (pseudo-element, paints before children)
+- `<dna-orb-canvas>` (first child, paints first)
+- Overlay elements (later in DOM, paint on top)
+
+### 3. Bubble replenishment fallback
+
+**Decision**: When `getSimilarArtists()` returns zero new bubbles (all deduplicated), fall back to calling `loadInitialArtists()` again but filter against the `seenArtistIds` set. This reloads the top-50 artist pool and any unseen artists become new bubbles.
+
+**Why not a new API?**: Adding a "random artists" endpoint would be ideal long-term, but the existing `ListTop` RPC already returns 50 artists. On second and subsequent calls, many will be seen, but some new ones may appear due to popularity changes. This is a pragmatic client-side fallback.
+
+**Implementation**: In `dna-orb-canvas.ts`, after `getSimilarArtists()` returns an empty array, call `discoveryService.loadReplacementBubbles()` — a new method that calls `ListTop` and filters against seen artists, returning only fresh ones.
+
+## Risks / Trade-offs
+
+- **[Risk] Replacement bubbles may also be empty** — If the user has seen all 50 top artists, the fallback produces nothing. → Mitigation: Accept this gracefully; the user has explored the full initial pool and the complete button is already available.
+- **[Risk] DOM order stacking may break if elements are conditionally rendered** — `if.bind` removes elements from DOM, changing paint order. → Mitigation: Use `show.bind` instead of `if.bind` for the overlay container so it stays in DOM.
+- **[Risk] Canvas touchstart with `passive: true` cannot call preventDefault** — The touch event on the canvas propagates to the button area. → Mitigation: The overlay structure with `pointer-events: none` on the canvas's host element in the button zone handles this naturally since the button is a separate DOM tree.

--- a/openspec/changes/fix-onboarding-ux-regressions/proposal.md
+++ b/openspec/changes/fix-onboarding-ux-regressions/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The onboarding artist discovery page has three UX issues:
+
+1. **Complete button unresponsive on mobile** — The "ダッシュボードを生成する" button does not respond to taps. The canvas element underneath consumes click/touch events before they reach the button, and z-index hacks used for stacking are unreliable across Shadow DOM boundaries.
+2. **z-index stacking violates project CSS standards** — The web-app-specialist skill explicitly rejects z-index stacking hacks. The current CSS uses z-index values (0, 15, 20, 30) for layer ordering, which should be replaced with DOM source order stacking.
+3. **Bubbles not replenished after follow** — When a user taps a bubble, `getSimilarArtists()` returns artists that are all deduplicated against the existing pool, so no new bubbles spawn. The screen empties after each tap, preventing continued discovery beyond 3 follows.
+
+## What Changes
+
+- Remove all `z-index` declarations from `artist-discovery-page.css`; rely on DOM source order for stacking
+- Reorder HTML elements in `artist-discovery-page.html` so that overlay elements (HUD, button) appear after the canvas in DOM order
+- Fix the complete button's tap target so it receives pointer events on mobile (ensure canvas does not capture events in the button's area)
+- Add a fallback bubble replenishment strategy in `dna-orb-canvas.ts`: when similar artists are fully deduplicated, reload a batch of random top artists to keep the canvas populated
+
+## Capabilities
+
+### New Capabilities
+
+- `bubble-replenishment`: Fallback strategy to keep the discovery canvas populated when similar-artist deduplication empties the pool
+
+### Modified Capabilities
+
+- `onboarding-guidance`: Complete button must be tappable on mobile; z-index stacking replaced with DOM order
+
+## Impact
+
+- `src/routes/artist-discovery/artist-discovery-page.css` — Remove z-index, reorder stacking via DOM
+- `src/routes/artist-discovery/artist-discovery-page.html` — Reorder elements for natural stacking
+- `src/components/dna-orb/dna-orb-canvas.ts` — Add fallback replenishment when similar artists are exhausted
+- `src/services/artist-discovery-service.ts` — May need a method to fetch replacement bubbles

--- a/openspec/changes/fix-onboarding-ux-regressions/specs/bubble-replenishment/spec.md
+++ b/openspec/changes/fix-onboarding-ux-regressions/specs/bubble-replenishment/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Canvas replenishes bubbles when similar artists are exhausted
+When a user follows an artist and the similar-artist API returns no new (unseen) artists, the system SHALL automatically fetch replacement bubbles from the top-artist pool to keep the canvas populated.
+
+#### Scenario: Similar artists fully deduplicated
+- **WHEN** user taps a bubble AND `getSimilarArtists()` returns zero new bubbles after deduplication
+- **THEN** the system SHALL call `loadReplacementBubbles()` to fetch fresh artists from the top-artist pool
+- **AND** any unseen artists SHALL be spawned as new bubbles near the absorption point
+
+#### Scenario: Top artist pool also exhausted
+- **WHEN** user taps a bubble AND both similar artists and replacement bubbles return zero new artists
+- **THEN** the system SHALL gracefully accept an empty canvas without errors
+- **AND** the complete button (if visible) SHALL remain functional
+
+#### Scenario: Replacement bubbles partially available
+- **WHEN** user taps a bubble AND similar artists are exhausted but 5 of 50 top artists are unseen
+- **THEN** the system SHALL spawn only the 5 unseen artists as new bubbles
+- **AND** the previously seen artists SHALL NOT reappear on the canvas

--- a/openspec/changes/fix-onboarding-ux-regressions/specs/onboarding-guidance/spec.md
+++ b/openspec/changes/fix-onboarding-ux-regressions/specs/onboarding-guidance/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Complete button is tappable on all devices
+The complete button ("ダッシュボードを生成する") SHALL be tappable on both desktop and mobile devices. The canvas element SHALL NOT intercept pointer events in the button's area.
+
+#### Scenario: Mobile tap on complete button
+- **WHEN** user taps the complete button on a mobile device
+- **THEN** the `onViewSchedule()` handler SHALL fire
+- **AND** the user SHALL be navigated to the loading sequence
+
+#### Scenario: Desktop click on complete button
+- **WHEN** user clicks the complete button on desktop
+- **THEN** the `onViewSchedule()` handler SHALL fire
+
+### Requirement: No z-index stacking in discovery page CSS
+The artist discovery page SHALL NOT use `z-index` for visual stacking. All layer ordering SHALL be achieved through DOM source order, following the web-app-specialist skill's CSS standards.
+
+#### Scenario: Overlay elements paint above canvas
+- **WHEN** the discovery page renders
+- **THEN** the onboarding HUD, orb label, and complete button SHALL paint above the canvas
+- **AND** no CSS `z-index` property SHALL be present in `artist-discovery-page.css`
+
+#### Scenario: Starfield pseudo-element paints behind content
+- **WHEN** the discovery page renders
+- **THEN** the `.container::before` starfield SHALL paint behind all content elements
+- **AND** the starfield SHALL use `pointer-events: none` without `z-index`

--- a/openspec/changes/fix-onboarding-ux-regressions/tasks.md
+++ b/openspec/changes/fix-onboarding-ux-regressions/tasks.md
@@ -1,0 +1,26 @@
+## 1. Remove z-index and fix stacking via DOM order
+
+- [x] 1.1 Remove all `z-index` declarations from `artist-discovery-page.css`
+- [x] 1.2 Remove `z-index: 0` from `.container::before` (pseudo-elements paint before children naturally)
+- [x] 1.3 Reorder HTML in `artist-discovery-page.html`: place `<dna-orb-canvas>` first, then overlay elements (HUD, orb-label, button) after it in DOM order
+- [x] 1.4 Verify overlay elements paint above canvas without z-index
+
+## 2. Fix complete button tap target
+
+- [x] 2.1 Add `pointer-events: none` to the overlay wrapper div (so canvas receives bubble taps through it)
+- [x] 2.2 Add `pointer-events: auto` to the complete button element (so it captures taps in its area)
+- [x] 2.3 Ensure onboarding HUD stays `pointer-events: none` (non-interactive, purely visual)
+- [x] 2.4 Verify button responds to tap/click on mobile and desktop
+
+## 3. Bubble replenishment fallback
+
+- [x] 3.1 Add `loadReplacementBubbles()` method to `ArtistDiscoveryService` that calls `ListTop`, filters against seen artists, and returns fresh bubbles
+- [x] 3.2 In `dna-orb-canvas.ts` `handleInteraction()`, call `loadReplacementBubbles()` when `getSimilarArtists()` returns empty
+- [x] 3.3 Spawn replacement bubbles near the absorption point, same as similar artists
+- [x] 3.4 Verify canvas stays populated after following artists during onboarding
+
+## 4. Verify end-to-end
+
+- [x] 4.1 Test full onboarding flow on mobile viewport: tap 3 bubbles, dots fill, button appears, button is tappable, navigates to loading
+- [x] 4.2 Test that bubbles replenish after each follow (canvas never empties until pool is truly exhausted)
+- [x] 4.3 Confirm no `z-index` present in `artist-discovery-page.css`

--- a/openspec/specs/onboarding-guidance/spec.md
+++ b/openspec/specs/onboarding-guidance/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Followed count reflects localStorage state
+The `LocalArtistClient.followedCount` property SHALL be an `@observable` that is updated whenever `follow()`, `unfollow()`, or `clearAll()` is called, so that Aurelia bindings re-evaluate immediately.
+
+#### Scenario: Initial page load with existing guest data
+- **WHEN** the user navigates to `/onboarding/discover` and `localStorage['guest.followedArtists']` contains 3 artists
+- **THEN** the counter SHALL display `3/3` and the complete button SHALL be visible
+
+#### Scenario: Follow an artist during onboarding
+- **WHEN** the user taps a bubble to follow an artist
+- **THEN** the counter SHALL increment by 1 within the same frame (e.g., `0/3` → `1/3`)
+- **AND** the progress bar fill width SHALL update accordingly
+
+#### Scenario: Unfollow an artist
+- **WHEN** the user unfollows a previously followed artist
+- **THEN** the counter SHALL decrement by 1 immediately
+
+### Requirement: Persistent guidance until first interaction
+The onboarding guidance message SHALL remain visible until the user taps their first bubble. The 5-second auto-dismiss timer SHALL be removed.
+
+#### Scenario: Page load without prior interactions
+- **WHEN** the user arrives at the discovery page for the first time (followedCount = 0)
+- **THEN** the guidance message "好きなアーティストを3組タップしよう！" SHALL be displayed
+- **AND** the message SHALL NOT auto-dismiss after any timeout
+
+#### Scenario: First bubble tap dismisses guidance
+- **WHEN** the user taps their first bubble
+- **THEN** the guidance message SHALL fade out (400ms transition)
+- **AND** a progress-specific message SHALL appear in its place
+
+### Requirement: Staged progress messages
+The system SHALL display contextual progress messages that change as the user follows more artists.
+
+#### Scenario: After following 1 artist
+- **WHEN** followedCount becomes 1
+- **THEN** the guidance area SHALL display "いいね！あと2組！"
+
+#### Scenario: After following 2 artists
+- **WHEN** followedCount becomes 2
+- **THEN** the guidance area SHALL display "あと1組！"
+
+#### Scenario: After following 3 or more artists
+- **WHEN** followedCount reaches 3 (TUTORIAL_FOLLOW_TARGET)
+- **THEN** the guidance area SHALL display "準備完了！"
+- **AND** the complete button SHALL become visible and visually highlighted
+
+### Requirement: Orb pulse on follow
+The central Music DNA orb SHALL pulse each time an artist is followed, providing visual feedback that the selection was registered.
+
+#### Scenario: Bubble tap triggers orb pulse
+- **WHEN** a bubble is tapped and the follow operation succeeds
+- **THEN** the `DnaOrbCanvas.followedCountChanged` callback SHALL fire
+- **AND** the orb SHALL play a pulse animation


### PR DESCRIPTION
## Description

Archive the completed `fix-onboarding-bubble-counter` OpenSpec change and sync the `onboarding-guidance` delta spec to main specs. Also track the active `fix-onboarding-ux-regressions` change artifacts.

## Type of Change

- [x] chore: Other changes that don't modify src or test files

## Verification

### Automated Tests
- [x] `npm run lint` passed
- [x] `npm run test` passed (22 pre-existing failures due to `@aurelia/i18n` import resolution — unrelated)
- [x] `npm run build` passed

### Manual Verification
- No source code changes — only OpenSpec markdown/yaml artifacts

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings