### PR TITLE
refactor(discovery): decouple ArtistBubble type and add comprehensive tests

### DIFF
--- a/src/components/dna-orb/bubble-physics.ts
+++ b/src/components/dna-orb/bubble-physics.ts
@@ -1,5 +1,5 @@
 import type Matter from 'matter-js'
-import type { ArtistBubble } from '../../services/artist-discovery-service'
+import type { ArtistBubble } from '../../services/artist-service-client'
 
 export interface PhysicsBubble {
 	body: Matter.Body

--- a/src/components/dna-orb/dna-orb-canvas.ts
+++ b/src/components/dna-orb/dna-orb-canvas.ts
@@ -6,7 +6,7 @@ import {
 	shadowCSS,
 	useShadowDOM,
 } from 'aurelia'
-import type { ArtistBubble } from '../../services/artist-discovery-service'
+import type { ArtistBubble } from '../../services/artist-service-client'
 import { AbsorptionAnimator } from './absorption-animator'
 import { BubblePhysics, type PhysicsBubble } from './bubble-physics'
 import { OrbRenderer } from './orb-renderer'

--- a/src/routes/discover/discover-page.ts
+++ b/src/routes/discover/discover-page.ts
@@ -3,8 +3,10 @@ import { IRouter } from '@aurelia/router'
 import { batch, IEventAggregator, ILogger, resolve, watch } from 'aurelia'
 import type { DnaOrbCanvas } from '../../components/dna-orb/dna-orb-canvas'
 import { Toast } from '../../components/toast-notification/toast'
-import type { ArtistBubble } from '../../services/artist-discovery-service'
-import { IArtistServiceClient } from '../../services/artist-service-client'
+import {
+	type ArtistBubble,
+	IArtistServiceClient,
+} from '../../services/artist-service-client'
 import { BubblePool } from '../../services/bubble-pool'
 import { IConcertService } from '../../services/concert-service'
 import { ILocalArtistClient } from '../../services/local-artist-client'

--- a/src/services/artist-discovery-service.ts
+++ b/src/services/artist-discovery-service.ts
@@ -1,9 +1,0 @@
-export interface ArtistBubble {
-	id: string
-	name: string
-	mbid: string
-	imageUrl: string
-	x: number
-	y: number
-	radius: number
-}

--- a/src/services/artist-service-client.ts
+++ b/src/services/artist-service-client.ts
@@ -5,11 +5,20 @@ import {
 import { ArtistService } from '@buf/liverty-music_schema.connectrpc_es/liverty_music/rpc/artist/v1/artist_service_connect.js'
 import { createPromiseClient, type PromiseClient } from '@connectrpc/connect'
 import { DI, ILogger, resolve } from 'aurelia'
-import type { ArtistBubble } from './artist-discovery-service'
 import { IAuthService } from './auth-service'
 import { createTransport } from './grpc-transport'
 import { ILocalArtistClient } from './local-artist-client'
 import { IOnboardingService } from './onboarding-service'
+
+export interface ArtistBubble {
+	id: string
+	name: string
+	mbid: string
+	imageUrl: string
+	x: number
+	y: number
+	radius: number
+}
 
 export interface FollowedArtistInfo {
 	id: string

--- a/src/services/bubble-pool.ts
+++ b/src/services/bubble-pool.ts
@@ -1,4 +1,4 @@
-import type { ArtistBubble } from './artist-discovery-service'
+import type { ArtistBubble } from './artist-service-client'
 
 /**
  * Manages the available bubble pool for the discover page.

--- a/test/components/dna-orb-canvas.spec.ts
+++ b/test/components/dna-orb-canvas.spec.ts
@@ -1,0 +1,449 @@
+import { INode, Registration } from 'aurelia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ArtistBubble } from '../../src/services/artist-service-client'
+import { createTestContainer } from '../helpers/create-container'
+
+// Mock Matter.js to avoid loading the actual physics engine
+vi.mock('matter-js', () => ({
+	default: {
+		Engine: {
+			create: vi.fn(() => ({ world: {} })),
+			update: vi.fn(),
+			clear: vi.fn(),
+		},
+		Composite: {
+			add: vi.fn(),
+			remove: vi.fn(),
+			clear: vi.fn(),
+		},
+		Bodies: {
+			circle: vi.fn(() => ({
+				position: { x: 100, y: 100 },
+			})),
+			rectangle: vi.fn(() => ({
+				position: { x: 0, y: 0 },
+			})),
+		},
+		Body: {
+			applyForce: vi.fn(),
+		},
+	},
+}))
+
+// Import after mocking
+const { DnaOrbCanvas } = await import(
+	'../../src/components/dna-orb/dna-orb-canvas'
+)
+
+function makeBubble(id: string, name: string): ArtistBubble {
+	return { id, name, mbid: '', imageUrl: '', x: 0, y: 0, radius: 30 }
+}
+
+function createMockCanvasContext(): CanvasRenderingContext2D {
+	return {
+		clearRect: vi.fn(),
+		save: vi.fn(),
+		restore: vi.fn(),
+		beginPath: vi.fn(),
+		arc: vi.fn(),
+		fill: vi.fn(),
+		stroke: vi.fn(),
+		clip: vi.fn(),
+		fillText: vi.fn(),
+		drawImage: vi.fn(),
+		moveTo: vi.fn(),
+		lineTo: vi.fn(),
+		setTransform: vi.fn(),
+		setLineDash: vi.fn(),
+		createRadialGradient: vi.fn(() => ({
+			addColorStop: vi.fn(),
+		})),
+		globalAlpha: 1,
+		fillStyle: '',
+		strokeStyle: '',
+		lineWidth: 1,
+		font: '',
+		textAlign: 'center',
+		textBaseline: 'middle',
+	} as unknown as CanvasRenderingContext2D
+}
+
+describe('DnaOrbCanvas', () => {
+	let sut: InstanceType<typeof DnaOrbCanvas>
+	let mockElement: HTMLElement
+	let mockCanvas: HTMLCanvasElement
+	let mockCtx: CanvasRenderingContext2D
+	let dispatchedEvents: CustomEvent[]
+
+	beforeEach(() => {
+		vi.useFakeTimers()
+		dispatchedEvents = []
+		mockCtx = createMockCanvasContext()
+
+		mockCanvas = {
+			getContext: vi.fn(() => mockCtx),
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			getBoundingClientRect: vi.fn(() => ({
+				width: 400,
+				height: 600,
+				top: 0,
+				left: 0,
+			})),
+			width: 400,
+			height: 600,
+			style: { width: '400px', height: '600px' },
+		} as unknown as HTMLCanvasElement
+
+		mockElement = {
+			getBoundingClientRect: vi.fn(() => ({
+				width: 400,
+				height: 600,
+				top: 0,
+				left: 0,
+			})),
+			dispatchEvent: vi.fn((event: CustomEvent) => {
+				dispatchedEvents.push(event)
+				return true
+			}),
+		} as unknown as HTMLElement
+
+		const container = createTestContainer(
+			Registration.instance(INode, mockElement),
+		)
+		container.register(DnaOrbCanvas)
+		sut = container.get(DnaOrbCanvas)
+
+		// Wire up the canvas ref (normally Aurelia template binding does this)
+		;(sut as any).canvas = mockCanvas
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+		vi.restoreAllMocks()
+	})
+
+	describe('bindable defaults', () => {
+		it('should initialize with default bindable values', () => {
+			expect(sut.followedCount).toBe(0)
+			expect(sut.showFollowedIndicator).toBe(false)
+			expect(sut.artists).toEqual([])
+			expect(sut.orbIntensity).toBe(0)
+			expect(sut.followedIds).toEqual(new Set())
+		})
+	})
+
+	describe('artistsChanged', () => {
+		it('should not add bubbles if not yet attached (no ctx)', () => {
+			// ctx is not set until attached() is called
+			const addBubblesSpy = vi.spyOn((sut as any).physics, 'addBubbles')
+			sut.artistsChanged([makeBubble('a1', 'Artist')])
+
+			expect(addBubblesSpy).not.toHaveBeenCalled()
+		})
+
+		it('should add bubbles to physics when ctx is available', async () => {
+			// Simulate attached
+			await sut.attached()
+			const addBubblesSpy = vi.spyOn((sut as any).physics, 'addBubbles')
+
+			const artists = [makeBubble('a1', 'Artist')]
+			sut.artistsChanged(artists)
+
+			expect(addBubblesSpy).toHaveBeenCalledWith(artists)
+		})
+	})
+
+	describe('attached', () => {
+		it('should get 2D context from canvas', async () => {
+			await sut.attached()
+
+			expect(mockCanvas.getContext).toHaveBeenCalledWith('2d')
+		})
+
+		it('should register event listeners on canvas', async () => {
+			await sut.attached()
+
+			expect(mockCanvas.addEventListener).toHaveBeenCalledWith(
+				'click',
+				expect.any(Function),
+			)
+			expect(mockCanvas.addEventListener).toHaveBeenCalledWith(
+				'touchstart',
+				expect.any(Function),
+				{ passive: true },
+			)
+			expect(mockCanvas.addEventListener).toHaveBeenCalledWith(
+				'keydown',
+				expect.any(Function),
+			)
+		})
+
+		it('should add initial artists to physics', async () => {
+			const addBubblesSpy = vi.spyOn((sut as any).physics, 'addBubbles')
+			sut.artists = [makeBubble('a1', 'Initial')]
+
+			await sut.attached()
+
+			expect(addBubblesSpy).toHaveBeenCalledWith(sut.artists)
+		})
+	})
+
+	describe('detaching', () => {
+		it('should remove event listeners and destroy physics', async () => {
+			await sut.attached()
+			const destroySpy = vi.spyOn((sut as any).physics, 'destroy')
+
+			sut.detaching()
+
+			expect(mockCanvas.removeEventListener).toHaveBeenCalledWith(
+				'click',
+				expect.any(Function),
+			)
+			expect(destroySpy).toHaveBeenCalled()
+		})
+	})
+
+	describe('pause / resume', () => {
+		it('should set paused state and cancel animation frame', async () => {
+			await sut.attached()
+			const cancelSpy = vi.spyOn(globalThis, 'cancelAnimationFrame')
+
+			sut.pause()
+
+			expect(cancelSpy).toHaveBeenCalled()
+		})
+
+		it('should be idempotent when already paused', async () => {
+			await sut.attached()
+			sut.pause()
+
+			const cancelSpy = vi.spyOn(globalThis, 'cancelAnimationFrame')
+			sut.pause() // second call
+
+			expect(cancelSpy).not.toHaveBeenCalled()
+		})
+
+		it('should restart animation loop on resume', async () => {
+			await sut.attached()
+			sut.pause()
+
+			const rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame')
+			sut.resume()
+
+			expect(rafSpy).toHaveBeenCalled()
+		})
+
+		it('should be idempotent when not paused', async () => {
+			await sut.attached()
+
+			const rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame')
+			const callsBefore = rafSpy.mock.calls.length
+			sut.resume()
+
+			// resume should not add additional requestAnimationFrame calls
+			expect(rafSpy.mock.calls.length).toBe(callsBefore)
+		})
+	})
+
+	describe('spawnBubblesAt', () => {
+		it('should delegate to physics.spawnBubblesAt', async () => {
+			await sut.attached()
+			const spawnSpy = vi.spyOn((sut as any).physics, 'spawnBubblesAt')
+			const bubbles = [makeBubble('s1', 'Spawn')]
+
+			sut.spawnBubblesAt(bubbles, 100, 200)
+
+			expect(spawnSpy).toHaveBeenCalledWith(bubbles, 100, 200)
+		})
+	})
+
+	describe('fadeOutBubbles', () => {
+		it('should delegate to physics.fadeOutBubbles', async () => {
+			await sut.attached()
+			const fadeOutSpy = vi
+				.spyOn((sut as any).physics, 'fadeOutBubbles')
+				.mockResolvedValue(undefined)
+
+			await sut.fadeOutBubbles(['a1', 'a2'])
+
+			expect(fadeOutSpy).toHaveBeenCalledWith(['a1', 'a2'])
+		})
+	})
+
+	describe('reloadBubbles', () => {
+		it('should reset physics and add new artists', async () => {
+			await sut.attached()
+			const resetSpy = vi.spyOn((sut as any).physics, 'reset')
+			const initSpy = vi
+				.spyOn((sut as any).physics, 'init')
+				.mockResolvedValue(undefined)
+			const addSpy = vi.spyOn((sut as any).physics, 'addBubbles')
+
+			const newArtists = [makeBubble('r1', 'Reloaded')]
+			sut.reloadBubbles(newArtists)
+
+			expect(resetSpy).toHaveBeenCalled()
+
+			// Wait for init promise
+			await vi.advanceTimersByTimeAsync(0)
+
+			expect(initSpy).toHaveBeenCalledWith(400, 600)
+			expect(addSpy).toHaveBeenCalledWith(newArtists)
+		})
+
+		it('should skip if element has zero dimensions', async () => {
+			await sut.attached()
+			;(
+				mockElement.getBoundingClientRect as ReturnType<typeof vi.fn>
+			).mockReturnValue({
+				width: 0,
+				height: 0,
+			})
+
+			const resetSpy = vi.spyOn((sut as any).physics, 'reset')
+			sut.reloadBubbles([makeBubble('r1', 'Skip')])
+
+			expect(resetSpy).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('bubbleCount', () => {
+		it('should delegate to physics.bubbleCount', () => {
+			vi.spyOn((sut as any).physics, 'bubbleCount', 'get').mockReturnValue(42)
+			expect(sut.bubbleCount).toBe(42)
+		})
+	})
+
+	describe('handleInteraction (DOM event dispatch)', () => {
+		it('should dispatch artist-selected and need-more-bubbles events on bubble tap', async () => {
+			await sut.attached()
+
+			const artist = makeBubble('a1', 'Tapped Artist')
+			const mockPhysicsBubble = {
+				body: { position: { x: 150, y: 250 } },
+				artist,
+				scale: 1,
+				opacity: 1,
+				isSpawning: false,
+				spawnProgress: 1,
+				isFadingOut: false,
+				fadeOutProgress: 0,
+			}
+
+			vi.spyOn((sut as any).physics, 'getBubbleAt').mockReturnValue(
+				mockPhysicsBubble,
+			)
+			vi.spyOn((sut as any).physics, 'removeBubble').mockReturnValue(
+				mockPhysicsBubble,
+			)
+			vi.spyOn((sut as any).absorptionAnimator, 'startAbsorption')
+
+			// Call handleInteraction directly
+			;(sut as any).handleInteraction(150, 250)
+
+			expect(dispatchedEvents).toHaveLength(2)
+
+			// First event: artist-selected
+			expect(dispatchedEvents[0].type).toBe('artist-selected')
+			expect(dispatchedEvents[0].detail.artist).toBe(artist)
+			expect(dispatchedEvents[0].detail.position).toEqual({ x: 150, y: 250 })
+
+			// Second event: need-more-bubbles
+			expect(dispatchedEvents[1].type).toBe('need-more-bubbles')
+			expect(dispatchedEvents[1].detail.artistId).toBe('a1')
+			expect(dispatchedEvents[1].detail.artistName).toBe('Tapped Artist')
+			expect(dispatchedEvents[1].detail.position).toEqual({ x: 150, y: 250 })
+		})
+
+		it('should not dispatch events when no bubble at tap position', async () => {
+			await sut.attached()
+
+			vi.spyOn((sut as any).physics, 'getBubbleAt').mockReturnValue(undefined)
+
+			;(sut as any).handleInteraction(999, 999)
+
+			expect(dispatchedEvents).toHaveLength(0)
+		})
+
+		it('should remove tapped bubble from physics and start absorption', async () => {
+			await sut.attached()
+
+			const artist = makeBubble('a1', 'Absorbed')
+			const mockBubble = {
+				body: { position: { x: 100, y: 200 } },
+				artist,
+				scale: 1,
+				opacity: 1,
+				isSpawning: false,
+				spawnProgress: 1,
+				isFadingOut: false,
+				fadeOutProgress: 0,
+			}
+
+			vi.spyOn((sut as any).physics, 'getBubbleAt').mockReturnValue(mockBubble)
+			const removeSpy = vi
+				.spyOn((sut as any).physics, 'removeBubble')
+				.mockReturnValue(mockBubble)
+			const absorptionSpy = vi.spyOn(
+				(sut as any).absorptionAnimator,
+				'startAbsorption',
+			)
+
+			;(sut as any).handleInteraction(100, 200)
+
+			expect(removeSpy).toHaveBeenCalledWith('a1')
+			expect(absorptionSpy).toHaveBeenCalledWith(
+				'a1',
+				'Absorbed',
+				100,
+				200,
+				expect.any(Number), // orbX
+				expect.any(Number), // orbY
+				30, // radius
+				'', // imageUrl
+			)
+		})
+
+		it('should prevent concurrent interactions (isProcessing guard)', async () => {
+			await sut.attached()
+
+			const artist = makeBubble('a1', 'Guard')
+			const mockBubble = {
+				body: { position: { x: 100, y: 200 } },
+				artist,
+				scale: 1,
+				opacity: 1,
+				isSpawning: false,
+				spawnProgress: 1,
+				isFadingOut: false,
+				fadeOutProgress: 0,
+			}
+
+			let callCount = 0
+			vi.spyOn((sut as any).physics, 'getBubbleAt').mockImplementation(() => {
+				callCount++
+				if (callCount === 1) {
+					// Simulate a concurrent call during processing
+					;(sut as any).handleInteraction(100, 200)
+				}
+				return mockBubble
+			})
+			vi.spyOn((sut as any).physics, 'removeBubble').mockReturnValue(mockBubble)
+			vi.spyOn((sut as any).absorptionAnimator, 'startAbsorption')
+
+			;(sut as any).handleInteraction(100, 200)
+
+			// getBubbleAt should only be called once (second call blocked by isProcessing)
+			expect(callCount).toBe(1)
+		})
+	})
+
+	describe('followedCountChanged', () => {
+		it('should pulse the orb renderer', () => {
+			const pulseSpy = vi.spyOn((sut as any).orbRenderer, 'pulse')
+			sut.followedCountChanged(5, 4)
+			expect(pulseSpy).toHaveBeenCalled()
+		})
+	})
+})

--- a/test/routes/discover-page.spec.ts
+++ b/test/routes/discover-page.spec.ts
@@ -1,7 +1,7 @@
 import { DI, IEventAggregator, Registration } from 'aurelia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Toast } from '../../src/components/toast-notification/toast'
-import type { ArtistBubble } from '../../src/services/artist-discovery-service'
+import type { ArtistBubble } from '../../src/services/artist-service-client'
 import { createTestContainer } from '../helpers/create-container'
 import { createMockRouter } from '../helpers/mock-router'
 import {
@@ -256,6 +256,411 @@ describe('DiscoverPage', () => {
 			await sut.onFollowFromSearch(makeBubble('a1', 'Artist'))
 
 			expect(mockArtistClient.follow).toHaveBeenCalledTimes(1)
+		})
+	})
+
+	describe('onArtistSelected', () => {
+		it('should follow artist and request similar artists via event detail', async () => {
+			;(mockArtistClient.follow as ReturnType<typeof vi.fn>).mockResolvedValue(
+				undefined,
+			)
+			;(mockConcert.listConcerts as ReturnType<typeof vi.fn>).mockResolvedValue(
+				[],
+			)
+
+			const artist = makeBubble('a1', 'Artist One')
+			const event = new CustomEvent('artist-selected', {
+				detail: { artist, position: { x: 100, y: 200 } },
+			})
+
+			await sut.onArtistSelected(event)
+
+			expect(mockArtistClient.follow).toHaveBeenCalledWith('a1', 'Artist One')
+		})
+
+		it('should update orbIntensity after following', async () => {
+			;(mockArtistClient.follow as ReturnType<typeof vi.fn>).mockResolvedValue(
+				undefined,
+			)
+			;(mockConcert.listConcerts as ReturnType<typeof vi.fn>).mockResolvedValue(
+				[],
+			)
+
+			expect(sut.orbIntensity).toBe(0)
+
+			const event = new CustomEvent('artist-selected', {
+				detail: {
+					artist: makeBubble('a1', 'Artist'),
+					position: { x: 0, y: 0 },
+				},
+			})
+			await sut.onArtistSelected(event)
+
+			expect(sut.orbIntensity).toBe(1 / 20) // 1 followed / 20
+		})
+
+		it('should skip if artist already followed', async () => {
+			;(mockArtistClient.follow as ReturnType<typeof vi.fn>).mockResolvedValue(
+				undefined,
+			)
+			;(mockConcert.listConcerts as ReturnType<typeof vi.fn>).mockResolvedValue(
+				[],
+			)
+
+			const artist = makeBubble('a1', 'Artist')
+			const event = new CustomEvent('artist-selected', {
+				detail: { artist, position: { x: 0, y: 0 } },
+			})
+
+			await sut.onArtistSelected(event)
+			await sut.onArtistSelected(event)
+
+			expect(mockArtistClient.follow).toHaveBeenCalledTimes(1)
+		})
+
+		it('should show toast when artist has upcoming live events', async () => {
+			;(mockArtistClient.follow as ReturnType<typeof vi.fn>).mockResolvedValue(
+				undefined,
+			)
+			;(mockConcert.listConcerts as ReturnType<typeof vi.fn>).mockResolvedValue(
+				[{ id: 'c1' }],
+			)
+
+			const event = new CustomEvent('artist-selected', {
+				detail: {
+					artist: makeBubble('a1', 'Live Band'),
+					position: { x: 0, y: 0 },
+				},
+			})
+			await sut.onArtistSelected(event)
+
+			// Wait for the fire-and-forget concert check to resolve
+			await vi.advanceTimersByTimeAsync(0)
+
+			expect(mockConcert.listConcerts).toHaveBeenCalledWith('a1')
+			expect(mockEa.publish).toHaveBeenCalled()
+		})
+
+		it('should show error toast on follow failure', async () => {
+			;(mockArtistClient.follow as ReturnType<typeof vi.fn>).mockRejectedValue(
+				new Error('network error'),
+			)
+
+			const event = new CustomEvent('artist-selected', {
+				detail: {
+					artist: makeBubble('a1', 'Fail Artist'),
+					position: { x: 10, y: 20 },
+				},
+			})
+			await sut.onArtistSelected(event)
+
+			// followArtist publishes a toast, then onArtistSelected publishes an error toast
+			expect(mockEa.published.length).toBeGreaterThanOrEqual(1)
+			const hasErrorToast = mockEa.published.some(
+				(t: Toast) => t.severity === 'error',
+			)
+			expect(hasErrorToast).toBe(true)
+		})
+	})
+
+	describe('followArtist rollback on RPC failure', () => {
+		it('should rollback followedArtists on follow failure', async () => {
+			;(mockArtistClient.follow as ReturnType<typeof vi.fn>).mockRejectedValue(
+				new Error('rpc fail'),
+			)
+
+			const event = new CustomEvent('artist-selected', {
+				detail: {
+					artist: makeBubble('a1', 'RollbackArtist'),
+					position: { x: 50, y: 50 },
+				},
+			})
+			await sut.onArtistSelected(event)
+
+			// followedArtists should be empty after rollback
+			expect(sut.followedCount).toBe(0)
+			expect(sut.orbIntensity).toBe(0)
+			expect(sut.isArtistFollowed('a1')).toBe(false)
+		})
+
+		it('should re-spawn bubble at original position on follow failure', async () => {
+			;(mockArtistClient.follow as ReturnType<typeof vi.fn>).mockRejectedValue(
+				new Error('fail'),
+			)
+
+			const event = new CustomEvent('artist-selected', {
+				detail: {
+					artist: makeBubble('a1', 'Respawn'),
+					position: { x: 100, y: 200 },
+				},
+			})
+			await sut.onArtistSelected(event)
+
+			expect(sut.dnaOrbCanvas.spawnBubblesAt).toHaveBeenCalledWith(
+				[expect.objectContaining({ id: 'a1' })],
+				100,
+				200,
+			)
+		})
+	})
+
+	describe('onNeedMoreBubbles', () => {
+		it('should fetch similar artists and spawn them at tap position', async () => {
+			const similar = [makeBubble('s1', 'Similar 1')]
+			;(
+				mockArtistClient.listSimilar as ReturnType<typeof vi.fn>
+			).mockResolvedValue(similar)
+
+			const event = new CustomEvent('need-more-bubbles', {
+				detail: {
+					artistId: 'a1',
+					artistName: 'Tapped',
+					position: { x: 50, y: 50 },
+				},
+			})
+
+			await sut.onNeedMoreBubbles(event)
+
+			expect(mockArtistClient.listSimilar).toHaveBeenCalledWith('a1', 30)
+			expect(sut.dnaOrbCanvas.spawnBubblesAt).toHaveBeenCalledWith(
+				similar,
+				50,
+				50,
+			)
+		})
+
+		it('should fall back to top artists when similar returns empty', async () => {
+			;(
+				mockArtistClient.listSimilar as ReturnType<typeof vi.fn>
+			).mockResolvedValue([])
+			;(mockArtistClient.listTop as ReturnType<typeof vi.fn>).mockResolvedValue(
+				[makeBubble('t1', 'Top Fallback')],
+			)
+
+			const event = new CustomEvent('need-more-bubbles', {
+				detail: {
+					artistId: 'a1',
+					artistName: 'NoSimilar',
+					position: { x: 0, y: 0 },
+				},
+			})
+			await sut.onNeedMoreBubbles(event)
+
+			expect(mockArtistClient.listTop).toHaveBeenCalled()
+			expect(sut.dnaOrbCanvas.spawnBubblesAt).toHaveBeenCalled()
+		})
+
+		it('should evict oldest bubbles when pool is full', async () => {
+			// Fill the pool up to MAX
+			const initial = Array.from({ length: 50 }, (_, i) =>
+				makeBubble(`existing${i}`, `Existing ${i}`),
+			)
+			;(mockArtistClient.listTop as ReturnType<typeof vi.fn>).mockResolvedValue(
+				initial,
+			)
+			await sut.loading()
+
+			// Mock canvas bubbleCount to match pool
+			;(sut.dnaOrbCanvas as any).bubbleCount = 50
+
+			const similar = [makeBubble('new1', 'New One')]
+			;(
+				mockArtistClient.listSimilar as ReturnType<typeof vi.fn>
+			).mockResolvedValue(similar)
+			;(
+				sut.dnaOrbCanvas.fadeOutBubbles as ReturnType<typeof vi.fn>
+			).mockResolvedValue(undefined)
+
+			const event = new CustomEvent('need-more-bubbles', {
+				detail: {
+					artistId: 'a1',
+					artistName: 'Source',
+					position: { x: 0, y: 0 },
+				},
+			})
+			await sut.onNeedMoreBubbles(event)
+
+			expect(sut.dnaOrbCanvas.fadeOutBubbles).toHaveBeenCalled()
+		})
+
+		it('should ignore concurrent requests (isLoadingBubbles guard)', async () => {
+			let resolveFirst: () => void
+			const firstPromise = new Promise<ArtistBubble[]>((resolve) => {
+				resolveFirst = () => resolve([makeBubble('s1', 'S1')])
+			})
+			;(
+				mockArtistClient.listSimilar as ReturnType<typeof vi.fn>
+			).mockReturnValueOnce(firstPromise)
+
+			const event = new CustomEvent('need-more-bubbles', {
+				detail: { artistId: 'a1', artistName: 'A', position: { x: 0, y: 0 } },
+			})
+
+			// Fire two events simultaneously
+			const first = sut.onNeedMoreBubbles(event)
+			const second = sut.onNeedMoreBubbles(event)
+
+			resolveFirst!()
+			await first
+			await second
+
+			// listSimilar should only be called once (second was blocked)
+			expect(mockArtistClient.listSimilar).toHaveBeenCalledTimes(1)
+		})
+
+		it('should show warning toast on fetch failure', async () => {
+			;(
+				mockArtistClient.listSimilar as ReturnType<typeof vi.fn>
+			).mockRejectedValue(new Error('network'))
+
+			const event = new CustomEvent('need-more-bubbles', {
+				detail: {
+					artistId: 'a1',
+					artistName: 'Failing',
+					position: { x: 0, y: 0 },
+				},
+			})
+			await sut.onNeedMoreBubbles(event)
+
+			expect(mockEa.published.length).toBe(1)
+			expect(mockEa.published[0].severity).toBe('warning')
+		})
+	})
+
+	describe('loading with existing followed artists (seed similar)', () => {
+		it('should fetch seed similar artists when followedArtists is non-empty', async () => {
+			// Pre-populate followed artists
+			;(mockArtistClient.follow as ReturnType<typeof vi.fn>).mockResolvedValue(
+				undefined,
+			)
+			;(mockConcert.listConcerts as ReturnType<typeof vi.fn>).mockResolvedValue(
+				[],
+			)
+			await sut.onFollowFromSearch(makeBubble('f1', 'Followed One'))
+
+			// Now loading should call listSimilar (seed) instead of listTop
+			;(
+				mockArtistClient.listSimilar as ReturnType<typeof vi.fn>
+			).mockResolvedValue([makeBubble('s1', 'Seed Similar')])
+
+			await sut.loading()
+
+			expect(mockArtistClient.listSimilar).toHaveBeenCalled()
+		})
+	})
+
+	describe('visibility change', () => {
+		it('should pause canvas when document becomes hidden', () => {
+			sut.attached()
+
+			Object.defineProperty(document, 'hidden', {
+				value: true,
+				writable: true,
+			})
+			document.dispatchEvent(new Event('visibilitychange'))
+
+			expect(sut.dnaOrbCanvas.pause).toHaveBeenCalled()
+
+			// Cleanup
+			Object.defineProperty(document, 'hidden', {
+				value: false,
+				writable: true,
+			})
+			sut.detaching()
+		})
+
+		it('should resume canvas when document becomes visible and not in search mode', () => {
+			sut.attached()
+			sut.isSearchMode = false
+
+			Object.defineProperty(document, 'hidden', {
+				value: false,
+				writable: true,
+			})
+			document.dispatchEvent(new Event('visibilitychange'))
+
+			expect(sut.dnaOrbCanvas.resume).toHaveBeenCalled()
+			sut.detaching()
+		})
+
+		it('should NOT resume canvas when document becomes visible but in search mode', () => {
+			sut.attached()
+			sut.isSearchMode = true
+
+			Object.defineProperty(document, 'hidden', {
+				value: false,
+				writable: true,
+			})
+			document.dispatchEvent(new Event('visibilitychange'))
+
+			expect(sut.dnaOrbCanvas.resume).not.toHaveBeenCalled()
+			sut.detaching()
+		})
+	})
+
+	describe('onboarding followedCount delegation', () => {
+		it('should delegate to localClient.followedCount during onboarding', () => {
+			mockOnboarding.isOnboarding = true
+			mockLocalClient.followedCount = 5
+
+			expect(sut.followedCount).toBe(5)
+		})
+
+		it('should use followedArtists.length when not onboarding', async () => {
+			mockOnboarding.isOnboarding = false
+			;(mockArtistClient.follow as ReturnType<typeof vi.fn>).mockResolvedValue(
+				undefined,
+			)
+			;(mockConcert.listConcerts as ReturnType<typeof vi.fn>).mockResolvedValue(
+				[],
+			)
+
+			await sut.onFollowFromSearch(makeBubble('a1', 'A'))
+			await sut.onFollowFromSearch(makeBubble('a2', 'B'))
+
+			expect(sut.followedCount).toBe(2)
+		})
+	})
+
+	describe('showCompleteButton', () => {
+		it('should show when onboarding and followed >= TUTORIAL_FOLLOW_TARGET', async () => {
+			mockOnboarding.isOnboarding = true
+			mockLocalClient.followedCount = 3
+
+			expect(sut.showCompleteButton).toBe(true)
+		})
+
+		it('should hide when not onboarding', () => {
+			mockOnboarding.isOnboarding = false
+			expect(sut.showCompleteButton).toBe(false)
+		})
+	})
+
+	describe('poolBubbles', () => {
+		it('should reflect pool availableBubbles', async () => {
+			;(mockArtistClient.listTop as ReturnType<typeof vi.fn>).mockResolvedValue(
+				[makeBubble('a1', 'Pool Artist')],
+			)
+
+			await sut.loading()
+
+			expect(sut.poolBubbles).toHaveLength(1)
+			expect(sut.poolBubbles[0].name).toBe('Pool Artist')
+		})
+	})
+
+	describe('guidanceMessage', () => {
+		it('should return start message when no artists followed during onboarding', () => {
+			mockOnboarding.isOnboarding = true
+			mockLocalClient.followedCount = 0
+
+			const msg = sut.guidanceMessage
+			expect(msg).toBeTruthy()
+		})
+
+		it('should return empty when not onboarding', () => {
+			mockOnboarding.isOnboarding = false
+			expect(sut.guidanceMessage).toBe('')
 		})
 	})
 })

--- a/test/services/bubble-pool.spec.ts
+++ b/test/services/bubble-pool.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { ArtistBubble } from '../../src/services/artist-discovery-service'
+import type { ArtistBubble } from '../../src/services/artist-service-client'
 import { BubblePool } from '../../src/services/bubble-pool'
 
 function makeBubble(id: string, name: string, mbid = ''): ArtistBubble {


### PR DESCRIPTION
Delete artist-discovery-service.ts and relocate ArtistBubble interface to artist-service-client.ts. Update all import paths. Add 23 DiscoverPage tests and 21 DnaOrbCanvas tests covering follow flow, bubble pool management, visibility, DOM events, and physics delegation. All 348 unit tests pass.