### PR TITLE
Remove OTLP span export, keep traceparent propagation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
 				"@connectrpc/connect": "^1.7.0",
 				"@connectrpc/connect-web": "^1.7.0",
 				"@opentelemetry/api": "^1.9.0",
-				"@opentelemetry/exporter-trace-otlp-http": "^0.212.0",
 				"@opentelemetry/instrumentation-fetch": "^0.212.0",
 				"@opentelemetry/resources": "^2.5.1",
 				"@opentelemetry/sdk-trace-web": "^2.5.1",
@@ -3159,25 +3158,6 @@
 				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
-		"node_modules/@opentelemetry/exporter-trace-otlp-http": {
-			"version": "0.212.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.212.0.tgz",
-			"integrity": "sha512-v/0wMozNoiEPRolzC4YoPo4rAT0q8r7aqdnRw3Nu7IDN0CGFzNQazkfAlBJ6N5y0FYJkban7Aw5WnN73//6YlA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.5.1",
-				"@opentelemetry/otlp-exporter-base": "0.212.0",
-				"@opentelemetry/otlp-transformer": "0.212.0",
-				"@opentelemetry/resources": "2.5.1",
-				"@opentelemetry/sdk-trace-base": "2.5.1"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.3.0"
-			}
-		},
 		"node_modules/@opentelemetry/instrumentation": {
 			"version": "0.212.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.212.0.tgz",
@@ -3213,43 +3193,6 @@
 				"@opentelemetry/api": "^1.3.0"
 			}
 		},
-		"node_modules/@opentelemetry/otlp-exporter-base": {
-			"version": "0.212.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.212.0.tgz",
-			"integrity": "sha512-HoMv5pQlzbuxiMS0hN7oiUtg8RsJR5T7EhZccumIWxYfNo/f4wFc7LPDfFK6oHdG2JF/+qTocfqIHoom+7kLpw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.5.1",
-				"@opentelemetry/otlp-transformer": "0.212.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.3.0"
-			}
-		},
-		"node_modules/@opentelemetry/otlp-transformer": {
-			"version": "0.212.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.212.0.tgz",
-			"integrity": "sha512-bj7zYFOg6Db7NUwsRZQ/WoVXpAf41WY2gsd3kShSfdpZQDRKHWJiRZIg7A8HvWsf97wb05rMFzPbmSHyjEl9tw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/api-logs": "0.212.0",
-				"@opentelemetry/core": "2.5.1",
-				"@opentelemetry/resources": "2.5.1",
-				"@opentelemetry/sdk-logs": "0.212.0",
-				"@opentelemetry/sdk-metrics": "2.5.1",
-				"@opentelemetry/sdk-trace-base": "2.5.1",
-				"protobufjs": "8.0.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.3.0"
-			}
-		},
 		"node_modules/@opentelemetry/resources": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.1.tgz",
@@ -3264,39 +3207,6 @@
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-logs": {
-			"version": "0.212.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.212.0.tgz",
-			"integrity": "sha512-qglb5cqTf0mOC1sDdZ7nfrPjgmAqs2OxkzOPIf2+Rqx8yKBK0pS7wRtB1xH30rqahBIut9QJDbDePyvtyqvH/Q==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/api-logs": "0.212.0",
-				"@opentelemetry/core": "2.5.1",
-				"@opentelemetry/resources": "2.5.1"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.4.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-metrics": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.5.1.tgz",
-			"integrity": "sha512-RKMn3QKi8nE71ULUo0g/MBvq1N4icEBo7cQSKnL3URZT16/YH3nSVgWegOjwx7FRBTrjOIkMJkCUn/ZFIEfn4A==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.5.1",
-				"@opentelemetry/resources": "2.5.1"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.9.0 <1.10.0"
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-base": {
@@ -3367,70 +3277,6 @@
 			"engines": {
 				"node": ">=18"
 			}
-		},
-		"node_modules/@protobufjs/aspromise": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/base64": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/codegen": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/eventemitter": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/fetch": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@protobufjs/aspromise": "^1.1.1",
-				"@protobufjs/inquire": "^1.1.0"
-			}
-		},
-		"node_modules/@protobufjs/float": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/inquire": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/path": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/pool": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/utf8": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/@rollup/plugin-babel": {
 			"version": "5.3.1",
@@ -4484,6 +4330,7 @@
 			"version": "22.19.8",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.8.tgz",
 			"integrity": "sha512-ebO/Yl+EAvVe8DnMfi+iaAyIqYdK0q/q0y0rw82INWEKJOBe6b/P3YWE8NW7oOlF/nXFNrHwhARrN/hdgDkraA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.21.0"
@@ -8629,12 +8476,6 @@
 			"integrity": "sha512-jLlHnlsPSJjpwUfcNyUxXCl33AYg2cHhIf9QhGL2T4iPT0XPB+xP1LRKFPgIg1M/sg9kAJvy94w9CzBNrfnstA==",
 			"license": "MIT"
 		},
