### PR TITLE
feat(config): make log level configurable via VITE_LOG_LEVEL

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,9 @@
 # Vite Environment Variables
 # These are embedded in the client bundle during build and visible in browser
 
+# Logging (trace | debug | info | warn | error)
+VITE_LOG_LEVEL=debug
+
 VITE_API_BASE_URL=https://api.dev.liverty-music.app
 
 # Zitadel Authentication

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ COPY . .
 # Build-time environment variables for Vite
 ARG VITE_VAPID_PUBLIC_KEY
 ENV VITE_VAPID_PUBLIC_KEY=${VITE_VAPID_PUBLIC_KEY}
+ARG VITE_LOG_LEVEL
+ENV VITE_LOG_LEVEL=${VITE_LOG_LEVEL}
 
 # Build the application
 RUN npm run build

--- a/src/main.ts
+++ b/src/main.ts
@@ -90,10 +90,26 @@ au.register(
 )
 au.register(
 	LoggerConfiguration.create({
-		level: import.meta.env.DEV ? LogLevel.debug : LogLevel.warn,
+		level: resolveLogLevel(),
 		sinks: [ConsoleSink, OtelLogSink],
 	}),
 )
+
+function resolveLogLevel(): LogLevel {
+	const env = import.meta.env.VITE_LOG_LEVEL as string | undefined
+	if (env) {
+		const map: Record<string, LogLevel> = {
+			trace: LogLevel.trace,
+			debug: LogLevel.debug,
+			info: LogLevel.info,
+			warn: LogLevel.warn,
+			error: LogLevel.error,
+		}
+		const level = map[env]
+		if (level !== undefined) return level
+	}
+	return import.meta.env.DEV ? LogLevel.debug : LogLevel.warn
+}
 
 au.register(IErrorBoundaryService)
 au.register(GlobalErrorHandlingTask)


### PR DESCRIPTION
## Summary

- Make log level configurable via `VITE_LOG_LEVEL` environment variable instead of hardcoding based on Vite build mode
- Set `debug` as default in `.env` (dev environment) with Dockerfile `ARG` for CI build-arg override

## Context

`dev.liverty-music.app` uses a production build where the log level was hardcoded to `warn`, suppressing all INFO-level logs from FollowService and ConcertService. This made it impossible to debug issues like the Gemini API 401 failure from the browser console.

## Test plan

- [x] `make check` passes (no regressions from this change; pre-existing issues only)
- [ ] Deploy to dev and verify INFO-level logs appear in browser console
- [ ] Verify `FollowService` and `ConcertService` logs are visible during onboarding flow