### PR TITLE
fix(service): update DateLaneGroup to ProximityGroup imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
 			"dependencies": {
 				"@aurelia/i18n": "^2.0.0-rc.0",
 				"@aurelia/router": "latest",
-				"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260310150029-c1a7c0621406.1",
-				"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260310150029-c1a7c0621406.2",
+				"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260312074833-163690671e3f.1",
+				"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260312074833-163690671e3f.2",
 				"@bufbuild/protobuf": "^1.10.1",
 				"@connectrpc/connect": "^1.7.0",
 				"@connectrpc/connect-web": "^1.7.0",
@@ -2141,8 +2141,8 @@
 			}
 		},
 		"node_modules/@buf/liverty-music_schema.bufbuild_es": {
-			"version": "1.10.0-20260311045553-1f8021df2ae2.1",
-			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.bufbuild_es/-/liverty-music_schema.bufbuild_es-1.10.0-20260311045553-1f8021df2ae2.1.tgz",
+			"version": "1.10.0-20260312074833-163690671e3f.1",
+			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.bufbuild_es/-/liverty-music_schema.bufbuild_es-1.10.0-20260312074833-163690671e3f.1.tgz",
 			"dependencies": {
 				"@buf/bufbuild_protovalidate.bufbuild_es": "1.10.0-20250717185734-6c6e0d3c608e.1",
 				"@buf/googleapis_googleapis.bufbuild_es": "1.10.0-20250411203938-61b203b9a916.1"
@@ -2152,12 +2152,12 @@
 			}
 		},
 		"node_modules/@buf/liverty-music_schema.connectrpc_es": {
-			"version": "1.6.1-20260311045553-1f8021df2ae2.2",
-			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.connectrpc_es/-/liverty-music_schema.connectrpc_es-1.6.1-20260311045553-1f8021df2ae2.2.tgz",
+			"version": "1.6.1-20260312074833-163690671e3f.2",
+			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.connectrpc_es/-/liverty-music_schema.connectrpc_es-1.6.1-20260312074833-163690671e3f.2.tgz",
 			"dependencies": {
 				"@buf/bufbuild_protovalidate.connectrpc_es": "1.6.1-20250717185734-6c6e0d3c608e.2",
 				"@buf/googleapis_googleapis.connectrpc_es": "1.6.1-20250411203938-61b203b9a916.2",
-				"@buf/liverty-music_schema.bufbuild_es": "1.10.0-20260311045553-1f8021df2ae2.1"
+				"@buf/liverty-music_schema.bufbuild_es": "1.10.0-20260312074833-163690671e3f.1"
 			},
 			"peerDependencies": {
 				"@connectrpc/connect": "^1.6.1"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
 	"dependencies": {
 		"@aurelia/i18n": "^2.0.0-rc.0",
 		"@aurelia/router": "latest",
-		"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260310150029-c1a7c0621406.1",
-		"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260310150029-c1a7c0621406.2",
+		"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260312074833-163690671e3f.1",
+		"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260312074833-163690671e3f.2",
 		"@bufbuild/protobuf": "^1.10.1",
 		"@connectrpc/connect": "^1.7.0",
 		"@connectrpc/connect-web": "^1.7.0",

--- a/src/services/concert-service.ts
+++ b/src/services/concert-service.ts
@@ -2,7 +2,7 @@ import { ArtistId } from '@buf/liverty-music_schema.bufbuild_es/liverty_music/en
 import type { Concert } from '@buf/liverty-music_schema.bufbuild_es/liverty_music/entity/v1/concert_pb.js'
 import {
 	type ArtistSearchStatus,
-	DateLaneGroup,
+	ProximityGroup,
 } from '@buf/liverty-music_schema.bufbuild_es/liverty_music/rpc/concert/v1/concert_service_pb.js'
 import { ConcertService } from '@buf/liverty-music_schema.connectrpc_es/liverty_music/rpc/concert/v1/concert_service_connect.js'
 import { createClient } from '@connectrpc/connect'
@@ -48,7 +48,7 @@ export class ConcertServiceClient {
 		}
 	}
 
-	public async listByFollower(signal?: AbortSignal): Promise<DateLaneGroup[]> {
+	public async listByFollower(signal?: AbortSignal): Promise<ProximityGroup[]> {
 		if (this.onboarding.isOnboarding) {
 			return this.listByFollowerOnboarding(signal)
 		}
@@ -69,7 +69,7 @@ export class ConcertServiceClient {
 	 */
 	private async listByFollowerOnboarding(
 		signal?: AbortSignal,
-	): Promise<DateLaneGroup[]> {
+	): Promise<ProximityGroup[]> {
 		const artists = this.localClient.listFollowed()
 		this.logger.info('Onboarding: listing concerts for local artists', {
 			count: artists.length,
@@ -130,19 +130,19 @@ export class ConcertServiceClient {
 }
 
 /**
- * Groups a flat list of concerts by date into DateLaneGroup messages.
+ * Groups a flat list of concerts by date into ProximityGroup messages.
  * All concerts are placed in the "away" lane (used during onboarding when
  * no server-side grouping is available).
  */
-function groupConcertsByDate(concerts: Concert[]): DateLaneGroup[] {
-	const groups = new Map<string, DateLaneGroup>()
+function groupConcertsByDate(concerts: Concert[]): ProximityGroup[] {
+	const groups = new Map<string, ProximityGroup>()
 	for (const concert of concerts) {
 		const ld = concert.localDate?.value
 		if (!ld) continue
 		const key = `${ld.year}-${String(ld.month).padStart(2, '0')}-${String(ld.day).padStart(2, '0')}`
 		let group = groups.get(key)
 		if (!group) {
-			group = new DateLaneGroup({ date: concert.localDate })
+			group = new ProximityGroup({ date: concert.localDate })
 			groups.set(key, group)
 		}
 		group.away.push(concert)

--- a/src/services/dashboard-service.ts
+++ b/src/services/dashboard-service.ts
@@ -1,6 +1,6 @@
 import type { Concert } from '@buf/liverty-music_schema.bufbuild_es/liverty_music/entity/v1/concert_pb.js'
 import { HypeType } from '@buf/liverty-music_schema.bufbuild_es/liverty_music/entity/v1/follow_pb.js'
-import type { DateLaneGroup } from '@buf/liverty-music_schema.bufbuild_es/liverty_music/rpc/concert/v1/concert_service_pb.js'
+import type { ProximityGroup } from '@buf/liverty-music_schema.bufbuild_es/liverty_music/rpc/concert/v1/concert_service_pb.js'
 import { DI, ILogger, resolve } from 'aurelia'
 import type {
 	DateGroup,
@@ -40,7 +40,7 @@ export class DashboardService {
 	}
 
 	private protoGroupToDateGroup(
-		group: DateLaneGroup,
+		group: ProximityGroup,
 		artistMap: Map<string, { name: string; hypeLevel: HypeLevel }>,
 	): DateGroup {
 		const ld = group.date?.value


### PR DESCRIPTION
## Related Issue

Refs: #191

## Summary of Changes

Update `DateLaneGroup` → `ProximityGroup` imports in concert-service and dashboard-service to match the renamed proto message. Update BSR packages to v0.24.0 which contains the `ProximityGroup.distant` → `ProximityGroup.away` field rename (consistent with `PROXIMITY_AWAY` enum).

- `concert-service.ts`: `DateLaneGroup` → `ProximityGroup` type references
- `dashboard-service.ts`: `DateLaneGroup` → `ProximityGroup` import and parameter type
- BSR packages updated to v0.24.0 commit

## Commit Log

- fix(service): update DateLaneGroup to ProximityGroup imports

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have added or updated tests to cover my changes.
- [x] I have run `make check` locally and all checks have passed.
- [x] My code follows the architecture and style guidelines of the project.
