### PR TITLE
fix(pwa): resolve cache.put TypeError on POST requests

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -107,68 +107,7 @@ Aurelia
 // In dev mode, vite-plugin-node-polyfills injects Buffer/global/process shims
 // into the SW bundle, which breaks ServiceWorker evaluation.
 if ('serviceWorker' in navigator && !import.meta.env.DEV) {
-	navigator.serviceWorker
-		.register('/sw.js')
-		.then(async (registration) => {
-			// Register Periodic Background Sync for concert data refresh (Chromium only).
-			if ('periodicSync' in registration) {
-				try {
-					await (
-						registration as ServiceWorkerRegistration & {
-							periodicSync: {
-								register(
-									tag: string,
-									options: { minInterval: number },
-								): Promise<void>
-							}
-						}
-					).periodicSync.register('concert-refresh', {
-						minInterval: 12 * 60 * 60 * 1000, // 12 hours
-					})
-				} catch {
-					// Periodic sync not granted or not supported — silent fallback.
-				}
-			}
-		})
-		.catch((err) => {
-			console.warn('Service Worker registration failed:', err)
-		})
-
-	// Handle REFRESH_CONCERT_CACHE messages from the SW's periodicsync handler.
-	// The SW cannot obtain fresh OIDC tokens, so the main thread performs the
-	// re-fetch with live credentials and updates the cache.
-	navigator.serviceWorker.addEventListener('message', async (event) => {
-		if (event.data?.type !== 'REFRESH_CONCERT_CACHE') return
-
-		const { UserManager, WebStorageStateStore } = await import('oidc-client-ts')
-		const userManager = new UserManager({
-			authority: import.meta.env.VITE_ZITADEL_ISSUER,
-			client_id: import.meta.env.VITE_ZITADEL_CLIENT_ID,
-			redirect_uri: `${window.location.origin}/auth/callback`,
-			response_type: 'code',
-			scope: 'openid',
-			userStore: new WebStorageStateStore({ store: window.localStorage }),
-		})
-
-		const user = await userManager.getUser()
-		if (!user?.access_token) return
-
-		const cache = await caches.open('concert-api-v1')
-		const keys = await cache.keys()
-
-		for (const request of keys) {
-			try {
-				const freshRequest = new Request(request.url, {
-					method: request.method,
-					headers: { Authorization: `Bearer ${user.access_token}` },
-				})
-				const response = await fetch(freshRequest)
-				if (response.ok) {
-					await cache.put(request, response)
-				}
-			} catch {
-				// Silent failure — will retry at next periodic sync interval.
-			}
-		}
+	navigator.serviceWorker.register('/sw.js').catch((err) => {
+		console.warn('Service Worker registration failed:', err)
 	})
 }

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -7,7 +7,7 @@ import { BackgroundSyncPlugin } from 'workbox-background-sync'
 import { ExpirationPlugin } from 'workbox-expiration'
 import { precacheAndRoute } from 'workbox-precaching'
 import { registerRoute } from 'workbox-routing'
-import { CacheFirst, NetworkFirst } from 'workbox-strategies'
+import { CacheFirst, NetworkOnly } from 'workbox-strategies'
 
 // ---------------------------------------------------------------------------
 // Precache app shell assets injected by vite-plugin-pwa at build time.
@@ -53,34 +53,13 @@ self.addEventListener('install', (event) => {
 })
 
 // ---------------------------------------------------------------------------
-// Concert list API — NetworkFirst with 3s timeout, 24h cache.
-// ---------------------------------------------------------------------------
-const CONCERT_CACHE = 'concert-api-v1'
-
-registerRoute(
-	({ url }) =>
-		url.pathname.includes('liverty_music.rpc.concert.v1.ConcertService'),
-	new NetworkFirst({
-		cacheName: CONCERT_CACHE,
-		networkTimeoutSeconds: 3,
-		plugins: [
-			new ExpirationPlugin({
-				maxEntries: 50,
-				maxAgeSeconds: 24 * 60 * 60, // 24 hours
-			}),
-		],
-		fetchOptions: {},
-	}),
-)
-
-// ---------------------------------------------------------------------------
 // Background Sync for artist operations (follow / unfollow / passion level).
+// NetworkOnly avoids cache.put() on POST responses (Cache API is GET-only).
 // ---------------------------------------------------------------------------
 registerRoute(
 	({ url }) =>
 		url.pathname.includes('liverty_music.rpc.artist.v1.ArtistService'),
-	new NetworkFirst({
-		cacheName: 'artist-api-v1',
+	new NetworkOnly({
 		plugins: [
 			new BackgroundSyncPlugin('artist-ops-queue', {
 				maxRetentionTime: 7 * 24 * 60, // 7 days (minutes)
@@ -88,26 +67,6 @@ registerRoute(
 		],
 	}),
 	'POST',
-)
-
-// ---------------------------------------------------------------------------
-// Periodic Background Sync — refresh concert cache.
-// The SW cannot obtain fresh OIDC tokens (no access to UserManager), so it
-// delegates the actual re-fetch to the main thread via postMessage.
-// ---------------------------------------------------------------------------
-self.addEventListener(
-	'periodicsync',
-	(event: ExtendableEvent & { tag?: string }) => {
-		if (event.tag !== 'concert-refresh') return
-
-		event.waitUntil(
-			self.clients.matchAll({ type: 'window' }).then((clients) => {
-				for (const client of clients) {
-					client.postMessage({ type: 'REFRESH_CONCERT_CACHE' })
-				}
-			}),
-		)
-	},
 )
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Change Artist API SW route from `NetworkFirst` to `NetworkOnly` to prevent `cache.put()` on POST responses (Cache API is GET-only). `BackgroundSyncPlugin` is preserved for offline operation queuing.
- Remove dead Concert API caching code: route registration, `CONCERT_CACHE` constant, `periodicSync` handler in `sw.ts`, and `periodicSync.register()` + `REFRESH_CONCERT_CACHE` message listener in `main.ts`. This code never functioned because the route lacked a `'POST'` method filter, so Connect-RPC POST requests never matched.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `vite build` succeeds (SW 30KB, 24 precache entries)
- [x] 260 unit tests pass
- [ ] Manual: verify Artist follow/unfollow works without console errors
- [ ] Manual: verify BackgroundSync queues operations when offline

Closes: #117