### PR TITLE
fix: add trailing slash to post_logout_redirect_uri

### DIFF
--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -10,7 +10,7 @@ const settings: UserManagerSettings = {
 	authority: import.meta.env.VITE_ZITADEL_ISSUER,
 	client_id: import.meta.env.VITE_ZITADEL_CLIENT_ID,
 	redirect_uri: `${window.location.origin}/auth/callback`,
-	post_logout_redirect_uri: window.location.origin,
+	post_logout_redirect_uri: `${window.location.origin}/`,
 	response_type: 'code',
 	scope: [
 		'openid profile email offline_access',


### PR DESCRIPTION
## Summary

- Add trailing `/` to `post_logout_redirect_uri` in OIDC settings so it matches the URI registered in Zitadel

## Motivation

Zitadel's end_session endpoint returns 400 Bad Request when the `post_logout_redirect_uri` doesn't exactly match the registered value. The registered URI includes a trailing slash but `window.location.origin` does not.

## Test plan

- [ ] CI passes (lint, typecheck, unit tests)
- [ ] Verify logout flow completes without 400 error

close: #162