-		"node_modules/long": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-			"license": "Apache-2.0"
-		},
 		"node_modules/loupe": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -9549,30 +9390,6 @@
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/protobufjs": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.0.tgz",
-			"integrity": "sha512-jx6+sE9h/UryaCZhsJWbJtTEy47yXoGNYI4z8ZaRncM0zBKeRqjO2JEcOUYwrYGb1WLhXM1FfMzW3annvFv0rw==",
-			"hasInstallScript": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@protobufjs/aspromise": "^1.1.2",
-				"@protobufjs/base64": "^1.1.2",
-				"@protobufjs/codegen": "^2.0.4",
-				"@protobufjs/eventemitter": "^1.1.0",
-				"@protobufjs/fetch": "^1.1.0",
-				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.0",
-				"@protobufjs/path": "^1.1.2",
-				"@protobufjs/pool": "^1.1.0",
-				"@protobufjs/utf8": "^1.1.0",
-				"@types/node": ">=13.7.0",
-				"long": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
 		},
 		"node_modules/public-encrypt": {
 			"version": "4.0.3",
@@ -11545,6 +11362,7 @@
 			"version": "6.21.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
 			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
 		"@connectrpc/connect": "^1.7.0",
 		"@connectrpc/connect-web": "^1.7.0",
 		"@opentelemetry/api": "^1.9.0",
-		"@opentelemetry/exporter-trace-otlp-http": "^0.212.0",
 		"@opentelemetry/instrumentation-fetch": "^0.212.0",
 		"@opentelemetry/resources": "^2.5.1",
 		"@opentelemetry/sdk-trace-web": "^2.5.1",

--- a/src/services/otel-init.ts
+++ b/src/services/otel-init.ts
@@ -1,29 +1,18 @@
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import { registerInstrumentations } from '@opentelemetry/instrumentation'
 import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch'
 import { resourceFromAttributes } from '@opentelemetry/resources'
-import {
-	BatchSpanProcessor,
-	WebTracerProvider,
-} from '@opentelemetry/sdk-trace-web'
+import { WebTracerProvider } from '@opentelemetry/sdk-trace-web'
 import {
 	ATTR_SERVICE_NAME,
 	ATTR_SERVICE_VERSION,
 } from '@opentelemetry/semantic-conventions'
 
-const OTEL_EXPORTER_URL = import.meta.env.VITE_OTEL_EXPORTER_URL as
-	| string
-	| undefined
-
 const API_BASE_URL =
 	import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080'
 
 /**
- * Initialize OpenTelemetry browser SDK with OTLP/HTTP exporter
- * and automatic fetch instrumentation for traceparent propagation.
- *
- * When VITE_OTEL_EXPORTER_URL is not set, trace export is disabled
- * to avoid CSP violations from the localhost fallback.
+ * Initialize OpenTelemetry browser SDK for traceparent propagation.
+ * No spans are exported — the backend handles trace export to Cloud Trace.
  */
 export function initOtel(): WebTracerProvider {
 	const resource = resourceFromAttributes({
@@ -31,18 +20,7 @@ export function initOtel(): WebTracerProvider {
 		[ATTR_SERVICE_VERSION]: '0.1.0',
 	})
 
-	const spanProcessors: BatchSpanProcessor[] = []
-	if (OTEL_EXPORTER_URL) {
-		const exporter = new OTLPTraceExporter({
-			url: OTEL_EXPORTER_URL,
-		})
-		spanProcessors.push(new BatchSpanProcessor(exporter))
-	}
-
-	const provider = new WebTracerProvider({
-		resource,
-		spanProcessors,
-	})
+	const provider = new WebTracerProvider({ resource })
 
 	provider.register()
 


### PR DESCRIPTION
## Description

Remove OTLP span export from the frontend OTel integration. The frontend only needs `WebTracerProvider` + `FetchInstrumentation` for `traceparent` header generation — backend handles trace export to Cloud Trace via the OTel Collector.

- Remove `OTLPTraceExporter` and `BatchSpanProcessor` from `otel-init.ts`
- Remove `@opentelemetry/exporter-trace-otlp-http` dependency
- `VITE_OTEL_EXPORTER_URL` is no longer needed
- Retain `WebTracerProvider`, `FetchInstrumentation`, Connect-RPC tracing interceptor, and `OtelLogSink`

## Type of Change

- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] docs: Documentation only changes
- [x] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] test: Adding missing tests or correcting existing tests
- [x] build: Changes that affect the build system or external dependencies
- [ ] chore: Other changes that don't modify src or test files

## Verification

### Automated Tests
- [x] `npm run lint` passed
- [x] `npm run test` passed (287/287)
- [x] `npm run build` passed

### Manual Verification
Verified no remaining references to `OTLPTraceExporter`, `BatchSpanProcessor`, `VITE_OTEL_EXPORTER_URL`, or `exporter-trace-otlp` in the codebase.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

close: #130
