### PR TITLE
fix(services): remove DeadlineExceeded from retry interceptor

### DIFF
--- a/src/services/connect-error-router.ts
+++ b/src/services/connect-error-router.ts
@@ -44,10 +44,12 @@ export const createAuthRetryInterceptor = (auth: IAuthService): Interceptor => {
 
 /**
  * Creates a Connect interceptor that retries transient errors
- * (Unavailable, DeadlineExceeded) with exponential backoff.
+ * (Unavailable) with exponential backoff.
+ * DeadlineExceeded is NOT retried — it indicates a long-running operation
+ * (e.g. Gemini API) timed out, and retrying wastes ~60s per attempt.
  */
 export const createRetryInterceptor = (maxRetries = 3): Interceptor => {
-	const retryableCodes = new Set([Code.Unavailable, Code.DeadlineExceeded])
+	const retryableCodes = new Set([Code.Unavailable])
 
 	return (next) => async (req) => {
 		let lastError: unknown

--- a/test/services/connect-error-router.spec.ts
+++ b/test/services/connect-error-router.spec.ts
@@ -167,24 +167,18 @@ describe('createRetryInterceptor', () => {
 		expect(next).toHaveBeenCalledTimes(2)
 	})
 
-	it('should retry on DeadlineExceeded error', async () => {
-		const response = { message: 'ok' }
+	it('should NOT retry on DeadlineExceeded error', async () => {
 		const next = vi
 			.fn()
 			.mockRejectedValueOnce(
 				new ConnectError('deadline', Code.DeadlineExceeded),
 			)
-			.mockResolvedValue(response)
 
 		const interceptor = createRetryInterceptor(3)
 		const handler = interceptor(next)
 
-		const promise = handler(makeRequest())
-		await vi.advanceTimersByTimeAsync(200)
-
-		const result = await promise
-		expect(result).toBe(response)
-		expect(next).toHaveBeenCalledTimes(2)
+		await expect(handler(makeRequest())).rejects.toThrow(ConnectError)
+		expect(next).toHaveBeenCalledTimes(1)
 	})
 
 	it('should throw after max retries exhausted', async () => {


### PR DESCRIPTION
## Summary

- Remove `DeadlineExceeded` from the retry interceptor's retryable codes
- Only `Unavailable` (503) is now retried with exponential backoff
- Prevents futile retries when Gemini API times out (~57s per attempt, observed 4x retries = ~230s total)

## Test plan

- [ ] Follow an artist on dev and verify that if SearchNewConcerts times out, the error appears immediately (no 4x retry loop)
