### PR TITLE
fix(settings): resolve home area i18n key mismatch and add language selector

### DIFF
--- a/src/constants/iso3166.ts
+++ b/src/constants/iso3166.ts
@@ -70,13 +70,13 @@ export function displayName(code: string, lang: 'ja' | 'en' = 'ja'): string {
 }
 
 /**
- * Returns the short display name (without suffix) for Japanese prefectures.
- * e.g., "JP-13" → "東京", "JP-27" → "大阪"
+ * Returns the i18n translation key for an ISO 3166-2 code.
+ * e.g., "JP-13" → "tokyo", "JP-40" → "fukuoka"
  */
-export function shortDisplayName(code: string): string {
+export function translationKey(code: string): string {
 	const entry = JP_PREFECTURES[code]
 	if (!entry) return code
-	return entry.ja.replace(/[都道府県]$/, '')
+	return entry.key
 }
 
 /**

--- a/src/routes/settings/settings-page.css
+++ b/src/routes/settings/settings-page.css
@@ -5,6 +5,8 @@
 			--_toggle-off: var(--color-white);
 			--_thumb-bg: var(--color-white);
 			--_signout-color: var(--color-error);
+			--_backdrop-bg: oklch(0% 0 0deg / 60%);
+			--_handle-bg: oklch(100% 0 0deg / 20%);
 		}
 
 		.page-header {
@@ -178,6 +180,150 @@
 			font-size: var(--step--1);
 			font-weight: 600;
 			color: var(--_signout-color);
+		}
+
+		/* Language selector bottom sheet */
+		dialog.language-selector {
+			position: fixed;
+			inset-block: auto 0;
+			inset-inline: 0;
+			translate: 0 0;
+
+			overflow: visible;
+			display: block;
+
+			inline-size: 100%;
+			max-inline-size: 100%;
+			margin: 0;
+			padding: 0;
+			border: none;
+
+			opacity: 1;
+			background: transparent;
+
+			transition:
+				opacity 300ms ease-out,
+				translate 300ms ease-out,
+				overlay 300ms ease-out allow-discrete,
+				display 300ms ease-out allow-discrete;
+
+			&::backdrop {
+				opacity: 1;
+				background: var(--_backdrop-bg);
+				backdrop-filter: blur(4px);
+				transition:
+					opacity 300ms ease-out,
+					overlay 300ms ease-out allow-discrete,
+					display 300ms ease-out allow-discrete;
+			}
+
+			&:not([open]) {
+				translate: 0 100%;
+				display: none;
+				opacity: 0;
+			}
+
+			&:not([open])::backdrop {
+				opacity: 0;
+			}
+		}
+
+		@starting-style {
+			dialog.language-selector[open] {
+				translate: 0 100%;
+				opacity: 0;
+			}
+
+			dialog.language-selector[open]::backdrop {
+				opacity: 0;
+			}
+		}
+
+		dialog.language-selector .selector-body {
+			overflow-y: auto;
+
+			max-block-size: 80vh;
+			border-radius: var(--radius-sheet) var(--radius-sheet) 0 0;
+
+			background: var(--color-surface-raised);
+			box-shadow: var(--shadow-sheet);
+		}
+
+		dialog.language-selector .selector-handle {
+			display: flex;
+			justify-content: center;
+			padding-block: var(--space-2xs) var(--space-3xs);
+		}
+
+		dialog.language-selector .selector-handle-bar {
+			inline-size: 2.5rem;
+			block-size: 0.25rem;
+			border-radius: var(--radius-full);
+			background: var(--_handle-bg);
+		}
+
+		dialog.language-selector .selector-content {
+			padding-block-end: var(--space-l);
+			padding-inline: var(--space-m);
+		}
+
+		dialog.language-selector .selector-title {
+			margin-block-end: var(--space-s);
+
+			font-family: var(--font-display);
+			font-size: var(--step-1);
+			font-weight: 700;
+			color: var(--color-text-primary);
+		}
+
+		.language-list {
+			display: flex;
+			flex-direction: column;
+			gap: var(--space-3xs);
+		}
+
+		.language-option {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+
+			padding: var(--space-xs) var(--space-s);
+			border: 1px solid color-mix(in oklch, var(--color-white) 10%, transparent);
+			border-radius: var(--radius-button);
+
+			font-family: var(--font-display);
+			font-size: var(--step--1);
+			font-weight: 600;
+			color: var(--color-text-primary);
+
+			background: var(--color-surface-overlay);
+
+			transition:
+				background-color 150ms ease-out,
+				border-color 150ms ease-out;
+
+			&:hover {
+				border-color: oklch(from var(--color-brand-primary) l c h / 40%);
+				background: oklch(from var(--color-brand-primary) l c h / 20%);
+			}
+
+			&[data-selected="true"] {
+				border-color: var(--color-brand-primary);
+				background: oklch(from var(--color-brand-primary) l c h / 15%);
+			}
+		}
+
+		.language-check {
+			inline-size: 1.25rem;
+			block-size: 1.25rem;
+			color: var(--color-brand-primary);
+		}
+
+		@media (prefers-reduced-motion: reduce) {
+			dialog.language-selector,
+			dialog.language-selector::backdrop {
+				transition-duration: var(--transition-fast);
+			}
 		}
 	}
 }

