### PR TITLE
refactor!: unify follow state into FollowOrchestrator

### DIFF
--- a/src/routes/discovery/bubble-manager.ts
+++ b/src/routes/discovery/bubble-manager.ts
@@ -19,14 +19,11 @@ export class BubbleManager {
 	constructor(
 		private readonly client: BubbleArtistClient,
 		private readonly logger: ILogger,
+		private readonly getFollowedIds: () => ReadonlySet<string>,
 	) {}
 
 	public get poolBubbles(): ArtistBubble[] {
 		return this.pool.availableBubbles
-	}
-
-	public get followedIds(): ReadonlySet<string> {
-		return this.pool.followedIds
 	}
 
 	public async loadInitialArtists(
@@ -47,7 +44,9 @@ export class BubbleManager {
 			bubbles = await this.fetchSeedSimilarArtists(followedArtists)
 		}
 
-		bubbles = this.pool.dedup(bubbles).slice(0, BubblePool.MAX_BUBBLES)
+		bubbles = this.pool
+			.dedup(bubbles, this.getFollowedIds())
+			.slice(0, BubblePool.MAX_BUBBLES)
 		this.pool.replace(bubbles)
 		this.pool.trackAllSeen(bubbles)
 
@@ -148,7 +147,7 @@ export class BubbleManager {
 			artistId,
 			BubbleManager.SIMILAR_LIMIT_ON_TAP,
 		)
-		const newBubbles = this.pool.dedup(rawBubbles)
+		const newBubbles = this.pool.dedup(rawBubbles, this.getFollowedIds())
 		this.pool.trackAllSeen(newBubbles)
 
 		return newBubbles
@@ -164,7 +163,7 @@ export class BubbleManager {
 			'',
 			BubblePool.MAX_BUBBLES,
 		)
-		const fresh = this.pool.dedup(rawBubbles)
+		const fresh = this.pool.dedup(rawBubbles, this.getFollowedIds())
 		this.pool.trackAllSeen(fresh)
 
 		this.logger.info('Replacement bubbles loaded', { count: fresh.length })

--- a/src/routes/discovery/discovery-route.ts
+++ b/src/routes/discovery/discovery-route.ts
@@ -42,6 +42,7 @@ export class DiscoveryRoute {
 	public readonly bubbles = new BubbleManager(
 		this.artistClient,
 		resolve(ILogger).scopeTo('BubbleManager'),
+		() => this.follow.followedIds,
 	)
 
 	public readonly search = new SearchController(

--- a/src/routes/discovery/follow-orchestrator.ts
+++ b/src/routes/discovery/follow-orchestrator.ts
@@ -31,7 +31,7 @@ export class FollowOrchestrator {
 	) {}
 
 	public get followedIds(): ReadonlySet<string> {
-		return this.pool.followedIds
+		return new Set(this.followedArtists.map((a) => a.id))
 	}
 
 	public get followedCount(): number {
@@ -42,12 +42,12 @@ export class FollowOrchestrator {
 		artist: ArtistBubble,
 		spawnPosition?: { x: number; y: number },
 	): Promise<void> {
-		if (this.pool.isFollowed(artist.id)) return
+		if (this.followedIds.has(artist.id)) return
 		this.logger.info('Following artist', { artist: artist.name })
 
 		// Optimistic UI update
-		this.pool.markFollowed(artist.id)
 		this.followedArtists = [...this.followedArtists, artist]
+		this.pool.remove(artist.id)
 
 		try {
 			await this.followClient.follow(artist.id, artist.name)
@@ -63,11 +63,10 @@ export class FollowOrchestrator {
 
 			// Rollback optimistic update
 			batch(() => {
-				this.pool.unmarkFollowed(artist.id)
-				this.pool.add([artist])
 				this.followedArtists = this.followedArtists.filter(
 					(b) => b.id !== artist.id,
 				)
+				this.pool.add([artist])
 			})
 
 			if (spawnPosition) {

--- a/src/routes/discovery/genre-filter-controller.ts
+++ b/src/routes/discovery/genre-filter-controller.ts
@@ -84,7 +84,10 @@ export class GenreFilterController {
 			tag,
 			BubblePool.MAX_BUBBLES,
 		)
-		const bubbles = this.pool.dedup(rawBubbles).slice(0, BubblePool.MAX_BUBBLES)
+		const followedIds = new Set(this.followedArtists().map((a) => a.id))
+		const bubbles = this.pool
+			.dedup(rawBubbles, followedIds)
+			.slice(0, BubblePool.MAX_BUBBLES)
 
 		this.pool.replace(bubbles)
 		this.pool.trackAllSeen(bubbles)

--- a/src/services/bubble-pool.ts
+++ b/src/services/bubble-pool.ts
@@ -15,8 +15,6 @@ export class BubblePool {
 	private readonly seenArtistNames = new Set<string>()
 	private readonly seenArtistIds = new Set<string>()
 	private readonly seenArtistMbids = new Set<string>()
-	public readonly followedIds = new Set<string>()
-
 	public get maxBubbles(): number {
 		return BubblePool.MAX_BUBBLES
 	}
@@ -77,33 +75,17 @@ export class BubblePool {
 	public reset(): void {
 		this.availableBubbles = []
 		this.clearSeenSets()
-		this.followedIds.clear()
-	}
-
-	/**
-	 * Mark an artist as followed. Removes from available pool.
-	 */
-	public markFollowed(artistId: string): void {
-		this.followedIds.add(artistId)
-		this.remove(artistId)
-	}
-
-	/**
-	 * Unmark an artist as followed (for rollback).
-	 */
-	public unmarkFollowed(artistId: string): void {
-		this.followedIds.delete(artistId)
-	}
-
-	public isFollowed(artistId: string): boolean {
-		return this.followedIds.has(artistId)
 	}
 
 	/**
 	 * Deduplicate bubbles: remove seen artists and already-followed artists.
+	 * Follow state is provided externally by the caller.
 	 */
-	public dedup(bubbles: ArtistBubble[]): ArtistBubble[] {
-		return bubbles.filter((b) => !this.isSeen(b) && !this.isFollowed(b.id))
+	public dedup(
+		bubbles: ArtistBubble[],
+		followedIds: ReadonlySet<string>,
+	): ArtistBubble[] {
+		return bubbles.filter((b) => !this.isSeen(b) && !followedIds.has(b.id))
 	}
 
 	/**

--- a/test/routes/discovery/bubble-manager.spec.ts
+++ b/test/routes/discovery/bubble-manager.spec.ts
@@ -26,6 +26,7 @@ function createMockCanvas() {
 describe('BubbleManager', () => {
 	let sut: BubbleManager
 	let mockClient: BubbleArtistClient
+	let followedIds: Set<string>
 
 	beforeEach(() => {
 		mockClient = {
@@ -33,7 +34,8 @@ describe('BubbleManager', () => {
 			listSimilar: vi.fn().mockResolvedValue([]),
 		}
 
-		sut = new BubbleManager(mockClient, createMockLogger())
+		followedIds = new Set<string>()
+		sut = new BubbleManager(mockClient, createMockLogger(), () => followedIds)
 	})
 
 	describe('loadInitialArtists', () => {
@@ -225,10 +227,47 @@ describe('BubbleManager', () => {
 
 			expect(sut.poolBubbles).toHaveLength(2)
 		})
+	})
 
-		it('should expose followedIds through pool', () => {
-			sut.pool.markFollowed('a1')
-			expect(sut.followedIds.has('a1')).toBe(true)
+	describe('dedup uses external followedIds', () => {
+		it('should exclude followed artists from loadInitialArtists', async () => {
+			followedIds.add('a1')
+			;(mockClient.listTop as ReturnType<typeof vi.fn>).mockResolvedValue([
+				makeBubble('a1', 'Followed'),
+				makeBubble('a2', 'Available'),
+			])
+
+			await sut.loadInitialArtists([], 'Japan', '')
+
+			expect(sut.poolBubbles).toHaveLength(1)
+			expect(sut.poolBubbles[0].id).toBe('a2')
+		})
+
+		it('should use latest followedIds at call time (lazy evaluation)', async () => {
+			;(mockClient.listTop as ReturnType<typeof vi.fn>).mockResolvedValue([
+				makeBubble('a1', 'One'),
+				makeBubble('a2', 'Two'),
+			])
+
+			// followedIds is empty at construction time
+			await sut.loadInitialArtists([], 'Japan', '')
+			expect(sut.poolBubbles).toHaveLength(2)
+
+			// Update followedIds after construction
+			followedIds.add('a3')
+			;(mockClient.listSimilar as ReturnType<typeof vi.fn>).mockResolvedValue([
+				makeBubble('a3', 'Now Followed'),
+				makeBubble('a4', 'Still Available'),
+			])
+
+			const canvas = createMockCanvas()
+			await sut.onNeedMoreBubbles('a1', 'One', { x: 0, y: 0 }, canvas)
+
+			// a3 should be filtered out because followedIds was updated
+			const spawnedBubbles = canvas.spawnBubblesAt.mock.calls[0]?.[0] ?? []
+			const spawnedIds = spawnedBubbles.map((b: ArtistBubble) => b.id)
+			expect(spawnedIds).not.toContain('a3')
+			expect(spawnedIds).toContain('a4')
 		})
 	})
 })

--- a/test/routes/discovery/follow-orchestrator.spec.ts
+++ b/test/routes/discovery/follow-orchestrator.spec.ts
@@ -108,6 +108,71 @@ describe('FollowOrchestrator', () => {
 		})
 	})
 
+	describe('followedIds derived getter', () => {
+		it('should be an empty Set when followedArtists is empty', () => {
+			expect(sut.followedIds.size).toBe(0)
+		})
+
+		it('should contain the artist ID after followArtist', async () => {
+			await sut.followArtist(makeBubble('a1', 'Artist One'))
+
+			expect(sut.followedIds.has('a1')).toBe(true)
+		})
+
+		it('should match followedArtists IDs', async () => {
+			await sut.followArtist(makeBubble('a1', 'Artist One'))
+			await sut.followArtist(makeBubble('a2', 'Artist Two'))
+
+			const ids = [...sut.followedIds]
+			expect(ids).toEqual(['a1', 'a2'])
+		})
+	})
+
+	describe('atomicity — state and pool are synchronized', () => {
+		it('should have artist in followedIds and absent from pool after follow', async () => {
+			await sut.followArtist(makeBubble('a1', 'Artist One'))
+
+			expect(sut.followedIds.has('a1')).toBe(true)
+			expect(pool.availableBubbles.find((b) => b.id === 'a1')).toBeUndefined()
+		})
+
+		it('should have artist absent from followedIds and restored in pool after rollback', async () => {
+			;(mockFollowClient.follow as ReturnType<typeof vi.fn>).mockRejectedValue(
+				new Error('fail'),
+			)
+
+			await expect(
+				sut.followArtist(makeBubble('a1', 'Artist One')),
+			).rejects.toThrow()
+
+			expect(sut.followedIds.has('a1')).toBe(false)
+			expect(pool.availableBubbles.find((b) => b.id === 'a1')).toBeDefined()
+		})
+	})
+
+	describe('regression: no dual-state desync', () => {
+		it('should keep followedIds.size === 2 after sequential follow (3) then rollback (1)', async () => {
+			await sut.followArtist(makeBubble('a1', 'Artist One'))
+			await sut.followArtist(makeBubble('a2', 'Artist Two'))
+
+			// Third follow will fail and rollback
+			const a3 = makeBubble('a3', 'Artist Three')
+			pool.add([a3])
+			;(
+				mockFollowClient.follow as ReturnType<typeof vi.fn>
+			).mockRejectedValueOnce(new Error('fail'))
+
+			await expect(sut.followArtist(a3)).rejects.toThrow()
+
+			expect(sut.followedIds.size).toBe(2)
+			expect(sut.followedIds.has('a1')).toBe(true)
+			expect(sut.followedIds.has('a2')).toBe(true)
+			expect(sut.followedIds.has('a3')).toBe(false)
+			// Only the rolled-back artist is restored to pool
+			expect(pool.availableBubbles.find((b) => b.id === 'a3')).toBeDefined()
+		})
+	})
+
 	describe('checkLiveEvents', () => {
 		it('should notify on upcoming events', async () => {
 			;(

--- a/test/routes/discovery/genre-filter-controller.spec.ts
+++ b/test/routes/discovery/genre-filter-controller.spec.ts
@@ -100,6 +100,28 @@ describe('GenreFilterController', () => {
 			expect(mockClient.listTop).toHaveBeenCalledTimes(1)
 		})
 
+		it('should exclude followed artists from dedup', async () => {
+			const followed = [makeBubble('f1', 'Followed Artist')]
+			sut = new GenreFilterController(
+				mockClient,
+				pool,
+				() => followed,
+				mockCallbacks,
+				createMockLogger(),
+				() => abortController.signal,
+			)
+
+			;(mockClient.listTop as ReturnType<typeof vi.fn>).mockResolvedValue([
+				makeBubble('f1', 'Followed Artist'),
+				makeBubble('a1', 'Available Artist'),
+			])
+
+			await sut.onGenreSelected('Rock')
+
+			expect(pool.availableBubbles).toHaveLength(1)
+			expect(pool.availableBubbles[0].id).toBe('a1')
+		})
+
 		it('should reset activeTag and call onError on failure', async () => {
 			;(mockClient.listTop as ReturnType<typeof vi.fn>).mockRejectedValue(
 				new Error('network'),

--- a/test/services/bubble-pool.spec.ts
+++ b/test/services/bubble-pool.spec.ts
@@ -129,53 +129,17 @@ describe('BubblePool', () => {
 	})
 
 	describe('reset', () => {
-		it('should clear pool, seen sets, and followed IDs', () => {
+		it('should clear pool and seen sets', () => {
 			const pool = new BubblePool()
 			pool.add([makeBubble('a1', 'One')])
 			pool.trackSeen(makeBubble('a1', 'One'))
-			pool.markFollowed('a1')
 
 			pool.reset()
 
 			expect(pool.availableBubbles).toHaveLength(0)
-			expect(pool.isFollowed('a1')).toBe(false)
 			// Seen sets cleared: dedup should no longer filter
-			const result = pool.dedup([makeBubble('a1', 'One')])
+			const result = pool.dedup([makeBubble('a1', 'One')], new Set())
 			expect(result).toHaveLength(1)
-		})
-	})
-
-	describe('markFollowed / unmarkFollowed / isFollowed', () => {
-		it('should mark an artist as followed and remove from pool', () => {
-			const pool = new BubblePool()
-			pool.add([makeBubble('a1', 'One'), makeBubble('a2', 'Two')])
-
-			pool.markFollowed('a1')
-
-			expect(pool.isFollowed('a1')).toBe(true)
-			expect(pool.followedIds.has('a1')).toBe(true)
-			expect(pool.availableBubbles).toHaveLength(1)
-			expect(pool.availableBubbles[0].id).toBe('a2')
-		})
-
-		it('should unmark a followed artist for rollback', () => {
-			const pool = new BubblePool()
-			pool.markFollowed('a1')
-
-			pool.unmarkFollowed('a1')
-
-			expect(pool.isFollowed('a1')).toBe(false)
-			expect(pool.followedIds.has('a1')).toBe(false)
-		})
-
-		it('should be a no-op when marking already followed artist', () => {
-			const pool = new BubblePool()
-			pool.add([makeBubble('a1', 'One')])
-			pool.markFollowed('a1')
-			pool.markFollowed('a1')
-
-			expect(pool.isFollowed('a1')).toBe(true)
-			expect(pool.availableBubbles).toHaveLength(0)
 		})
 	})
 
@@ -184,10 +148,13 @@ describe('BubblePool', () => {
 			const pool = new BubblePool()
 			pool.trackSeen(makeBubble('a1', 'Artist X'))
 
-			const result = pool.dedup([
-				makeBubble('a2', 'Artist X'), // same name, different id
-				makeBubble('a3', 'Artist Y'),
-			])
+			const result = pool.dedup(
+				[
+					makeBubble('a2', 'Artist X'), // same name, different id
+					makeBubble('a3', 'Artist Y'),
+				],
+				new Set(),
+			)
 
 			expect(result).toHaveLength(1)
 			expect(result[0].name).toBe('Artist Y')
@@ -197,10 +164,10 @@ describe('BubblePool', () => {
 			const pool = new BubblePool()
 			pool.trackSeen(makeBubble('a1', 'Original Name'))
 
-			const result = pool.dedup([
-				makeBubble('a1', 'Different Name'),
-				makeBubble('a2', 'New Artist'),
-			])
+			const result = pool.dedup(
+				[makeBubble('a1', 'Different Name'), makeBubble('a2', 'New Artist')],
+				new Set(),
+			)
 
 			expect(result).toHaveLength(1)
 			expect(result[0].id).toBe('a2')
@@ -210,33 +177,65 @@ describe('BubblePool', () => {
 			const pool = new BubblePool()
 			pool.trackSeen(makeBubble('a1', 'Artist', 'mbid-123'))
 
-			const result = pool.dedup([
-				makeBubble('a2', 'Different', 'mbid-123'), // same mbid
-				makeBubble('a3', 'Other', 'mbid-456'),
-			])
+			const result = pool.dedup(
+				[
+					makeBubble('a2', 'Different', 'mbid-123'), // same mbid
+					makeBubble('a3', 'Other', 'mbid-456'),
+				],
+				new Set(),
+			)
 
 			expect(result).toHaveLength(1)
 			expect(result[0].id).toBe('a3')
 		})
 
-		it('should filter out followed artists', () => {
+		it('should filter out followed artists via external followedIds', () => {
 			const pool = new BubblePool()
-			pool.markFollowed('a1')
+			const followedIds = new Set(['a1'])
 
-			const result = pool.dedup([
-				makeBubble('a1', 'Followed Artist'),
-				makeBubble('a2', 'Not Followed'),
-			])
+			const result = pool.dedup(
+				[makeBubble('a1', 'Followed Artist'), makeBubble('a2', 'Not Followed')],
+				followedIds,
+			)
 
 			expect(result).toHaveLength(1)
 			expect(result[0].id).toBe('a2')
+		})
+
+		it('should work without follow filtering when followedIds is empty', () => {
+			const pool = new BubblePool()
+
+			const result = pool.dedup(
+				[makeBubble('a1', 'Artist One'), makeBubble('a2', 'Artist Two')],
+				new Set(),
+			)
+
+			expect(result).toHaveLength(2)
+		})
+
+		it('should apply both seen and followed filters', () => {
+			const pool = new BubblePool()
+			pool.trackSeen(makeBubble('a1', 'Seen Artist'))
+			const followedIds = new Set(['a2'])
+
+			const result = pool.dedup(
+				[
+					makeBubble('a1', 'Seen Artist'),
+					makeBubble('a2', 'Followed Artist'),
+					makeBubble('a3', 'Fresh Artist'),
+				],
+				followedIds,
+			)
+
+			expect(result).toHaveLength(1)
+			expect(result[0].id).toBe('a3')
 		})
 
 		it('should normalize name matching (case-insensitive, whitespace-collapsed)', () => {
 			const pool = new BubblePool()
 			pool.trackSeen(makeBubble('a1', 'Artist  X'))
 
-			const result = pool.dedup([makeBubble('a2', ' artist x ')])
+			const result = pool.dedup([makeBubble('a2', ' artist x ')], new Set())
 
 			expect(result).toHaveLength(0)
 		})
@@ -247,11 +246,14 @@ describe('BubblePool', () => {
 			const pool = new BubblePool()
 			pool.trackAllSeen([makeBubble('a1', 'One'), makeBubble('a2', 'Two')])
 
-			const result = pool.dedup([
-				makeBubble('a1', 'One'),
-				makeBubble('a2', 'Two'),
-				makeBubble('a3', 'Three'),
-			])
+			const result = pool.dedup(
+				[
+					makeBubble('a1', 'One'),
+					makeBubble('a2', 'Two'),
+					makeBubble('a3', 'Three'),
+				],
+				new Set(),
+			)
 
 			expect(result).toHaveLength(1)
 			expect(result[0].id).toBe('a3')
@@ -266,11 +268,11 @@ describe('BubblePool', () => {
 			pool.resetSeenWith([makeBubble('keep1', 'Keep One')])
 
 			// Old seen artist should no longer be filtered
-			const result1 = pool.dedup([makeBubble('old1', 'Old One')])
+			const result1 = pool.dedup([makeBubble('old1', 'Old One')], new Set())
 			expect(result1).toHaveLength(1)
 
 			// Kept artist should still be filtered
-			const result2 = pool.dedup([makeBubble('keep1', 'Keep One')])
+			const result2 = pool.dedup([makeBubble('keep1', 'Keep One')], new Set())
 			expect(result2).toHaveLength(0)
 		})
 	})
@@ -282,7 +284,7 @@ describe('BubblePool', () => {
 
 			pool.clearSeenSets()
 
-			const result = pool.dedup([makeBubble('a1', 'One')])
+			const result = pool.dedup([makeBubble('a1', 'One')], new Set())
 			expect(result).toHaveLength(1)
 		})
 	})


### PR DESCRIPTION
## Summary

- Remove follow tracking from `BubblePool`: delete `followedIds` Set, `markFollowed()`, `unmarkFollowed()`, `isFollowed()`
- Make `FollowOrchestrator.followedArtists` the single source of truth; derive `followedIds` via getter
- Change `BubblePool.dedup()` to accept external `followedIds: ReadonlySet<string>` parameter
- Inject `getFollowedIds` callback into `BubbleManager`; `GenreFilterController` derives from existing `followedArtists()` callback
- Preserve atomicity: state update + `pool.remove()` synchronous in `followArtist()`, rollback uses `batch()`

## Test plan

- [ ] All 670 unit tests pass (`make test`)
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] No remaining references to `pool.markFollowed` / `pool.unmarkFollowed` / `pool.isFollowed` / `pool.followedIds`
- [ ] New tests cover: derived getter, atomicity, dual-state desync regression, lazy evaluation, genre filter exclusion