### PR TITLE
feat(auth): force re-authentication in dev environment

### DIFF
--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -78,7 +78,11 @@ export class AuthService {
 
 	public async signIn(): Promise<void> {
 		this.logger.info('Starting sign-in flow')
-		await this.userManager.signinRedirect()
+		// In dev, force re-authentication to bypass Zitadel session cookies,
+		// making it easy to switch between test users without clearing cookies.
+		await this.userManager.signinRedirect(
+			import.meta.env.DEV ? { prompt: 'login' } : undefined,
+		)
 	}
 
 	public async signUp(): Promise<void> {


### PR DESCRIPTION
## Description

In dev environment, Zitadel's session cookie keeps users authenticated for 10 days without re-prompting for passkey. This makes switching between test users painful — requiring manual cookie deletion on the Zitadel domain.

This adds `prompt: 'login'` to `signinRedirect()` in dev mode only, forcing Zitadel to ignore existing sessions and always prompt for passkey authentication. Production behavior is unchanged.

## Type of Change

- [x] feat: A new feature

## Verification

### Automated Tests
- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] `npm run build` passed

### Manual Verification
- Click "Sign In" in dev → Zitadel prompts for passkey (no session reuse)
- Production build → `import.meta.env.DEV` is false, no prompt parameter sent

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

close: #187
