### PR TITLE
fix(discovery): stop aborting RPC on route detach and suppress cancellation logs

### DIFF
--- a/src/routes/discovery/discovery-route.ts
+++ b/src/routes/discovery/discovery-route.ts
@@ -301,30 +301,22 @@ export class DiscoveryRoute {
 		artistName: string,
 	): Promise<void> {
 		try {
-			await this.concertService.searchNewConcerts(
-				artistId,
-				this.abortController.signal,
-			)
-			if (this.abortController.signal.aborted) return
-
-			const concerts = await this.concertService.listConcerts(
-				artistId,
-				this.abortController.signal,
-			)
-			if (this.abortController.signal.aborted) return
+			await this.concertService.searchNewConcerts(artistId)
+			const concerts = await this.concertService.listConcerts(artistId)
 
 			if (concerts.length > 0) {
 				this.concertService.addArtistWithConcerts(artistId)
-				this.ea.publish(
-					new Snack(
-						this.i18n.tr('discovery.hasUpcomingEvents', {
-							name: artistName,
-						}),
-					),
-				)
+				if (!this.abortController.signal.aborted) {
+					this.ea.publish(
+						new Snack(
+							this.i18n.tr('discovery.hasUpcomingEvents', {
+								name: artistName,
+							}),
+						),
+					)
+				}
 			}
 		} catch (err) {
-			if ((err as Error).name === 'AbortError') return
 			this.logger.warn('Concert search failed for artist', {
 				artistId,
 				error: err,

--- a/src/services/grpc-transport.ts
+++ b/src/services/grpc-transport.ts
@@ -1,5 +1,5 @@
 import type { Interceptor } from '@connectrpc/connect'
-import { ConnectError } from '@connectrpc/connect'
+import { Code, ConnectError } from '@connectrpc/connect'
 import { createConnectTransport } from '@connectrpc/connect-web'
 import { SpanStatusCode, trace } from '@opentelemetry/api'
 import type { ILogger } from 'aurelia'
@@ -12,6 +12,11 @@ import {
 const baseUrl = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080'
 
 const tracer = trace.getTracer('connect-rpc')
+
+/** Returns true for errors caused by intentional request cancellation. */
+const isCancellation = (err: unknown): boolean =>
+	(err instanceof DOMException && err.name === 'AbortError') ||
+	(err instanceof ConnectError && err.code === Code.Canceled)
 
 /**
  * Creates a Connect transport with authentication, logging, and OTEL interceptors.
@@ -57,16 +62,18 @@ export const createTransport = (auth: IAuthService, logger: ILogger) => {
 			logger.debug('RPC response', method, `${durationMs}ms`)
 			return response
 		} catch (err) {
-			const durationMs = Math.round(performance.now() - start)
-			if (err instanceof ConnectError) {
-				logger.error(
-					'RPC error',
-					method,
-					`${durationMs}ms`,
-					err.code.toString(),
-				)
-			} else {
-				logger.error('RPC error', method, `${durationMs}ms`, err)
+			if (!isCancellation(err)) {
+				const durationMs = Math.round(performance.now() - start)
+				if (err instanceof ConnectError) {
+					logger.error(
+						'RPC error',
+						method,
+						`${durationMs}ms`,
+						err.code.toString(),
+					)
+				} else {
+					logger.error('RPC error', method, `${durationMs}ms`, err)
+				}
 			}
 			throw err
 		}
@@ -94,6 +101,10 @@ export const createTransport = (auth: IAuthService, logger: ILogger) => {
 				span.setStatus({ code: SpanStatusCode.OK })
 				return response
 			} catch (err) {
+				if (isCancellation(err)) {
+					span.setStatus({ code: SpanStatusCode.OK })
+					throw err
+				}
 				if (err instanceof ConnectError) {
 					span.setAttributes({
 						'rpc.connect.error_code': err.code.toString(),

--- a/test/routes/discovery-route.spec.ts
+++ b/test/routes/discovery-route.spec.ts
@@ -295,10 +295,7 @@ describe('DiscoveryRoute', () => {
 			expect(mockFollowClient.follow).toHaveBeenCalledWith(
 				expect.objectContaining({ id: 'a1' }),
 			)
-			expect(mockConcert.searchNewConcerts).toHaveBeenCalledWith(
-				'a1',
-				expect.any(AbortSignal),
-			)
+			expect(mockConcert.searchNewConcerts).toHaveBeenCalledWith('a1')
 		})
 
 		it('should not follow already-followed artist', async () => {
@@ -377,10 +374,7 @@ describe('DiscoveryRoute', () => {
 			expect(mockFollowClient.follow).toHaveBeenCalledWith(
 				expect.objectContaining({ id: 'a1' }),
 			)
-			expect(mockConcert.searchNewConcerts).toHaveBeenCalledWith(
-				'a1',
-				expect.any(AbortSignal),
-			)
+			expect(mockConcert.searchNewConcerts).toHaveBeenCalledWith('a1')
 		})
 
 		it('should skip if artist already followed', async () => {


### PR DESCRIPTION
## Summary

- Stop passing `AbortSignal` to `SearchNewConcerts` RPC in `DiscoveryRoute` — the server intentionally does not cancel Gemini API calls, so client-side abort is pointless noise
- Adjust the detach guard so concert data (`addArtistWithConcerts`) is still persisted after navigation, while Snack notifications are skipped
- Add `isCancellation()` helper to `grpc-transport.ts` that detects `AbortError` (DOMException) and `ConnectError(Canceled)`
- Suppress error logging in `loggingInterceptor` and mark OTEL spans as OK in `otelInterceptor` for cancellation errors

## Test plan

- [x] `make lint` passes
- [x] Unit tests pass (`make test`)
- [ ] Verify console no longer shows `[ERR Transport] RPC error AbortError` on page navigation from Discovery
- [ ] Verify concert search results still persist after navigating away mid-search