### PR TITLE
refactor(discovery): replace onboarding popover with snack-bar

### DIFF
--- a/e2e/onboarding-flow.spec.ts
+++ b/e2e/onboarding-flow.spec.ts
@@ -201,22 +201,21 @@ test.describe('Onboarding tutorial flow', () => {
 		).toBeVisible()
 	})
 
-	test('Step 1: Popover guide appears on discover page entry', async ({
+	test('Step 1: Snack notification appears on discover page entry', async ({
 		page,
 	}) => {
 		await page.addInitScript(() => {
 			localStorage.setItem('onboardingStep', '1')
 		})
 		await page.goto('http://localhost:9000/discover')
-		await page.waitForSelector('.discover-layout')
+		await page.waitForSelector('.discovery-layout')
 
-		// Popover guide should be visible
-		const popover = page.locator('.onboarding-guide')
-		await expect(popover).toBeVisible({ timeout: 5000 })
+		// Snack notification should be visible
+		const snack = page.locator('.snack-item')
+		await expect(snack).toBeVisible({ timeout: 5000 })
 
-		// Light-dismiss: clicking outside should close the popover
-		await page.locator('.bubble-area').click({ position: { x: 10, y: 10 } })
-		await expect(popover).not.toBeVisible({ timeout: 3000 })
+		// Auto-dismiss: snack disappears after duration
+		await expect(snack).not.toBeVisible({ timeout: 7000 })
 	})
 
 	test('Step 0 → Step 1: Get Started navigates to Discover', async ({

--- a/src/routes/discovery/discovery-route.css
+++ b/src/routes/discovery/discovery-route.css
@@ -16,8 +16,6 @@
 			--_brand-60: oklch(58.5% 0.204 277deg / 60%);
 			--_brand-80: oklch(58.5% 0.204 277deg / 80%);
 			--_magenta-60: oklch(62.7% 0.233 304deg / 60%);
-			--_purple-25: oklch(70.9% 0.159 294deg / 25%);
-			--_backdrop-bg: oklch(0% 0 0deg / 30%);
 			--_green-30: oklch(80% 0.182 152deg / 30%);
 			--_green-90: oklch(80% 0.182 152deg / 90%);
 			--_star-img:
@@ -361,55 +359,6 @@
 			color: var(--_green-90);
 		}
 
-		.onboarding-guide {
-			--_guide-bg: linear-gradient(
-				135deg,
-				oklch(58.5% 0.204 277deg / 20%),
-				oklch(60.6% 0.219 293deg / 15%)
-			);
-
-			translate: 0 1rem;
-
-			max-inline-size: none;
-			max-block-size: none;
-			margin: auto;
-			padding: var(--space-s) var(--space-l);
-			border: 1px solid var(--_purple-25);
-			border-radius: var(--radius-button);
-
-			font-family: var(--font-display);
-			font-size: var(--step--1);
-			font-weight: 500;
-			color: var(--_white-90);
-			text-align: center;
-
-			opacity: 0;
-			background: var(--_guide-bg);
-			backdrop-filter: blur(12px);
-
-			transition:
-				opacity 400ms ease,
-				translate 400ms ease,
-				display 400ms ease allow-discrete,
-				overlay 400ms ease allow-discrete;
-
-			&::backdrop {
-				background: var(--_backdrop-bg);
-			}
-
-			&:popover-open {
-				translate: 0 0;
-				opacity: 1;
-			}
-
-			@starting-style {
-				&:popover-open {
-					translate: 0 1rem;
-					opacity: 0;
-				}
-			}
-		}
-
 		/* State-driven visibility (after base selectors to avoid descending specificity) */
 		.discovery-layout[data-search-mode="true"] :is(fieldset, .bubble-area) {
 			display: none;
@@ -417,12 +366,6 @@
 
 		.discovery-layout:not([data-search-mode="true"]) .search-results {
 			display: none;
-		}
-
-		@media (prefers-reduced-motion: reduce) {
-			.onboarding-guide {
-				transition: none;
-			}
 		}
 	}
 }

--- a/src/routes/discovery/discovery-route.html
+++ b/src/routes/discovery/discovery-route.html
@@ -38,16 +38,6 @@
       </button>
     </fieldset>
 
-    <!-- Onboarding popover guide (shown once on entry) -->
-    <dialog
-      if.bind="isOnboarding"
-      class="onboarding-guide"
-      popover="auto"
-      ref="onboardingGuide"
-    >
-      <span t="discovery.popoverGuide"></span>
-    </dialog>
-
     <!-- Bubble UI (hidden during search) -->
     <div class="bubble-area">
       <dna-orb-canvas

--- a/src/routes/discovery/discovery-route.ts
+++ b/src/routes/discovery/discovery-route.ts
@@ -34,7 +34,6 @@ export class DiscoveryRoute {
 	public readonly i18n = resolve(I18N)
 
 	public dnaOrbCanvas!: DnaOrbCanvas
-	public onboardingGuide!: HTMLElement
 
 	private abortController = new AbortController()
 
@@ -186,8 +185,12 @@ export class DiscoveryRoute {
 	public attached(): void {
 		document.addEventListener('visibilitychange', this.onVisibilityChange)
 
-		if (this.isOnboarding && this.onboardingGuide) {
-			this.onboardingGuide.showPopover()
+		if (this.isOnboarding) {
+			this.ea.publish(
+				new Snack(this.i18n.tr('discovery.popoverGuide'), 'info', {
+					duration: 5000,
+				}),
+			)
 		}
 	}
 

--- a/test/routes/discovery-route.spec.ts
+++ b/test/routes/discovery-route.spec.ts
@@ -753,26 +753,31 @@ describe('DiscoveryRoute', () => {
 		})
 	})
 
-	describe('onboarding popover', () => {
-		it('should call showPopover on attach when onboarding', () => {
+	describe('onboarding snack notification', () => {
+		it('should publish a Snack when onboarding', () => {
 			mockOnboarding.isOnboarding = true
-			const mockPopover = { showPopover: vi.fn() }
-			sut.onboardingGuide = mockPopover as any
 
 			sut.attached()
 
-			expect(mockPopover.showPopover).toHaveBeenCalledTimes(1)
+			expect(mockEa.publish).toHaveBeenCalledWith(
+				expect.objectContaining({
+					message: 'discovery.popoverGuide',
+					severity: 'info',
+					options: expect.objectContaining({ duration: 5000 }),
+				}),
+			)
 			sut.detaching()
 		})
 
-		it('should not call showPopover when not onboarding', () => {
+		it('should not publish a Snack when not onboarding', () => {
 			mockOnboarding.isOnboarding = false
-			const mockPopover = { showPopover: vi.fn() }
-			sut.onboardingGuide = mockPopover as any
 
 			sut.attached()
 
-			expect(mockPopover.showPopover).not.toHaveBeenCalled()
+			const snackCalls = (
+				mockEa.publish as ReturnType<typeof vi.fn>
+			).mock.calls.filter(([arg]: [unknown]) => arg instanceof Snack)
+			expect(snackCalls).toHaveLength(0)
 			sut.detaching()
 		})
 	})


### PR DESCRIPTION
## Description

Replace the custom `<dialog popover="auto">` onboarding guide on the discover page with the existing snack-bar notification system. The popover had poor visibility — its translucent gradient blended into the bubble canvas background. The snack-bar provides consistent visual language, better contrast, and a proven auto-dismiss pattern.

### What changed
- Removed `<dialog>` element, `onboardingGuide` ref, `showPopover()` call, and ~50 lines of custom CSS (gradient, backdrop, `@starting-style` animations)
- Added `ea.publish(new Snack(...))` in `attached()` — one line, `info` severity, 5000ms duration
- Removed unused CSS custom properties (`--_purple-25`, `--_backdrop-bg`)
- Updated unit tests: `showPopover` mocks → `Snack` publish assertions
- Updated E2E test: popover visibility → snack-item visibility + auto-dismiss assertion
- Fixed pre-existing selector typo in E2E: `.discover-layout` → `.discovery-layout`

## Type of Change

- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] docs: Documentation only changes
- [x] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] test: Adding missing tests or correcting existing tests
- [ ] build: Changes that affect the build system or external dependencies
- [ ] chore: Other changes that don't modify src or test files

## Verification

### Automated Tests
- [x] `npm run lint` passed
- [x] `npm run test` passed (663 tests)
- [ ] `npm run build` passed

### Manual Verification
- Verified snack notification appears on discover page entry during onboarding (E2E)
- Verified snack auto-dismisses after ~5 seconds
- Verified no snack appears for non-onboarding users (unit test)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

close: #242
