### PR TITLE
fix(discover): fix canvas containing block and data-state migration

### DIFF
--- a/e2e/layout/discover.layout.spec.ts
+++ b/e2e/layout/discover.layout.spec.ts
@@ -2,13 +2,13 @@ import { expectContainedIn, expectFillsParent } from './assertions'
 import { expect, test } from './fixtures'
 
 test.describe('Discover page layout', () => {
-	test.beforeEach(async ({ layoutPage: page }) => {
+	test.beforeEach(async ({ discoverLayoutPage: page }) => {
 		await page.goto('/discover')
 		await page.waitForSelector('.discover-layout')
 	})
 
 	test('discover-layout fills viewport width and au-viewport height (D1)', async ({
-		layoutPage: page,
+		discoverLayoutPage: page,
 	}) => {
 		const viewportSize = page.viewportSize()!
 		const layout = page.locator('.discover-layout')
@@ -24,7 +24,7 @@ test.describe('Discover page layout', () => {
 	})
 
 	test('bubble-area width equals discover-layout width (D2)', async ({
-		layoutPage: page,
+		discoverLayoutPage: page,
 	}) => {
 		const layout = page.locator('.discover-layout')
 		const bubbleArea = page.locator('.bubble-area')
@@ -38,7 +38,7 @@ test.describe('Discover page layout', () => {
 	})
 
 	test('canvas fills bubble-area within 1px tolerance (D3)', async ({
-		layoutPage: page,
+		discoverLayoutPage: page,
 	}) => {
 		// Wait for canvas to initialize (dna-orb-canvas sets width/height on attaching)
 		await page.waitForSelector('dna-orb-canvas canvas')
@@ -50,7 +50,7 @@ test.describe('Discover page layout', () => {
 	})
 
 	test('search-bar right edge within viewport (D4)', async ({
-		layoutPage: page,
+		discoverLayoutPage: page,
 	}) => {
 		const viewportSize = page.viewportSize()!
 		const searchBar = page.locator('.search-bar')
@@ -65,7 +65,7 @@ test.describe('Discover page layout', () => {
 	})
 
 	test('bubble-area bottom does not exceed bottom-nav top (D5)', async ({
-		layoutPage: page,
+		discoverLayoutPage: page,
 	}) => {
 		await page.waitForSelector('bottom-nav-bar')
 		const bubbleArea = page.locator('.bubble-area')
@@ -80,7 +80,7 @@ test.describe('Discover page layout', () => {
 	})
 
 	test('no horizontal overflow on discover-layout (D6)', async ({
-		layoutPage: page,
+		discoverLayoutPage: page,
 	}) => {
 		const overflow = await page.evaluate(() => {
 			const el = document.querySelector('.discover-layout')
@@ -91,7 +91,7 @@ test.describe('Discover page layout', () => {
 	})
 
 	test('bubble-area occupies majority of vertical space (D7)', async ({
-		layoutPage: page,
+		discoverLayoutPage: page,
 	}) => {
 		const layout = page.locator('.discover-layout')
 		const bubbleArea = page.locator('.bubble-area')
@@ -106,7 +106,7 @@ test.describe('Discover page layout', () => {
 	})
 
 	test('genre-chips height is constrained (D8)', async ({
-		layoutPage: page,
+		discoverLayoutPage: page,
 	}) => {
 		const chips = page.locator('.genre-chips')
 		const chipsBox = await chips.boundingBox()
@@ -117,7 +117,7 @@ test.describe('Discover page layout', () => {
 	})
 
 	test('vertical order: search-bar above genre-chips above bubble-area (D9)', async ({
-		layoutPage: page,
+		discoverLayoutPage: page,
 	}) => {
 		const searchBar = page.locator('.search-bar')
 		const chips = page.locator('.genre-chips')
@@ -135,7 +135,7 @@ test.describe('Discover page layout', () => {
 	})
 
 	test('all grid children contained within discover-layout (D10)', async ({
-		layoutPage: page,
+		discoverLayoutPage: page,
 	}) => {
 		const layoutBox = await page.locator('.discover-layout').boundingBox()
 		expect(layoutBox).toBeTruthy()

--- a/e2e/layout/fixtures.ts
+++ b/e2e/layout/fixtures.ts
@@ -19,15 +19,31 @@ async function mockRpcRoutes(page: Page): Promise<void> {
 
 /**
  * Set localStorage values so routes render without auth/onboarding redirects.
+ * Step 7 = COMPLETED: bypasses tutorial restrictions for non-tutorial routes.
  */
 const BYPASS_AUTH_SETUP = () => {
-	// Set step to COMPLETED (7) so isOnboarding=false and bottom-nav is visible
 	localStorage.setItem('onboardingStep', '7')
 }
 
-export const test = base.extend<{ layoutPage: Page }>({
+/**
+ * Set onboarding step to DISCOVER (1) so the auth hook allows
+ * tutorial routes (discover, loading, dashboard) without authentication.
+ */
+const ONBOARDING_DISCOVER_SETUP = () => {
+	localStorage.setItem('onboardingStep', '1')
+}
+
+export const test = base.extend<{
+	layoutPage: Page
+	discoverLayoutPage: Page
+}>({
 	layoutPage: async ({ page }, use) => {
 		await page.addInitScript(BYPASS_AUTH_SETUP)
+		await mockRpcRoutes(page)
+		await use(page)
+	},
+	discoverLayoutPage: async ({ page }, use) => {
+		await page.addInitScript(ONBOARDING_DISCOVER_SETUP)
 		await mockRpcRoutes(page)
 		await use(page)
 	},

--- a/e2e/layout/shell.layout.spec.ts
+++ b/e2e/layout/shell.layout.spec.ts
@@ -2,7 +2,9 @@ import { expectAnchored, expectFillsViewport } from './assertions'
 import { expect, test } from './fixtures'
 
 test.describe('Shell layout', () => {
-	test('my-app fills viewport height (S1)', async ({ layoutPage: page }) => {
+	test('my-app fills viewport height (S1)', async ({
+		discoverLayoutPage: page,
+	}) => {
 		await page.goto('/discover')
 		await page.waitForSelector('.discover-layout')
 
@@ -11,7 +13,7 @@ test.describe('Shell layout', () => {
 	})
 
 	test('au-viewport + bottom-nav equals my-app height (S2)', async ({
-		layoutPage: page,
+		discoverLayoutPage: page,
 	}) => {
 		await page.goto('/discover')
 		await page.waitForSelector('.discover-layout')
@@ -33,7 +35,7 @@ test.describe('Shell layout', () => {
 	})
 
 	test('bottom-nav anchored to viewport bottom (S3)', async ({
-		layoutPage: page,
+		discoverLayoutPage: page,
 	}) => {
 		await page.goto('/discover')
 		await page.waitForSelector('.discover-layout')

--- a/src/routes/discover/discover-page.css
+++ b/src/routes/discover/discover-page.css
@@ -241,17 +241,21 @@
 		}
 
 		.bubble-area {
+			position: relative;
+
 			container-name: bubble-area;
-			container-type: inline-size;
+			container-type: size;
+			overflow: hidden;
 			grid-row: -2 / -1;
+
 			min-block-size: 0;
 		}
 
 		.orb-label {
 			position: absolute;
-			inset-block-end: 10rem;
+			inset-block-end: 15cqb;
 			inset-inline-start: 50%;
-			transform: translateX(-50%);
+			translate: -50% 0;
 
 			font-family: var(--font-display);
 			font-size: var(--step--2);
@@ -418,6 +422,15 @@
 				transform: translateY(0);
 				opacity: 1;
 			}
+		}
+
+		/* State-driven visibility (after base selectors to avoid descending specificity) */
+		.discover-layout[data-state="search"] :is(.genre-chips, .bubble-area) {
+			display: none;
+		}
+
+		.discover-layout:not([data-state="search"]) .search-results {
+			display: none;
 		}
 	}
 }

--- a/src/routes/discover/discover-page.html
+++ b/src/routes/discover/discover-page.html
@@ -3,7 +3,7 @@
   <import from="../../components/dna-orb/dna-orb-canvas"></import>
 
 
-  <div class="discover-layout">
+  <div class="discover-layout" data-state.bind="isSearchMode ? 'search' : null">
 
     <!-- Search bar -->
     <div class="search-bar">
@@ -32,7 +32,7 @@
     </div>
 
     <!-- Genre chips (hidden during search) -->
-    <div class="genre-chips ${isSearchMode ? 'hidden' : ''}">
+    <div class="genre-chips">
       <button
         repeat.for="tag of genreTags; key.bind: tag"
         class="genre-chip ${activeTag === tag ? 'active' : ''}"
@@ -52,7 +52,7 @@
     </div>
 
     <!-- Bubble UI (hidden during search) -->
-    <div class="bubble-area ${isSearchMode ? 'hidden' : ''}">
+    <div class="bubble-area">
       <dna-orb-canvas
         component.ref="dnaOrbCanvas"
         artists.bind="poolBubbles"
@@ -71,7 +71,7 @@
     </div>
 
     <!-- Search results (shown during search) -->
-    <div class="search-results ${isSearchMode ? '' : 'hidden'}">
+    <div class="search-results">
       <div if.bind="isSearching" class="search-status" t="discover.searching">
       </div>
 


### PR DESCRIPTION
## Description

Fix the Discover page layout where `dna-orb-canvas` (position: absolute) resolved its containing block to `.discover-layout` instead of `.bubble-area`, causing the canvas to overlay the search bar and genre chips.

**Changes:**
- Establish `.bubble-area` as a proper containing block (`position: relative`, `overflow: hidden`, `container-type: size`)
- Replace `.orb-label` magic number (`inset-block-end: 10rem`) with container-relative units (`15cqb`)
- Migrate browse/search mode toggling from `.hidden` class bindings to `data-state` attribute selectors (CUBE CSS exception pattern)
- Add `discoverLayoutPage` E2E fixture with correct onboarding step for discover route

## Type of Change

- [x] fix: A bug fix

## Verification

### Automated Tests
- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] `npm run build` passed

### Manual Verification
- E2E layout tests D1-D10 all pass (canvas fills bubble-area, no overflow, correct vertical order)
- Pre-existing C3 dashboard sticky positioning failure is unrelated

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

close: #165