### PR TITLE
fix: replace deprecated view-model.ref with component.ref

### DIFF
--- a/src/components/live-highway/live-highway.html
+++ b/src/components/live-highway/live-highway.html
@@ -62,5 +62,5 @@
   </div>
 
   <!-- Bottom sheet (outside scroll container) -->
-  <event-detail-sheet view-model.ref="detailSheet"></event-detail-sheet>
+  <event-detail-sheet component.ref="detailSheet"></event-detail-sheet>
 </template>

--- a/src/routes/dashboard.html
+++ b/src/routes/dashboard.html
@@ -83,7 +83,7 @@
 
 <!-- Region setup bottom sheet -->
 <region-setup-sheet
-  view-model.ref="regionSheet"
+  component.ref="regionSheet"
   on-region-selected.bind="(region) => onRegionSelected(region)"
 ></region-setup-sheet>
 

--- a/src/routes/settings/settings-page.html
+++ b/src/routes/settings/settings-page.html
@@ -150,6 +150,6 @@
 
 <!-- Area Selector Bottom Sheet -->
 <area-selector-sheet
-  view-model.ref="areaSheet"
+  component.ref="areaSheet"
   on-area-selected.bind="(area) => onAreaSelected(area)"
 ></area-selector-sheet>


### PR DESCRIPTION
## Summary

- Replace all `view-model.ref` usages with `component.ref` to resolve Aurelia 2 deprecation warnings

## Changes

- `src/routes/settings/settings-page.html` — `view-model.ref="areaSheet"` → `component.ref="areaSheet"`
- `src/routes/dashboard.html` — `view-model.ref="regionSheet"` → `component.ref="regionSheet"`
- `src/components/live-highway/live-highway.html` — `view-model.ref="detailSheet"` → `component.ref="detailSheet"`

## Test plan

- [ ] Verify no `view-model.ref` deprecation warnings in browser console
- [ ] Verify area sheet, region sheet, and detail sheet still open/close correctly

Closes #110