### PR TITLE
fix(hype-slider): resolve reactivity bug in hype level binding

### DIFF
--- a/src/components/hype-inline-slider/hype-inline-slider.css
+++ b/src/components/hype-inline-slider/hype-inline-slider.css
@@ -8,6 +8,15 @@
 			align-items: center;
 
 			min-block-size: 44px;
+			margin: 0;
+			padding: 0;
+			border: none;
+		}
+
+		.hype-slider-stop {
+			cursor: pointer;
+			grid-row: 1;
+			justify-self: center;
 		}
 
 		.hype-slider-track {
@@ -23,16 +32,12 @@
 		}
 
 		.hype-slider-dot {
-			cursor: pointer;
-
 			position: relative;
 
-			grid-row: 1;
-			justify-self: center;
+			display: block;
 
 			inline-size: 8px;
 			block-size: 8px;
-			padding: 0;
 			border: none;
 			border-radius: var(--radius-full);
 
@@ -52,14 +57,14 @@
 				block-size: 14px;
 			}
 
-			/* WATCH: minimal */
-			&[data-active="true"][data-level="watch"] {
+			/* WATCH (1): minimal */
+			&[data-active="true"][data-level="1"] {
 				border: 1px solid oklch(100% 0 0deg / 10%);
 				background: var(--color-surface-base, oklch(100% 0 0deg / 5%));
 			}
 
-			/* HOME: subtle glow */
-			&[data-active="true"][data-level="home"] {
+			/* HOME (2): subtle glow */
+			&[data-active="true"][data-level="2"] {
 				border: 1px solid var(--_dot-color, oklch(70% 0.15 60deg));
 				opacity: 0.4;
 				background: var(--_dot-color, oklch(70% 0.15 60deg));
@@ -67,8 +72,8 @@
 					oklch(from var(--_dot-color, oklch(70% 0.15 60deg)) l c h / 30%);
 			}
 
-			/* NEARBY: neon glow */
-			&[data-active="true"][data-level="nearby"] {
+			/* NEARBY (3): neon glow */
+			&[data-active="true"][data-level="3"] {
 				border: 2px solid var(--_dot-color, oklch(70% 0.15 60deg));
 				background: var(--_dot-color, oklch(70% 0.15 60deg));
 				box-shadow: 0 0 16px
@@ -76,8 +81,8 @@
 				animation: dot-pulse 2s ease-in-out infinite;
 			}
 
-			/* AWAY: intense neon */
-			&[data-active="true"][data-level="away"] {
+			/* AWAY (4): intense neon */
+			&[data-active="true"][data-level="4"] {
 				border: 2px solid var(--_dot-color, oklch(70% 0.15 60deg));
 				background: var(--_dot-color, oklch(70% 0.15 60deg));
 				box-shadow:

--- a/src/components/hype-inline-slider/hype-inline-slider.html
+++ b/src/components/hype-inline-slider/hype-inline-slider.html
@@ -1,14 +1,20 @@
 <import from="./hype-inline-slider.css"></import>
 
-<div class="[ hype-slider ]">
+<fieldset class="[ hype-slider ]">
+  <legend class="[ visually-hidden ]">Hype level</legend>
   <div class="hype-slider-track"></div>
-  <button
-    repeat.for="stop of stops"
-    class="hype-slider-dot"
-    data-active.bind="stop === hypeLevel"
-    data-level.bind="stop"
-    dot-color.bind="hypeColor"
-    click.trigger="selectHype(stop)"
-    aria-label.bind="stop">
-  </button>
-</div>
+  <label repeat.for="stop of stops" class="hype-slider-stop">
+    <input type="radio"
+      name.bind="'hype-' + artistId"
+      model.bind="stop"
+      checked.bind="hype"
+      class="[ visually-hidden ]"
+      click.trigger="selectHype(stop, $event)">
+    <span
+      class="hype-slider-dot"
+      data-active.bind="stop === hype"
+      data-level.bind="stop"
+      dot-color.bind="hypeColor">
+    </span>
+  </label>
+</fieldset>

--- a/src/components/hype-inline-slider/hype-inline-slider.ts
+++ b/src/components/hype-inline-slider/hype-inline-slider.ts
@@ -1,20 +1,26 @@
 import { bindable, INode, resolve } from 'aurelia'
+import { HypeType } from '@buf/liverty-music_schema.bufbuild_es/liverty_music/entity/v1/follow_pb.js'
 
-const HYPE_STOPS = ['watch', 'home', 'nearby', 'away'] as const
-export type HypeStop = (typeof HYPE_STOPS)[number]
+const HYPE_STOPS: readonly HypeType[] = [
+	HypeType.WATCH,
+	HypeType.HOME,
+	HypeType.NEARBY,
+	HypeType.AWAY,
+]
 
 export class HypeInlineSlider {
 	@bindable public artistId = ''
 	@bindable public hypeColor = ''
-	@bindable public hypeLevel: HypeStop = 'watch'
+	@bindable public hype: HypeType = HypeType.WATCH
 	@bindable public isAuthenticated = false
 
-	public readonly stops: readonly HypeStop[] = HYPE_STOPS
+	public readonly stops = HYPE_STOPS
 
 	private readonly element = resolve(INode) as HTMLElement
 
-	public selectHype(level: HypeStop): void {
+	public selectHype(level: HypeType, event: Event): void {
 		if (!this.isAuthenticated) {
+			event.preventDefault()
 			this.element.dispatchEvent(
 				new CustomEvent('hype-signup-prompt', {
 					bubbles: true,
@@ -26,7 +32,7 @@ export class HypeInlineSlider {
 		this.element.dispatchEvent(
 			new CustomEvent('hype-changed', {
 				bubbles: true,
-				detail: { artistId: this.artistId, level },
+				detail: { artistId: this.artistId, hype: level },
 			}),
 		)
 	}

--- a/src/routes/my-artists/my-artists-route.html
+++ b/src/routes/my-artists/my-artists-route.html
@@ -64,8 +64,8 @@
         <!-- Inline hype slider -->
         <hype-inline-slider
           artist-id.bind="artist.id"
-          hype-color.bind="getArtistColor(artist.id)"
-          hype-level.bind="hypeStop(artist)"
+          hype-color.bind="artist.color"
+          hype.bind="artist.hype"
           is-authenticated.bind="isAuthenticated"
           hype-changed.trigger="onHypeChanged($event)"
           hype-signup-prompt.trigger="onHypeSignupPrompt($event)">

--- a/src/routes/my-artists/my-artists-route.ts
+++ b/src/routes/my-artists/my-artists-route.ts
@@ -3,7 +3,6 @@ import { IRouter } from '@aurelia/router'
 import { ArtistId } from '@buf/liverty-music_schema.bufbuild_es/liverty_music/entity/v1/artist_pb.js'
 import { HypeType } from '@buf/liverty-music_schema.bufbuild_es/liverty_music/entity/v1/follow_pb.js'
 import { IEventAggregator, ILogger, resolve } from 'aurelia'
-import type { HypeStop } from '../../components/hype-inline-slider/hype-inline-slider'
 import { artistColor } from '../../components/live-highway/color-generator'
 import {
 	Toast,
@@ -95,22 +94,6 @@ export class MyArtistsRoute {
 
 	public get isAuthenticated(): boolean {
 		return this.authService.isAuthenticated
-	}
-
-	public getArtistColor(id: string): string {
-		const artist = this.artists.find((a) => a.id === id)
-		return artist?.color ?? ''
-	}
-
-	private static readonly HYPE_TO_STOP: Record<number, HypeStop> = {
-		[HypeType.WATCH]: 'watch',
-		[HypeType.HOME]: 'home',
-		[HypeType.NEARBY]: 'nearby',
-		[HypeType.AWAY]: 'away',
-	}
-
-	public hypeStop(artist: FollowedArtist): HypeStop {
-		return MyArtistsRoute.HYPE_TO_STOP[artist.hype] ?? 'watch'
 	}
 
 	public async loading(): Promise<void> {
@@ -275,27 +258,19 @@ export class MyArtistsRoute {
 
 	// --- Hype level inline slider ---
 
-	private static readonly HYPE_FROM_STOP: Record<HypeStop, HypeType> = {
-		watch: HypeType.WATCH,
-		home: HypeType.HOME,
-		nearby: HypeType.NEARBY,
-		away: HypeType.AWAY,
-	}
-
 	public onHypeChanged(
-		event: CustomEvent<{ artistId: string; level: HypeStop }>,
+		event: CustomEvent<{ artistId: string; hype: HypeType }>,
 	): void {
-		const { artistId, level } = event.detail
+		const { artistId, hype } = event.detail
 		const artist = this.artists.find((a) => a.id === artistId)
 		if (!artist) return
 
-		const hypeType = MyArtistsRoute.HYPE_FROM_STOP[level]
 		const prev = artist.hype
-		if (prev === hypeType) return
+		if (prev === hype) return
 
 		// During onboarding step 5: visual demo only, no persistence
 		if (this.isOnboardingStepMyArtists) {
-			artist.hype = hypeType
+			artist.hype = hype
 
 			// Immediate pulse feedback
 			this.pulsingArtistId = artistId
@@ -314,18 +289,18 @@ export class MyArtistsRoute {
 		if (this.isOnboarding) return
 
 		// Optimistic update
-		artist.hype = hypeType
+		artist.hype = hype
 
 		// Fire-and-forget RPC with 1 retry
 		const client = this.followService.getClient()
 		const req = {
 			artistId: new ArtistId({ value: artistId }),
-			hype: hypeType,
+			hype,
 		}
 		client
 			.setHype(req)
 			.then(() => {
-				this.logger.info('Hype level updated', { artistId, level })
+				this.logger.info('Hype level updated', { artistId, hype })
 			})
 			.catch((firstErr) => {
 				this.logger.warn('Hype level update failed, retrying', {
@@ -337,7 +312,7 @@ export class MyArtistsRoute {
 					.then(() => {
 						this.logger.info('Hype level updated on retry', {
 							artistId,
-							level,
+							hype,
 						})
 					})
 					.catch((retryErr) => {

--- a/test/components/hype-inline-slider.spec.ts
+++ b/test/components/hype-inline-slider.spec.ts
@@ -2,17 +2,20 @@ import { DI, ILogger, INode, Registration } from 'aurelia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createMockLogger } from '../helpers/mock-logger'
 
+vi.mock(
+	'@buf/liverty-music_schema.bufbuild_es/liverty_music/entity/v1/follow_pb.js',
+	() => ({
+		HypeType: { UNSPECIFIED: 0, WATCH: 1, HOME: 2, NEARBY: 3, AWAY: 4 },
+	}),
+)
+
 const { HypeInlineSlider } = await import(
 	'../../src/components/hype-inline-slider/hype-inline-slider'
 )
 
-/**
- * HypeInlineSlider resolves INode via DI. We create a real HTMLElement and
- * register it as INode so that dispatchEvent works on an actual DOM node.
- */
 function createSliderWithHost(opts: {
 	artistId?: string
-	hypeLevel?: string
+	hype?: number
 	isAuthenticated?: boolean
 }) {
 	const hostElement = document.createElement('div')
@@ -24,10 +27,18 @@ function createSliderWithHost(opts: {
 
 	const sut = container.invoke(HypeInlineSlider)
 	sut.artistId = opts.artistId ?? 'artist-1'
-	sut.hypeLevel = (opts.hypeLevel ?? 'watch') as any
+	sut.hype = opts.hype ?? 1 // HypeType.WATCH
 	sut.isAuthenticated = opts.isAuthenticated ?? false
 
 	return { sut, hostElement }
+}
+
+function mockClickEvent(): Event & {
+	preventDefault: ReturnType<typeof vi.fn>
+} {
+	return { preventDefault: vi.fn() } as unknown as Event & {
+		preventDefault: ReturnType<typeof vi.fn>
+	}
 }
 
 describe('HypeInlineSlider', () => {
@@ -51,13 +62,13 @@ describe('HypeInlineSlider', () => {
 			const handler = vi.fn()
 			hostElement.addEventListener('hype-changed', handler)
 
-			sut.selectHype('away')
+			sut.selectHype(4, mockClickEvent()) // HypeType.AWAY
 
 			expect(handler).toHaveBeenCalledTimes(1)
 			const event = handler.mock.calls[0][0] as CustomEvent
 			expect(event.detail).toEqual({
 				artistId: 'artist-1',
-				level: 'away',
+				hype: 4,
 			})
 		})
 
@@ -65,9 +76,17 @@ describe('HypeInlineSlider', () => {
 			const handler = vi.fn()
 			hostElement.addEventListener('hype-signup-prompt', handler)
 
-			sut.selectHype('home')
+			sut.selectHype(2, mockClickEvent()) // HypeType.HOME
 
 			expect(handler).not.toHaveBeenCalled()
+		})
+
+		it('should NOT call preventDefault on tap', () => {
+			const event = mockClickEvent()
+
+			sut.selectHype(2, event) // HypeType.HOME
+
+			expect(event.preventDefault).not.toHaveBeenCalled()
 		})
 	})
 
@@ -91,7 +110,7 @@ describe('HypeInlineSlider', () => {
 			const handler = vi.fn()
 			hostElement.addEventListener('hype-signup-prompt', handler)
 
-			sut.selectHype('home')
+			sut.selectHype(2, mockClickEvent()) // HypeType.HOME
 
 			expect(handler).toHaveBeenCalledTimes(1)
 		})
@@ -100,17 +119,17 @@ describe('HypeInlineSlider', () => {
 			const handler = vi.fn()
 			hostElement.addEventListener('hype-changed', handler)
 
-			sut.selectHype('away')
+			sut.selectHype(4, mockClickEvent()) // HypeType.AWAY
 
 			expect(handler).not.toHaveBeenCalled()
 		})
 
-		it('should NOT change hypeLevel on tap', () => {
-			sut.hypeLevel = 'watch' as any
+		it('should call preventDefault to block radio selection', () => {
+			const event = mockClickEvent()
 
-			sut.selectHype('away')
+			sut.selectHype(4, event) // HypeType.AWAY
 
-			expect(sut.hypeLevel).toBe('watch')
+			expect(event.preventDefault).toHaveBeenCalledTimes(1)
 		})
 	})
 })

--- a/test/routes/my-artists-route.spec.ts
+++ b/test/routes/my-artists-route.spec.ts
@@ -321,7 +321,7 @@ describe('MyArtistsRoute', () => {
 
 		it('should set pulsingArtistId immediately on hype change', () => {
 			const event = new CustomEvent('hype-changed', {
-				detail: { artistId: 'id-1', level: 'away' },
+				detail: { artistId: 'id-1', hype: 4 },
 			})
 
 			onboardingSut.onHypeChanged(event)
@@ -331,7 +331,7 @@ describe('MyArtistsRoute', () => {
 
 		it('should clear pulsingArtistId after 300ms', () => {
 			const event = new CustomEvent('hype-changed', {
-				detail: { artistId: 'id-1', level: 'away' },
+				detail: { artistId: 'id-1', hype: 4 },
 			})
 
 			onboardingSut.onHypeChanged(event)
@@ -342,7 +342,7 @@ describe('MyArtistsRoute', () => {
 
 		it('should advance to COMPLETED after hype change', () => {
 			const event = new CustomEvent('hype-changed', {
-				detail: { artistId: 'id-1', level: 'away' },
+				detail: { artistId: 'id-1', hype: 4 },
 			})
 
 			onboardingSut.onHypeChanged(event)


### PR DESCRIPTION
## Description

Fix the hype inline slider not reflecting optimistic UI updates after tapping a dot. The `SetHype` RPC completes successfully but the slider visually stays in place.

**Root cause:** `hype-level.bind="hypeStop(artist)"` — Aurelia 2 observes the `artist` reference (stable), not the mutated `artist.hype` property inside the method call.

**Fix:** Bind `hype.bind="artist.hype"` directly, giving Aurelia a property path to observe. Remove `HypeStop` string type and all conversion tables (`HYPE_TO_STOP`, `HYPE_FROM_STOP`). Migrate from ARIA `role="radiogroup"` to native `<fieldset>` + `<input type="radio">` using Aurelia 2's `model.bind`/`checked.bind` pattern.

## Type of Change

- [x] fix: A bug fix
- [x] refactor: A code change that neither fixes a bug nor adds a feature

## Verification

### Automated Tests
- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] `npm run build` passed

### Manual Verification
- Tap each hype dot on My Artists list view → slider moves immediately
- Unauthenticated tap → signup prompt shown, slider does not move
- RPC failure → slider reverts to previous position

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

close: #212
