### PR TITLE
fix(concert): increase SearchNewConcerts timeoutMs to 30s

### DIFF
--- a/src/services/concert-service.ts
+++ b/src/services/concert-service.ts
@@ -95,7 +95,7 @@ export class ConcertServiceClient {
 				{
 					artistId: new ArtistId({ value: artistId }),
 				},
-				{ signal, timeoutMs: 20_000 },
+				{ signal, timeoutMs: 30_000 },
 			)
 			this.logger.info('Concert search completed', { artistId })
 		} catch (err) {

--- a/test/services/concert-service.spec.ts
+++ b/test/services/concert-service.spec.ts
@@ -143,7 +143,7 @@ describe('ConcertServiceClient', () => {
 				expect.objectContaining({}),
 				expect.objectContaining({
 					signal: controller.signal,
-					timeoutMs: 20_000,
+					timeoutMs: 30_000,
 				}),
 			)
 		})


### PR DESCRIPTION
## Summary

- Increase `timeoutMs` from `20_000` to `30_000` for the `SearchNewConcerts` RPC call
- 20s was insufficient for 3 server-side Gemini retries with exponential backoff when each call takes 10-15s

## Test plan

- [x] `npx vitest run` — all 281 tests pass

close: #108