### PR TITLE
feat(auth): remove email_verified gate, ensureLoaded-first flow

### DIFF
--- a/src/routes/auth-callback/auth-callback-route.ts
+++ b/src/routes/auth-callback/auth-callback-route.ts
@@ -37,16 +37,7 @@ export class AuthCallbackRoute {
 			const user = await this.authService.handleCallback()
 			this.logger.info('handleCallback success!')
 
-			// Reject unverified emails before provisioning a backend user
-			if (!user.profile.email_verified) {
-				await this.authService.signOut()
-				this.error =
-					'Your email address has not been verified. Please check your inbox for a verification email and try again.'
-				return true
-			}
-
-			await this.provisionUser(user.profile.email)
-			await this.userService.ensureLoaded()
+			await this.ensureUserProvisioned(user.profile.email)
 
 			// If onboarding was in progress, mark as completed
 			if (this.onboarding.isOnboarding) {
@@ -71,6 +62,25 @@ export class AuthCallbackRoute {
 			this.error = `Login failed: ${err instanceof Error ? err.message : String(err)}`
 			return true
 		}
+	}
+
+	// Load the user profile from the backend. If the user does not exist yet
+	// (new registration), provision first and then load.
+	private async ensureUserProvisioned(
+		email: string | undefined,
+	): Promise<void> {
+		try {
+			await this.userService.ensureLoaded()
+			return
+		} catch (err) {
+			if (!(err instanceof ConnectError && err.code === Code.NotFound)) {
+				throw err
+			}
+			this.logger.info('User not found in backend, provisioning...')
+		}
+
+		await this.provisionUser(email)
+		await this.userService.ensureLoaded()
 	}
 
 	// Call Create RPC with ALREADY_EXISTS handling.

--- a/test/routes/auth-callback-route.spec.ts
+++ b/test/routes/auth-callback-route.spec.ts
@@ -83,40 +83,33 @@ describe('AuthCallbackRoute', () => {
 	})
 
 	describe('canLoad', () => {
-		it('should reject unverified email, sign out, and show error', async () => {
+		it('should redirect to dashboard for returning user (ensureLoaded succeeds, no create)', async () => {
 			mockAuth.handleCallback = vi.fn().mockResolvedValue({
-				profile: { email: 'new@example.com', email_verified: false },
+				profile: { email: 'existing@example.com' },
 			})
 
 			const result = await sut.canLoad({}, {} as RouteNode)
 
-			expect(mockAuth.signOut).toHaveBeenCalled()
-			expect(result).toBe(true)
-			expect(sut.error).toBe(
-				'Your email address has not been verified. Please check your inbox for a verification email and try again.',
-			)
+			expect(mockUserService.ensureLoaded).toHaveBeenCalled()
 			expect(mockUserService.client.create).not.toHaveBeenCalled()
-		})
-
-		it('should redirect to dashboard and always merge guest data after authentication', async () => {
-			mockAuth.handleCallback = vi.fn().mockResolvedValue({
-				profile: { email: 'new@example.com', email_verified: true },
-			})
-
-			const result = await sut.canLoad({}, {} as RouteNode)
-
-			expect(mockUserService.client.create).toHaveBeenCalled()
 			expect(mockMergeService.merge).toHaveBeenCalled()
 			expect(result).toBe('/dashboard')
 		})
 
-		it('should redirect to dashboard when state is undefined', async () => {
+		it('should provision new user when ensureLoaded returns NotFound', async () => {
 			mockAuth.handleCallback = vi.fn().mockResolvedValue({
-				profile: { email: 'existing@example.com', email_verified: true },
+				profile: { email: 'new@example.com' },
 			})
+			mockUserService.ensureLoaded = vi
+				.fn()
+				.mockRejectedValueOnce(new ConnectError('not found', Code.NotFound))
+				.mockResolvedValueOnce(undefined)
 
 			const result = await sut.canLoad({}, {} as RouteNode)
 
+			expect(mockUserService.ensureLoaded).toHaveBeenCalledTimes(2)
+			expect(mockUserService.client.create).toHaveBeenCalled()
+			expect(mockMergeService.merge).toHaveBeenCalled()
 			expect(result).toBe('/dashboard')
 		})
 
@@ -146,8 +139,12 @@ describe('AuthCallbackRoute', () => {
 
 		it('should handle provisionUser ALREADY_EXISTS gracefully', async () => {
 			mockAuth.handleCallback = vi.fn().mockResolvedValue({
-				profile: { email: 'existing@example.com', email_verified: true },
+				profile: { email: 'existing@example.com' },
 			})
+			mockUserService.ensureLoaded = vi
+				.fn()
+				.mockRejectedValueOnce(new ConnectError('not found', Code.NotFound))
+				.mockResolvedValueOnce(undefined)
 			mockUserService.client.create = vi
 				.fn()
 				.mockRejectedValue(new ConnectError('exists', Code.AlreadyExists))
@@ -159,8 +156,11 @@ describe('AuthCallbackRoute', () => {
 
 		it('should show error when provisionUser fails with non-AlreadyExists error', async () => {
 			mockAuth.handleCallback = vi.fn().mockResolvedValue({
-				profile: { email: 'new@example.com', email_verified: true },
+				profile: { email: 'new@example.com' },
 			})
+			mockUserService.ensureLoaded = vi
+				.fn()
+				.mockRejectedValue(new ConnectError('not found', Code.NotFound))
 			mockUserService.client.create = vi
 				.fn()
 				.mockRejectedValue(new Error('server error'))
@@ -171,10 +171,14 @@ describe('AuthCallbackRoute', () => {
 			expect(sut.error).toBe('Login failed: server error')
 		})
 
-		it('should skip provisionUser when email is missing', async () => {
+		it('should skip provisionUser when email is missing and ensureLoaded returns NotFound', async () => {
 			mockAuth.handleCallback = vi.fn().mockResolvedValue({
-				profile: { email_verified: true },
+				profile: {},
 			})
+			mockUserService.ensureLoaded = vi
+				.fn()
+				.mockRejectedValueOnce(new ConnectError('not found', Code.NotFound))
+				.mockResolvedValueOnce(undefined)
 
 			const result = await sut.canLoad({}, {} as RouteNode)
 
@@ -186,7 +190,7 @@ describe('AuthCallbackRoute', () => {
 			mockOnboarding.currentStep = OnboardingStep.DISCOVERY
 			mockOnboarding.isOnboarding = true
 			mockAuth.handleCallback = vi.fn().mockResolvedValue({
-				profile: { email: 'user@example.com', email_verified: true },
+				profile: { email: 'user@example.com' },
 			})
 
 			const result = await sut.canLoad({}, {} as RouteNode)


### PR DESCRIPTION
## Summary of Changes

Remove the `email_verified` gate from the auth callback and refactor user provisioning to an ensureLoaded-first flow.

- Remove `email_verified` check and `signOut()` call — unverified users can now use all features
- Refactor callback: call `ensureLoaded()` first, only call `provisionUser()` when NotFound (new user)
- This avoids an unnecessary Create RPC on every callback for returning users
- Update tests to match the new flow (8 tests passing)

## Commit Log

- feat(auth): remove email_verified gate and use ensureLoaded-first flow

## Self-Checklist

- [x] I have added or updated tests to cover my changes.
- [x] My code follows the architecture and style guidelines of the project.