### PR TITLE
fix(onboarding): show loading screen before navigating to dashboard

### DIFF
--- a/src/routes/onboarding-loading/loading-sequence.ts
+++ b/src/routes/onboarding-loading/loading-sequence.ts
@@ -31,8 +31,11 @@ export class LoadingSequence {
 	public isPhaseVisible = true
 
 	private nextRoute: string | null = null
+	private isOnboardingFlow = false
 	private phaseTimer: number | null = null
+	private displayTimer: number | null = null
 	private readonly FADE_DURATION_MS = 600
+	private readonly ONBOARDING_DISPLAY_MS = 3000
 
 	private get phases() {
 		return [
@@ -127,9 +130,9 @@ export class LoadingSequence {
 		this.startPhaseAnimation()
 
 		if (this.onboarding.isOnboarding) {
-			await new Promise((r) => setTimeout(r, 3000))
-			this.onboarding.setStep(OnboardingStep.DASHBOARD)
-			this.nextRoute = '/dashboard'
+			// Return immediately so the router swaps in the loading screen.
+			// The display timer in attached() handles the 3s wait + navigation.
+			this.isOnboardingFlow = true
 			return
 		}
 
@@ -174,6 +177,14 @@ export class LoadingSequence {
 	 * pipeline finishes before the new navigation starts.
 	 */
 	public attached(): void {
+		if (this.isOnboardingFlow) {
+			this.displayTimer = window.setTimeout(() => {
+				this.onboarding.setStep(OnboardingStep.DASHBOARD)
+				this.router.load('/dashboard')
+			}, this.ONBOARDING_DISPLAY_MS)
+			return
+		}
+
 		if (this.nextRoute) {
 			const route = this.nextRoute
 			this.nextRoute = null
@@ -185,8 +196,12 @@ export class LoadingSequence {
 
 	public unbinding(): void {
 		if (this.phaseTimer !== null) {
-			clearTimeout(this.phaseTimer)
+			window.clearTimeout(this.phaseTimer)
 			this.phaseTimer = null
+		}
+		if (this.displayTimer !== null) {
+			window.clearTimeout(this.displayTimer)
+			this.displayTimer = null
 		}
 	}
 

--- a/test/routes/loading-sequence.spec.ts
+++ b/test/routes/loading-sequence.spec.ts
@@ -243,6 +243,49 @@ describe('LoadingSequence', () => {
 		})
 	})
 
+	describe('loading - onboarding flow', () => {
+		beforeEach(() => {
+			mockOnboarding.isOnboarding = true
+			mockOnboarding.currentStep = 2
+			mockLocalClient.followedCount = 3
+		})
+
+		it('should return immediately from loading() without waiting', async () => {
+			sut.binding()
+			await sut.loading()
+
+			// loading() should NOT have set the step or navigated yet
+			expect(mockOnboarding.setStep).not.toHaveBeenCalled()
+			expect(mockRouter.load).not.toHaveBeenCalled()
+		})
+
+		it('should navigate to dashboard after 3s display in attached()', async () => {
+			sut.binding()
+			await sut.loading()
+			sut.attached()
+
+			// Before 3s: still on loading screen
+			await vi.advanceTimersByTimeAsync(2999)
+			expect(mockRouter.load).not.toHaveBeenCalled()
+
+			// At 3s: navigates to dashboard
+			await vi.advanceTimersByTimeAsync(1)
+			expect(mockOnboarding.setStep).toHaveBeenCalledWith(3) // DASHBOARD
+			expect(mockRouter.load).toHaveBeenCalledWith('/dashboard')
+		})
+
+		it('should clear display timer on unbinding', async () => {
+			sut.binding()
+			await sut.loading()
+			sut.attached()
+
+			sut.unbinding()
+			await vi.advanceTimersByTimeAsync(5000)
+
+			expect(mockRouter.load).not.toHaveBeenCalled()
+		})
+	})
+
 	describe('unbinding', () => {
 		it('should clear phase timer', () => {
 			;(


### PR DESCRIPTION
## Description

Fix onboarding loading screen not being visible during the transition from artist discovery to dashboard.

Aurelia 2's router awaits `loading()` before swapping the component into the DOM. The onboarding path blocked for 3s inside `loading()` while DiscoverPage was still displayed, then immediately navigated to dashboard in `attached()` — making the loading screen invisible (~0ms visibility).

**Fix**: Move the 3s display wait from `loading()` to `attached()`, so the router swaps in LoadingSequence first, the user sees the loading animation for 3 seconds, then navigates to dashboard.

## Type of Change

- [x] fix: A bug fix

## Verification

### Automated Tests
- [x] `npm run lint` passed
- [x] `npm run test` passed (265 tests, 3 new onboarding flow tests)
- [x] `npm run build` passed

### Manual Verification
- Verified via Playwright MCP: "Generate Dashboard" button → loading screen visible for 3s → dashboard renders
- `page.title()` returned `"Loading | Liverty Music"` at t=1s, confirming visibility

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

close: #119