### PR TITLE
fix(my-artists): restore hype dot track line and fix away label

### DIFF
--- a/src/adapter/view/hype-display.ts
+++ b/src/adapter/view/hype-display.ts
@@ -5,8 +5,8 @@ import type { Hype } from '../../entities/follow'
  * Maps hype values to their UI label key and icon.
  */
 export const HYPE_TIERS: Record<Hype, { labelKey: string; icon: string }> = {
-	watch: { labelKey: 'チェック', icon: '👀' },
-	home: { labelKey: '地元', icon: '🔥' },
-	nearby: { labelKey: '近くも', icon: '🔥🔥' },
-	away: { labelKey: 'どこでも！', icon: '🔥🔥🔥' },
+	watch: { labelKey: 'myArtists.table.watch', icon: '👀' },
+	home: { labelKey: 'myArtists.table.home', icon: '🔥' },
+	nearby: { labelKey: 'myArtists.table.nearby', icon: '🔥🔥' },
+	away: { labelKey: 'myArtists.table.away', icon: '🔥🔥🔥' },
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -173,7 +173,7 @@
 			"watch": "Watch",
 			"home": "Home",
 			"nearby": "Nearby",
-			"away": "Anywhere!"
+			"away": "Away"
 		},
 		"spotlight": {
 			"setHypeMessage": "Raise the hype for artists you never want to miss"

--- a/src/routes/my-artists/my-artists-route.css
+++ b/src/routes/my-artists/my-artists-route.css
@@ -214,6 +214,22 @@
 			padding: 0;
 			text-align: center;
 			vertical-align: middle;
+
+			/* Track line: drawn on the first hype-col; spans dot-center to dot-center */
+			&:first-of-type > .hype-label::before {
+				content: "";
+				pointer-events: none;
+
+				position: absolute;
+				inset-block-start: 50%;
+				inset-inline-start: 50%;
+				translate: 0 -50%;
+
+				inline-size: calc(3 * 100%);
+				block-size: 2px;
+
+				background: var(--color-border-subtle, oklch(100% 0 0deg / 10%));
+			}
 		}
 
 		.hype-label {

--- a/src/routes/my-artists/my-artists-route.ts
+++ b/src/routes/my-artists/my-artists-route.ts
@@ -36,16 +36,10 @@ export class MyArtistsRoute {
 
 	// Hype tier references
 	public readonly hypeLevels: Hype[] = ['watch', 'home', 'nearby', 'away']
-	public readonly hypeTiers = HYPE_TIERS
 
 	private readonly logger = resolve(ILogger).scopeTo('MyArtistsRoute')
 	public readonly i18n = resolve(I18N)
 	private readonly authService = resolve(IAuthService)
-
-	public trHypeLabel(level: Hype): string {
-		const meta = HYPE_TIERS[level]
-		return meta?.labelKey ?? ''
-	}
 
 	private readonly followService = resolve(IFollowServiceClient)
 	private readonly onboarding = resolve(IOnboardingService)


### PR DESCRIPTION
## Summary

- Restore the 2px horizontal track line connecting hype dots (accidentally removed in e64f6e8)
- Fix EN "Anywhere!" → "Away" in `translation.json` to match the `rename-hype-anywhere-to-away` spec decision
- Replace hardcoded Japanese in `hype-display.ts` with i18n translation keys
- Remove dead `trHypeLabel` method and unused `hypeTiers` property

### CSS nesting note

The original `::before` rule was nested inside `.hype-label` as `.hype-col:first-of-type > &::before`. This is silently dropped by Chromium inside `@scope`. Restructured to nest inside `.hype-col` as `&:first-of-type > .hype-label::before` — same resolved selector, works correctly.

## Test plan

- [x] `make check` passes (lint + 815 unit tests)
- [x] Visual verification: track line visible connecting dots, no vertical grid lines, "Away" column header correct
