### PR TITLE
ci: unify lint and test via Makefile and pre-commit hook

### DIFF
--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# PreToolUse hook: runs `make check` before git commit.
+# Exit 2 = block the tool call (stderr shown to Claude as reason).
+
+COMMAND=$(jq -r '.tool_input.command' < /dev/stdin)
+
+# Only act on git commit calls
+if ! echo "$COMMAND" | grep -q 'git commit'; then
+  exit 0
+fi
+
+make check
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -ne 0 ]; then
+  echo "Blocked: 'make check' failed (exit $EXIT_CODE). Fix errors before committing." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/pre-commit-check.sh",
+            "timeout": 300
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,7 @@ jobs:
               - 'vite.config.ts'
               - 'vitest.config.ts'
               - 'biome.json'
+              - 'Makefile'
               - '.github/workflows/**'
 
   lint:
@@ -57,11 +58,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run linter
-        run: npx biome lint src test && npm run lint:css
-
-      - name: Check formatting
-        run: npx biome format src test
+      - name: Run make lint
+        run: make lint
 
   lint-skip:
     needs: changes
@@ -70,36 +68,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "No relevant changes, skipping lint"
-
-  typecheck:
-    needs: changes
-    if: needs.changes.outputs.src == 'true'
-    name: Typecheck
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run type check
-        run: npx tsc --noEmit
-
-  typecheck-skip:
-    needs: changes
-    if: needs.changes.outputs.src == 'false'
-    name: Typecheck
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "No relevant changes, skipping typecheck"
 
   test:
     needs: changes
@@ -120,8 +88,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run tests with coverage
-        run: npx vitest run --coverage
+      - name: Run make test
+        run: make test
 
       - name: Report coverage on PR
         uses: davelosert/vitest-coverage-report-action@v2
@@ -181,10 +149,10 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [changes, lint, lint-skip, typecheck, typecheck-skip, test, test-skip, security, security-skip]
+    needs: [changes, lint, lint-skip, test, test-skip, security, security-skip]
     if: always()
     steps:
       - uses: re-actors/alls-green@release/v1
         with:
-          allowed-skips: lint, lint-skip, typecheck, typecheck-skip, test, test-skip, security, security-skip
+          allowed-skips: lint, lint-skip, test, test-skip, security, security-skip
           jobs: ${{ toJSON(needs) }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,13 @@
   <responsibilities>Aurelia 2 single-page PWA for music fans. Vite build, TailwindCSS v4,
   Biome linter, Zitadel OIDC auth, Vitest + Playwright testing.</responsibilities>
   <essential-commands>
-    npm start                        # Dev server
-    npm run build                    # Production build
-    npx @biomejs/biome check src/    # Lint
-    npx vitest                       # Unit tests
-    npx playwright test              # E2E tests
+    make lint              # Biome lint + format check + stylelint + typecheck (matches CI)
+    make fix               # Auto-fix formatting (biome check --write)
+    make test              # Unit tests with coverage (vitest)
+    make check             # Full pre-commit check (lint + test)
+    npm start              # Dev server
+    npm run build          # Production build
+    npx playwright test    # E2E tests
   </essential-commands>
 </poly-repo-context>
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: lint fix test check
+
+## lint: biome lint + format check + stylelint + typecheck (matches CI)
+lint:
+	npx biome lint src test
+	npx biome format src test
+	npm run lint:css
+	npx tsc --noEmit
+
+## fix: auto-fix formatting and lint issues
+fix:
+	npx biome check --write src test
+
+## test: unit tests with coverage
+test:
+	npx vitest run --coverage
+
+## check: full local pre-commit check (lint + test)
+check: lint test


### PR DESCRIPTION
## Summary

Unify lint and test operations across the frontend repo via Makefile targets, and enforce pre-commit checks structurally through a Claude Code PreToolUse hook.

### Changes

- **Makefile**: New file with unified targets (`lint`, `fix`, `test`, `check`)
  - `make lint`: biome lint + format check + stylelint + typecheck (matches CI)
  - `make fix`: auto-fix with `biome check --write`
  - `make test`: vitest with coverage
  - `make check`: full pre-commit (lint + test)
- **CI workflow**: Updated `ci.yaml` to use `make lint` and `make test`. Removed separate typecheck job (merged into `make lint`).
- **PreToolUse hook**: Blocks `git commit` unless `make check` passes
- **AGENTS.md**: Updated essential-commands to reference Makefile targets

close: #133, close: #134, close: #135, close: #136
