### PR TITLE
ci: restore branch:main filter for visual baseline download

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -256,6 +256,7 @@ jobs:
         with:
           name: visual-baselines
           path: e2e/__screenshots__/
+          branch: main
           workflow: ci.yaml
           if_no_artifact_found: warn
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4684,9 +4684,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"


### PR DESCRIPTION
## Summary

- Restore `branch: main` to the visual baseline download step in CI

The filter was temporarily removed in #323 to allow one-time baseline regeneration after an intentional visual change (trash column hidden on `pointer: coarse` devices). Now that #323 is merged and `main`'s CI has uploaded the correct updated baselines, this restores the constraint so future PRs compare against `main`'s baselines as intended.
