### PR TITLE
fix(live-highway): improve event card logo and text visibility

### DIFF
--- a/src/components/live-highway/event-card.css
+++ b/src/components/live-highway/event-card.css
@@ -21,6 +21,7 @@
 
 			display: flex;
 			flex-direction: column;
+			align-items: center;
 			justify-content: end;
 
 			padding: var(--space-xs);
@@ -48,7 +49,7 @@
 		/* --- Artist logo (clearLOGO transparent PNG) --- */
 		.artist-logo {
 			max-inline-size: 80%;
-			max-block-size: 3rem;
+			max-block-size: 25cqi;
 			object-fit: contain;
 			filter: drop-shadow(0 2px 4px var(--_drop-shadow));
 		}
@@ -57,7 +58,7 @@
 		.artist-name {
 			font-family: var(--font-display);
 			/* stylelint-disable-next-line cube/require-token-variables -- container-query clamp cannot be tokenized */
-			font-size: clamp(12px, 5cqi, 24px);
+			font-size: clamp(14px, 8cqi, 32px);
 			font-weight: normal;
 			line-height: var(--leading-snug);
 			color: var(--color-white);
@@ -177,7 +178,7 @@
 		}
 
 		/* =============================================
-		   UNMATCHED — faded concert poster
+		   UNMATCHED — adaptive contrast background
 		   ============================================= */
 		.event-card:not([data-matched]) {
 			/*
@@ -195,7 +196,7 @@
 			);
 		}
 
-		/* Noise texture overlay — aged poster grain */
+		/* Noise texture overlay — subtle surface grain */
 		.event-card:not([data-matched])::after {
 			pointer-events: none;
 			content: "";
@@ -208,16 +209,6 @@
 			opacity: 0.08;
 			background-image: var(--_noise-url);
 			background-size: 200px 200px;
-		}
-
-		/* ClearLOGO dimmed */
-		.event-card:not([data-matched]) .artist-logo {
-			filter: brightness(0.35) grayscale(0.8);
-		}
-
-		/* Text fallback dimmed */
-		.event-card:not([data-matched]) .artist-name {
-			opacity: 0.6;
 		}
 
 		/* =============================================


### PR DESCRIPTION
## Description

Improve event card logo and text visibility by removing redundant unmatched card dimming, centering content, and scaling logos proportionally.

- Remove `brightness(0.35) grayscale(0.8)` filter on unmatched logos and `opacity: 0.6` on text fallback — the matched/unmatched distinction is already clear from neon glow and spotlight effects
- Add `align-items: center` to center logos and text within cards
- Scale logos proportionally using `max-block-size: 25cqi` instead of fixed `3rem`
- Increase text fallback font size from `clamp(12px, 5cqi, 24px)` to `clamp(14px, 8cqi, 32px)`

## Type of Change

- [x] fix: A bug fix

## Verification

### Automated Tests
- [x] `npm run lint` passed
- [x] `npm run test` passed
- [x] `npm run build` passed

### Manual Verification
- Verified on dev.liverty-music.app that logos (椎名林檎, UVERworld, SPYAIR) render at full brightness on unmatched cards
- Confirmed matched cards retain strong visual differentiation via neon glow, spotlight, and animated effects
- Verified text fallback (Vaundy, キタニタツヤ) is larger and centered

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

close: #235