--- a/src/routes/settings/settings-page.html
+++ b/src/routes/settings/settings-page.html
@@ -28,7 +28,7 @@
 
       <!-- Language -->
       <button
-        click.trigger="cycleLanguage()"
+        click.trigger="openLanguageSelector()"
         class="settings-row"
       >
         <div class="settings-row-start">
@@ -129,3 +129,32 @@
   component.ref="homeSelector"
   on-home-selected.bind="(code) => onHomeSelected(code)"
 ></user-home-selector>
+
+<!-- Language Selector Bottom Sheet -->
+<dialog
+  ref="languageDialog"
+  t="[aria-label]settings.language"
+  click.trigger="handleLanguageBackdropClick($event)"
+  cancel.trigger="handleLanguageCancel($event)"
+  class="[ language-selector ]"
+>
+  <div class="selector-body">
+    <div class="selector-handle">
+      <div class="selector-handle-bar"></div>
+    </div>
+    <div class="selector-content">
+      <h2 t="settings.language" class="selector-title"></h2>
+      <div class="language-list">
+        <button
+          repeat.for="lang of supportedLanguages"
+          click.trigger="selectLanguage(lang)"
+          class="language-option"
+          data-selected.bind="isCurrentLanguage(lang)"
+        >
+          <span>${ languageLabel(lang) }</span>
+          <svg-icon if.bind="isCurrentLanguage(lang)" name="check" class="language-check"></svg-icon>
+        </button>
+      </div>
+    </div>
+  </div>
+</dialog>

--- a/src/routes/settings/settings-page.ts
+++ b/src/routes/settings/settings-page.ts
@@ -2,7 +2,7 @@ import { I18N } from '@aurelia/i18n'
 import { IEventAggregator, ILogger, resolve } from 'aurelia'
 import { Toast } from '../../components/toast-notification/toast'
 import { UserHomeSelector } from '../../components/user-home-selector/user-home-selector'
-import { shortDisplayName } from '../../constants/iso3166'
+import { translationKey } from '../../constants/iso3166'
 import { StorageKeys } from '../../constants/storage-keys'
 import { IAuthService } from '../../services/auth-service'
 import { INotificationManager } from '../../services/notification-manager'
