### PR TITLE
feat(post-signup-dialog): add hype guide hint and dynamic close button

### DIFF
--- a/src/components/post-signup-dialog/post-signup-dialog.html
+++ b/src/components/post-signup-dialog/post-signup-dialog.html
@@ -4,6 +4,14 @@
   <section class="post-signup-content">
     <h2 class="post-signup-title" t="postSignup.title"></h2>
 
+    <!-- Hype guide hint (always shown) -->
+    <div class="post-signup-row">
+      <span class="post-signup-row-icon">💡</span>
+      <div class="post-signup-row-body">
+        <p class="post-signup-row-label" t="postSignup.hypeGuideLabel"></p>
+      </div>
+    </div>
+
     <!-- Notification opt-in row -->
     <div class="post-signup-row" if.bind="notificationManager.permission === 'default'">
       <span class="post-signup-row-icon">🔔</span>
@@ -52,7 +60,7 @@
         type="button"
         class="post-signup-btn-ghost"
         click.trigger="onDefer()"
-        t="postSignup.defer"
+        t.bind="isAllDone ? 'postSignup.close' : 'postSignup.defer'"
       ></button>
     </footer>
   </section>

--- a/src/components/post-signup-dialog/post-signup-dialog.spec.ts
+++ b/src/components/post-signup-dialog/post-signup-dialog.spec.ts
@@ -45,6 +45,7 @@ describe('PostSignupDialog', () => {
 	beforeEach(() => {
 		fakeCanShowFab = true
 		fakeIsIos = false
+		fakeNotificationManager.permission = 'default'
 		vi.clearAllMocks()
 		// Restore scopeTo after clearAllMocks resets mock implementations
 		fakeLogger.scopeTo.mockReturnValue(fakeLogger)
@@ -140,6 +141,56 @@ describe('PostSignupDialog', () => {
 			sut.onDefer()
 
 			expect(sut.isOpen).toBe(false)
+		})
+	})
+
+	describe('isAllDone', () => {
+		it('is false when canInstallPwa is true', () => {
+			fakeCanShowFab = true
+			fakeIsIos = false
+			fakeNotificationManager.permission = 'granted'
+			sut = new PostSignupDialog()
+
+			expect(sut.isAllDone).toBe(false)
+		})
+
+		it('is false when permission is not granted', () => {
+			fakeCanShowFab = false
+			fakeIsIos = false
+			fakeNotificationManager.permission = 'default'
+			sut = new PostSignupDialog()
+
+			expect(sut.isAllDone).toBe(false)
+		})
+
+		it('is true when PWA installed and notification granted', () => {
+			fakeCanShowFab = false
+			fakeIsIos = false
+			fakeNotificationManager.permission = 'granted'
+			sut = new PostSignupDialog()
+
+			expect(sut.isAllDone).toBe(true)
+		})
+
+		it('is true when iOS (canInstallPwa always false) and notification granted', () => {
+			fakeCanShowFab = true
+			fakeIsIos = true
+			fakeNotificationManager.permission = 'granted'
+			sut = new PostSignupDialog()
+
+			expect(sut.isAllDone).toBe(true)
+		})
+
+		it('becomes true when permission changes to granted after dialog creation', () => {
+			fakeCanShowFab = false
+			fakeIsIos = false
+			fakeNotificationManager.permission = 'default'
+			sut = new PostSignupDialog()
+			expect(sut.isAllDone).toBe(false)
+
+			fakeNotificationManager.permission = 'granted'
+
+			expect(sut.isAllDone).toBe(true)
 		})
 	})
 })

--- a/src/components/post-signup-dialog/post-signup-dialog.ts
+++ b/src/components/post-signup-dialog/post-signup-dialog.ts
@@ -24,6 +24,13 @@ export class PostSignupDialog {
 		return this.pwaInstall.canShowFab && !this.pwaInstall.isIos
 	}
 
+	public get isAllDone(): boolean {
+		return (
+			!this.canInstallPwa &&
+			this.notificationManager.permission === 'granted'
+		)
+	}
+
 	public activeChanged(): void {
 		if (this.active) {
 			this.isOpen = true

--- a/src/components/post-signup-dialog/post-signup-dialog.ts
+++ b/src/components/post-signup-dialog/post-signup-dialog.ts
@@ -25,7 +25,9 @@ export class PostSignupDialog {
 	}
 
 	public get isAllDone(): boolean {
-		return !this.canInstallPwa && this.notificationManager.permission === 'granted'
+		return (
+			!this.canInstallPwa && this.notificationManager.permission === 'granted'
+		)
 	}
 
 	public activeChanged(): void {

--- a/src/components/post-signup-dialog/post-signup-dialog.ts
+++ b/src/components/post-signup-dialog/post-signup-dialog.ts
@@ -25,10 +25,7 @@ export class PostSignupDialog {
 	}
 
 	public get isAllDone(): boolean {
-		return (
-			!this.canInstallPwa &&
-			this.notificationManager.permission === 'granted'
-		)
+		return !this.canInstallPwa && this.notificationManager.permission === 'granted'
 	}
 
 	public activeChanged(): void {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -274,6 +274,7 @@
 	"postSignup": {
 		"title": "Account registration complete!",
 		"ariaLabel": "Account registration complete",
+		"hypeGuideLabel": "Change hype on the My Artists page to control which notifications you receive",
 		"notificationLabel": "Turn on new live notifications",
 		"notificationEnable": "Enable notifications",
 		"notificationEnabling": "Enabling…",
@@ -282,7 +283,8 @@
 		"notificationDenied": "Notifications are blocked in your browser settings. You can change this in your browser.",
 		"pwaLabel": "Add to home screen for a better experience",
 		"pwaInstall": "Add to home screen",
-		"defer": "Later"
+		"defer": "Later",
+		"close": "Close"
 	},
 	"pageHelp": {
 		"discovery": {

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -274,6 +274,7 @@
 	"postSignup": {
 		"title": "✅ アカウント登録完了！",
 		"ariaLabel": "アカウント登録完了",
+		"hypeGuideLabel": "My Artists ページで hype を変更すると通知の範囲をコントロールできます",
 		"notificationLabel": "新着ライブ通知をオンにしよう",
 		"notificationEnable": "通知をオンにする",
 		"notificationEnabling": "有効化中…",
@@ -282,7 +283,8 @@
 		"notificationDenied": "ブラウザの設定で通知が拒否されています。設定から変更できます。",
 		"pwaLabel": "ホーム画面に追加するとより快適に",
 		"pwaInstall": "ホーム画面に追加",
-		"defer": "あとで"
+		"defer": "あとで",
+		"close": "閉じる"
 	},
 	"pageHelp": {
 		"discovery": {


### PR DESCRIPTION
## Summary

- Add always-visible hype guide hint row to `PostSignupDialog` so the sheet always has meaningful content, even when PWA is already installed and notifications are already granted
- Add `isAllDone` getter that returns `true` when both PWA install and push notification opt-in are complete
- Change footer button label from "Later" to "Close" when `isAllDone` is `true`, using `t.bind` for dynamic i18n key switching
- Add `postSignup.hypeGuideLabel` and `postSignup.close` i18n keys (ja/en)

close: #306

## Test plan

- [x] Unit tests for `isAllDone`: false when PWA installable, false when permission not granted, true when both complete, true after permission changes to granted mid-session
- [ ] Manual: signup in PWA-installed state → sheet shows hype guide row + "Close" button
- [ ] Manual: signup with notification not yet granted → sheet shows hype guide row + notification row + "Later" button
