### PR TITLE
fix(bottom-sheet): add contain: layout to prevent Chromium scroll-snap displacement

### DIFF
--- a/src/components/bottom-sheet/bottom-sheet.css
+++ b/src/components/bottom-sheet/bottom-sheet.css
@@ -79,7 +79,6 @@
 			block-size: 100dvh;
 
 			animation: initial-snap 0.01s backwards;
-			scroll-timeline: --sheet-scroll block;
 		}
 
 		/* Safari: re-run initial-snap animation each time display toggles */
@@ -101,6 +100,25 @@
 
 		.sheet-body {
 			scroll-snap-align: end;
+
+			/*
+			 * Chromium bug workaround: scroll-snap re-evaluation inside popover top-layer.
+			 *
+			 * When a scroll container with `scroll-snap-type: y mandatory` is inside a
+			 * popover top-layer (`position: fixed; inset: 0`), any child layout change
+			 * triggers scroll-snap re-evaluation. Chromium incorrectly offsets the scroll
+			 * container itself by `-scrollTop` pixels in the rendered position (while
+			 * `scrollTop` remains unchanged), visually shifting the sheet upward.
+			 *
+			 * `contain: layout` establishes a layout containment boundary on `.sheet-body`,
+			 * isolating child layout changes (e.g., chip-check SVG toggle, dynamic content)
+			 * from `.scroll-area`. This prevents the re-evaluation from being triggered.
+			 *
+			 * Removal condition: when Chromium fixes scroll container offset on snap
+			 * re-evaluation inside top-layer, this declaration MAY be removed. The
+			 * regression guard is the artist-filter chip-check E2E test.
+			 */
+			contain: layout;
 
 			overflow-y: auto;
 


### PR DESCRIPTION
## Summary

- Adds `contain: layout` to `.sheet-body` in `bottom-sheet.css` to fix a Chromium rendering bug where the artist-filter sheet displaces upward when a chip is checked
- Removes `scroll-timeline: --sheet-scroll block` from `.scroll-area` (dead code — no `animation-timeline` consumer has existed since commit `72c768a`)

## Root cause

When a scroll container with `scroll-snap-type: y mandatory` is inside a popover top-layer (`position: fixed; inset: 0`), any child layout change (e.g., chip-check SVG toggling `display: none` to `block`) triggers Chromium's scroll-snap re-evaluation. Chromium incorrectly offsets the scroll container itself by `-scrollTop` pixels in the rendered position while `scrollTop` remains unchanged — visually shifting the sheet from the bottom toward the top of the viewport.

`contain: layout` on `.sheet-body` establishes a layout containment boundary that isolates child layout changes from `.scroll-area`, preventing the re-evaluation from being triggered. All scroll-snap UX (mandatory snap, swipe-to-dismiss, snap-back) is preserved unchanged.

## Playwright verification

- `scrollRatio=1.000` and `rect.top=0` after chip check (was `-294px`)
- All 11 functional E2E tests pass

## Removal condition

When Chromium fixes scroll container offset on snap re-evaluation inside top-layer, `contain: layout` MAY be removed. The regression guard is the artist-filter chip-check E2E test (`e2e/functional/artist-filter-bar.spec.ts`).

close: #325