@@ -24,6 +24,8 @@ export class SettingsPage {
 	public notificationsEnabled = false
 	public vapidAvailable = !!(import.meta.env.VITE_VAPID_PUBLIC_KEY ?? '')
 	public homeSelector!: UserHomeSelector
+	public languageDialog?: HTMLDialogElement
+	public readonly supportedLanguages = SUPPORTED_LANGUAGES
 	private isToggling = false
 
 	public get currentHomeDisplay(): string {
@@ -39,7 +41,7 @@ export class SettingsPage {
 	public loading(): void {
 		const homeLevel1 = this.userService.current?.home?.level1
 		const code = homeLevel1 ?? UserHomeSelector.getStoredHome()
-		this.currentHome = code ? shortDisplayName(code) : null
+		this.currentHome = code ? translationKey(code) : null
 		const storedPref =
 			localStorage.getItem(StorageKeys.userNotificationsEnabled) === 'true'
 		// If the browser permission was revoked externally, override the stored preference
@@ -52,19 +54,47 @@ export class SettingsPage {
 	}
 
 	public onHomeSelected(code: string): void {
-		this.currentHome = shortDisplayName(code)
+		this.currentHome = translationKey(code)
 		this.logger.info('Home area updated from settings', { code })
 	}
 
-	public async cycleLanguage(): Promise<void> {
+	public openLanguageSelector(): void {
+		this.languageDialog?.showModal()
+	}
+
+	public closeLanguageSelector(): void {
+		this.languageDialog?.close()
+	}
+
+	public handleLanguageBackdropClick(event: MouseEvent): void {
+		if (event.target === this.languageDialog) {
+			this.closeLanguageSelector()
+		}
+	}
+
+	public handleLanguageCancel(event: Event): void {
+		event.preventDefault()
+		this.closeLanguageSelector()
+	}
+
+	public async selectLanguage(lang: string): Promise<void> {
 		const current = this.i18n.getLocale()
-		const idx = SUPPORTED_LANGUAGES.indexOf(
-			current as (typeof SUPPORTED_LANGUAGES)[number],
-		)
-		const next = SUPPORTED_LANGUAGES[(idx + 1) % SUPPORTED_LANGUAGES.length]
-		await this.i18n.setLocale(next)
-		localStorage.setItem('language', next)
-		this.logger.info('Language changed', { from: current, to: next })
+		if (lang === current) {
+			this.closeLanguageSelector()
+			return
+		}
+		await this.i18n.setLocale(lang)
+		localStorage.setItem('language', lang)
+		this.logger.info('Language changed', { from: current, to: lang })
+		this.closeLanguageSelector()
+	}
+
+	public isCurrentLanguage(lang: string): boolean {
+		return this.i18n.getLocale() === lang
+	}
+
+	public languageLabel(lang: string): string {
+		return this.i18n.tr(`languages.${lang}`)
 	}
 
 	public async toggleNotifications(): Promise<void> {

--- a/test/i18n/language-switching.spec.ts
+++ b/test/i18n/language-switching.spec.ts
@@ -73,44 +73,55 @@ describe('i18n language switching', () => {
 		expect(mockI18n.getLocale()).toBe('ja')
 	})
 
-	it('should cycle from ja to en', async () => {
-		await sut.cycleLanguage()
+	it('should select English language', async () => {
+		await sut.selectLanguage('en')
 
 		expect(mockI18n.setLocale).toHaveBeenCalledWith('en')
 		expect(localStorage.getItem('language')).toBe('en')
 	})
 
-	it('should cycle from en back to ja', async () => {
-		// Switch to English first
-		await sut.cycleLanguage()
+	it('should switch back to Japanese', async () => {
+		await sut.selectLanguage('en')
 		expect(mockI18n.currentLocale).toBe('en')
 
-		// Switch back to Japanese
-		await sut.cycleLanguage()
+		await sut.selectLanguage('ja')
 
 		expect(mockI18n.setLocale).toHaveBeenCalledWith('ja')
 		expect(localStorage.getItem('language')).toBe('ja')
 	})
 
+	it('should not call setLocale when selecting current language', async () => {
+		await sut.selectLanguage('ja')
+
+		expect(mockI18n.setLocale).not.toHaveBeenCalled()
+	})
+
 	it('should persist language choice in localStorage', async () => {
-		await sut.cycleLanguage()
+		await sut.selectLanguage('en')
 		expect(localStorage.getItem('language')).toBe('en')
 
-		await sut.cycleLanguage()
+		await sut.selectLanguage('ja')
 		expect(localStorage.getItem('language')).toBe('ja')
 	})
 
 	it('should update currentLanguageLabel after locale change', async () => {
-		// Before switching: ja
 		sut.currentLanguageLabel
 		expect(mockI18n.tr).toHaveBeenCalledWith('languages.ja')
 
-		// Switch to English
-		await sut.cycleLanguage()
+		await sut.selectLanguage('en')
 
-		// After switching: en
 		mockI18n.tr.mockClear()
 		sut.currentLanguageLabel
+		expect(mockI18n.tr).toHaveBeenCalledWith('languages.en')
+	})
+
+	it('should identify current language', () => {
+		expect(sut.isCurrentLanguage('ja')).toBe(true)
+		expect(sut.isCurrentLanguage('en')).toBe(false)
+	})
+
+	it('should return language label via languageLabel()', () => {
+		sut.languageLabel('en')
 		expect(mockI18n.tr).toHaveBeenCalledWith('languages.en')
 	})
 


### PR DESCRIPTION
## Description

Fix two bugs on the Settings page:

1. **Home area displays raw i18n key**: The home area row showed `userHome.prefectures.福岡` instead of the translated name. Root cause was `shortDisplayName()` returning a Japanese name (e.g., '福岡') while i18n keys use romaji (e.g., 'fukuoka'). Fixed by replacing `shortDisplayName()` with `translationKey()` that returns the correct i18n key.

2. **Language selector toggles immediately**: Tapping the language row instantly cycled between ja/en instead of showing a selection UI. Replaced `cycleLanguage()` with a bottom sheet language selector dialog, consistent with the home area selector pattern.

## Type of Change

- [x] fix: A bug fix

## Verification

### Automated Tests
- [x] `npm run lint` passed
- [x] `npm run test` passed (574 tests, 0 failures)
- [x] `npm run build` passed

### Manual Verification
- Verified home area displays correct translated name after selecting a prefecture
- Verified language selector opens a bottom sheet with ja/en options
- Verified selecting a language updates the UI and persists to localStorage
- Verified pressing Escape closes the language selector
- Verified selecting the current language closes the dialog without triggering setLocale

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

close: #197
