### PR TITLE
feat(service): add 24h TTL cache to dashboard concert list

### DIFF
--- a/src/services/concert-service.spec.ts
+++ b/src/services/concert-service.spec.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ProximityGroup } from '../adapter/rpc/client/concert-client'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockLogger = {
+	scopeTo: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}
+const mockAuth = { isAuthenticated: true }
+const mockGuest = { follows: [], home: null }
+const mockRpcClient = {
+	listByFollower: vi.fn(async (): Promise<ProximityGroup[]> => []),
+	listConcerts: vi.fn(),
+	listWithProximity: vi.fn(),
+}
+
+vi.mock('aurelia', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('aurelia')>()
+	return {
+		...actual,
+		resolve: vi.fn((token: unknown) => {
+			const map: Record<string, unknown> = {
+				ILogger: mockLogger,
+				IAuthService: mockAuth,
+				IGuestService: mockGuest,
+				IConcertRpcClient: mockRpcClient,
+			}
+			const tokenAny = token as { friendlyName?: string }
+			return map[tokenAny.friendlyName ?? ''] ?? {}
+		}),
+		observable: actual.observable,
+	}
+})
+
+import { ConcertServiceClient } from './concert-service'
+
+function makeGroups(count: number): ProximityGroup[] {
+	return Array.from({ length: count }, (_, _i) => ({
+		date: undefined,
+		home: [],
+		nearby: [],
+		away: [],
+	})) as unknown as ProximityGroup[]
+}
+
+describe('ConcertServiceClient', () => {
+	let sut: ConcertServiceClient
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mockAuth.isAuthenticated = true
+		sut = new ConcertServiceClient()
+	})
+
+	describe('listByFollower — caching', () => {
+		it('returns cached result on second call without issuing RPC', async () => {
+			const groups = makeGroups(2)
+			mockRpcClient.listByFollower.mockResolvedValueOnce(groups)
+
+			await sut.listByFollower()
+			const result = await sut.listByFollower()
+
+			expect(mockRpcClient.listByFollower).toHaveBeenCalledTimes(1)
+			expect(result).toBe(groups)
+		})
+
+		it('issues RPC on first call (cache miss) and stores result', async () => {
+			const groups = makeGroups(3)
+			mockRpcClient.listByFollower.mockResolvedValueOnce(groups)
+
+			const result = await sut.listByFollower()
+
+			expect(mockRpcClient.listByFollower).toHaveBeenCalledTimes(1)
+			expect(result).toEqual(groups)
+		})
+
+		it('re-fetches after cache TTL has expired', async () => {
+			const first = makeGroups(1)
+			const second = makeGroups(2)
+			mockRpcClient.listByFollower
+				.mockResolvedValueOnce(first)
+				.mockResolvedValueOnce(second)
+
+			await sut.listByFollower()
+
+			// Advance time past 24h TTL
+			vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 25 * 60 * 60 * 1000)
+
+			const result = await sut.listByFollower()
+
+			expect(mockRpcClient.listByFollower).toHaveBeenCalledTimes(2)
+			expect(result).toEqual(second)
+
+			vi.restoreAllMocks()
+		})
+	})
+
+	describe('invalidateFollowerCache', () => {
+		it('causes next listByFollower() call to issue RPC', async () => {
+			mockRpcClient.listByFollower.mockResolvedValue(makeGroups(1))
+
+			await sut.listByFollower()
+			sut.invalidateFollowerCache()
+			await sut.listByFollower()
+
+			expect(mockRpcClient.listByFollower).toHaveBeenCalledTimes(2)
+		})
+	})
+})

--- a/src/services/concert-service.spec.ts
+++ b/src/services/concert-service.spec.ts
@@ -194,5 +194,50 @@ describe('ConcertServiceClient', () => {
 			expect(await secondCall).toEqual(fresh)
 			expect(mockRpcClient.listByFollower).toHaveBeenCalledTimes(2)
 		})
+
+		it('stale finally does not evict a newer post-invalidation in-flight (own-promise identity guard)', async () => {
+			// Without the own-promise check in .finally(), this sequence
+			// produces 3 RPC calls instead of 2:
+			//   1. RPC-1 fires           → slot = promise1 (gen 0)
+			//   2. invalidate()          → slot = null, gen = 1
+			//   3. RPC-2 fires           → slot = promise2 (gen 1)
+			//   4. RPC-1 settles         → buggy finally clears slot to null (evicts promise2)
+			//   5. caller-3 arrives      → sees slot = null → fires RPC-3 unnecessarily
+			// Both RPCs are hand-released here so settling order is deterministic
+			// (mockResolvedValueOnce's microtask-queue artifact masks the bug).
+			let releaseFirst: (g: ProximityGroup[]) => void = () => {}
+			let releaseSecond: (g: ProximityGroup[]) => void = () => {}
+			const firstRpc = new Promise<ProximityGroup[]>((r) => {
+				releaseFirst = r
+			})
+			const secondRpc = new Promise<ProximityGroup[]>((r) => {
+				releaseSecond = r
+			})
+			mockRpcClient.listByFollower
+				.mockReturnValueOnce(firstRpc)
+				.mockReturnValueOnce(secondRpc)
+				// A third mock would only fire if the bug is present.
+				.mockResolvedValueOnce(makeGroups(99))
+
+			const firstCall = sut.listByFollower()
+			sut.invalidateFollowerCache()
+			const secondCall = sut.listByFollower()
+
+			// Settle RPC-1 → its .finally() runs while RPC-2 is still pending.
+			// With the fix, slot stays = promise2 (own-promise guard).
+			// Without the fix, slot = null.
+			releaseFirst(makeGroups(1))
+			await firstCall
+
+			// Caller-3 must coalesce onto RPC-2 (slot still occupied if guard works).
+			const thirdCall = sut.listByFollower()
+
+			// Settle RPC-2 → both secondCall and thirdCall resolve to the same value.
+			releaseSecond(makeGroups(2))
+			const [b, c] = await Promise.all([secondCall, thirdCall])
+
+			expect(mockRpcClient.listByFollower).toHaveBeenCalledTimes(2)
+			expect(c).toEqual(b)
+		})
 	})
 })

--- a/src/services/concert-service.spec.ts
+++ b/src/services/concert-service.spec.ts
@@ -112,5 +112,62 @@ describe('ConcertServiceClient', () => {
 
 			expect(mockRpcClient.listByFollower).toHaveBeenCalledTimes(2)
 		})
+
+		it('discards in-flight RPC result if invalidated before it resolves', async () => {
+			// Reproduce the in-flight repopulation race: an RPC is fired,
+			// invalidateFollowerCache() runs while it's in flight, then the
+			// RPC settles. The settled result MUST NOT silently repopulate
+			// the cache, otherwise a follow-action's intentional invalidation
+			// would be undone for up to 24h.
+			let releaseFirst: (groups: ProximityGroup[]) => void = () => {}
+			const firstRpc = new Promise<ProximityGroup[]>((resolve) => {
+				releaseFirst = resolve
+			})
+			const second = makeGroups(2)
+			mockRpcClient.listByFollower
+				.mockReturnValueOnce(firstRpc)
+				.mockResolvedValueOnce(second)
+
+			const firstCallPromise = sut.listByFollower()
+			sut.invalidateFollowerCache()
+			releaseFirst(makeGroups(1))
+			await firstCallPromise
+
+			// Next call MUST hit the RPC again — cache should be empty
+			// because invalidation fenced the stale write.
+			const result = await sut.listByFollower()
+			expect(mockRpcClient.listByFollower).toHaveBeenCalledTimes(2)
+			expect(result).toEqual(second)
+		})
+	})
+
+	describe('listByFollower — concurrent-call dedup', () => {
+		it('coalesces two simultaneous signal-less callers onto one RPC', async () => {
+			const groups = makeGroups(1)
+			mockRpcClient.listByFollower.mockResolvedValueOnce(groups)
+
+			const [a, b] = await Promise.all([
+				sut.listByFollower(),
+				sut.listByFollower(),
+			])
+
+			expect(mockRpcClient.listByFollower).toHaveBeenCalledTimes(1)
+			expect(a).toEqual(groups)
+			expect(b).toEqual(groups)
+		})
+
+		it('does NOT dedup when callers provide AbortSignal (per-caller cancellation must be honored)', async () => {
+			const groups = makeGroups(1)
+			mockRpcClient.listByFollower.mockResolvedValue(groups)
+
+			const ctrlA = new AbortController()
+			const ctrlB = new AbortController()
+			await Promise.all([
+				sut.listByFollower(ctrlA.signal),
+				sut.listByFollower(ctrlB.signal),
+			])
+
+			expect(mockRpcClient.listByFollower).toHaveBeenCalledTimes(2)
+		})
 	})
 })

--- a/src/services/concert-service.spec.ts
+++ b/src/services/concert-service.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ProximityGroup } from '../adapter/rpc/client/concert-client'
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
@@ -52,6 +52,15 @@ describe('ConcertServiceClient', () => {
 		sut = new ConcertServiceClient()
 	})
 
+	// Restore spies (including the Date.now spy used by the TTL-expiry
+	// test) in afterEach so an assertion failure in a test body cannot
+	// leak the spy onto subsequent tests. A failed expect() inside the
+	// body would otherwise leave Date.now permanently frozen at the
+	// spied future timestamp.
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
 	describe('listByFollower — caching', () => {
 		it('returns cached result on second call without issuing RPC', async () => {
 			const groups = makeGroups(2)
@@ -90,8 +99,6 @@ describe('ConcertServiceClient', () => {
 
 			expect(mockRpcClient.listByFollower).toHaveBeenCalledTimes(2)
 			expect(result).toEqual(second)
-
-			vi.restoreAllMocks()
 		})
 	})
 

--- a/src/services/concert-service.spec.ts
+++ b/src/services/concert-service.spec.ts
@@ -169,5 +169,30 @@ describe('ConcertServiceClient', () => {
 
 			expect(mockRpcClient.listByFollower).toHaveBeenCalledTimes(2)
 		})
+
+		it('does not coalesce a post-invalidation caller onto the pre-invalidation in-flight', async () => {
+			// Reproduce the stale-coalesce window: an RPC is in flight,
+			// invalidateFollowerCache() runs, then a second caller arrives
+			// before the first RPC settles. The second caller MUST issue
+			// its own RPC (not be coalesced onto the now-stale in-flight),
+			// otherwise it would receive the stale payload for its render.
+			let releaseFirst: (groups: ProximityGroup[]) => void = () => {}
+			const firstRpc = new Promise<ProximityGroup[]>((resolve) => {
+				releaseFirst = resolve
+			})
+			const fresh = makeGroups(2)
+			mockRpcClient.listByFollower
+				.mockReturnValueOnce(firstRpc)
+				.mockResolvedValueOnce(fresh)
+
+			const firstCall = sut.listByFollower()
+			sut.invalidateFollowerCache()
+			const secondCall = sut.listByFollower()
+			releaseFirst(makeGroups(1))
+
+			await firstCall
+			expect(await secondCall).toEqual(fresh)
+			expect(mockRpcClient.listByFollower).toHaveBeenCalledTimes(2)
+		})
 	})
 })

--- a/src/services/concert-service.ts
+++ b/src/services/concert-service.ts
@@ -33,6 +33,10 @@ export class ConcertServiceClient {
 	private readonly guest = resolve(IGuestService)
 	private readonly rpcClient = resolve(IConcertRpcClient)
 
+	private readonly CACHE_TTL_MS = 24 * 60 * 60 * 1000
+	private cachedGroups: ProximityGroup[] | null = null
+	private cacheTimestamp: number | null = null
+
 	@observable public artistsWithConcerts = new Set<string>()
 
 	public get artistsWithConcertsCount(): number {
@@ -60,7 +64,23 @@ export class ConcertServiceClient {
 		if (!this.authService.isAuthenticated) {
 			return this.listByFollowerGuest(signal)
 		}
-		return this.rpcClient.listByFollower(signal)
+		const now = Date.now()
+		if (
+			this.cachedGroups !== null &&
+			this.cacheTimestamp !== null &&
+			now - this.cacheTimestamp < this.CACHE_TTL_MS
+		) {
+			return this.cachedGroups
+		}
+		const result = await this.rpcClient.listByFollower(signal)
+		this.cachedGroups = result
+		this.cacheTimestamp = Date.now()
+		return result
+	}
+
+	public invalidateFollowerCache(): void {
+		this.cachedGroups = null
+		this.cacheTimestamp = null
 	}
 
 	public async listWithProximity(

--- a/src/services/concert-service.ts
+++ b/src/services/concert-service.ts
@@ -33,9 +33,17 @@ export class ConcertServiceClient {
 	private readonly guest = resolve(IGuestService)
 	private readonly rpcClient = resolve(IConcertRpcClient)
 
-	private readonly CACHE_TTL_MS = 24 * 60 * 60 * 1000
+	private static readonly CACHE_TTL_MS = 24 * 60 * 60 * 1000
 	private cachedGroups: ProximityGroup[] | null = null
 	private cacheTimestamp: number | null = null
+	// In-flight RPC promise: coalesces concurrent cache-miss callers
+	// (e.g. two dashboard sub-components rendering simultaneously)
+	// onto a single RPC. Without this, both miss the cache check,
+	// both fire `listByFollower` RPCs, and the second result
+	// silently overwrites the first. Cleared on resolve/reject so
+	// the next miss after settle (cache populated or RPC failed)
+	// behaves correctly.
+	private inFlightListByFollower: Promise<ProximityGroup[]> | null = null
 
 	@observable public artistsWithConcerts = new Set<string>()
 
@@ -68,14 +76,27 @@ export class ConcertServiceClient {
 		if (
 			this.cachedGroups !== null &&
 			this.cacheTimestamp !== null &&
-			now - this.cacheTimestamp < this.CACHE_TTL_MS
+			now - this.cacheTimestamp < ConcertServiceClient.CACHE_TTL_MS
 		) {
 			return this.cachedGroups
 		}
-		const result = await this.rpcClient.listByFollower(signal)
-		this.cachedGroups = result
-		this.cacheTimestamp = Date.now()
-		return result
+		// Concurrent-call dedup: if an RPC is already in flight, return
+		// its promise instead of starting a second one. See the
+		// `inFlightListByFollower` field comment for the rationale.
+		if (this.inFlightListByFollower !== null) {
+			return this.inFlightListByFollower
+		}
+		this.inFlightListByFollower = this.rpcClient
+			.listByFollower(signal)
+			.then((result) => {
+				this.cachedGroups = result
+				this.cacheTimestamp = Date.now()
+				return result
+			})
+			.finally(() => {
+				this.inFlightListByFollower = null
+			})
+		return this.inFlightListByFollower
 	}
 
 	public invalidateFollowerCache(): void {

--- a/src/services/concert-service.ts
+++ b/src/services/concert-service.ts
@@ -112,6 +112,12 @@ export class ConcertServiceClient {
 		this.cachedGroups = null
 		this.cacheTimestamp = null
 		this.cacheGeneration++
+		// Also clear the in-flight slot so post-invalidate signal-less
+		// callers issue a fresh RPC instead of joining the now-stale
+		// in-flight promise. The generation guard already prevents the
+		// stale .then() from writing to the cache, but a coalesced
+		// reader would still RECEIVE the stale payload for its render.
+		this.inFlightListByFollower = null
 	}
 
 	public async listWithProximity(

--- a/src/services/concert-service.ts
+++ b/src/services/concert-service.ts
@@ -36,14 +36,11 @@ export class ConcertServiceClient {
 	private static readonly CACHE_TTL_MS = 24 * 60 * 60 * 1000
 	private cachedGroups: ProximityGroup[] | null = null
 	private cacheTimestamp: number | null = null
-	// In-flight RPC promise: coalesces concurrent cache-miss callers
-	// (e.g. two dashboard sub-components rendering simultaneously)
-	// onto a single RPC. Without this, both miss the cache check,
-	// both fire `listByFollower` RPCs, and the second result
-	// silently overwrites the first. Cleared on resolve/reject so
-	// the next miss after settle (cache populated or RPC failed)
-	// behaves correctly.
+	// Coalesces concurrent cache-miss calls onto a single RPC.
 	private inFlightListByFollower: Promise<ProximityGroup[]> | null = null
+	// Bumped on every invalidate; an in-flight .then() compares against
+	// it to detect that its cache write has been superseded.
+	private cacheGeneration = 0
 
 	@observable public artistsWithConcerts = new Set<string>()
 
@@ -80,28 +77,41 @@ export class ConcertServiceClient {
 		) {
 			return this.cachedGroups
 		}
-		// Concurrent-call dedup: if an RPC is already in flight, return
-		// its promise instead of starting a second one. See the
-		// `inFlightListByFollower` field comment for the rationale.
-		if (this.inFlightListByFollower !== null) {
-			return this.inFlightListByFollower
+		// Only dedup when no signal is provided: a shared in-flight
+		// promise honors only the first caller's AbortSignal, so coalescing
+		// signal-bearing callers would let one caller's abort reject the
+		// other's awaited result. With signal=undefined the cancellation
+		// concern doesn't apply, so dedup is safe and useful for the
+		// common dashboard concurrent-render case.
+		if (this.inFlightListByFollower !== null && signal === undefined) {
+			return await this.inFlightListByFollower
 		}
-		this.inFlightListByFollower = this.rpcClient
+		const generationAtIssue = this.cacheGeneration
+		const promise = this.rpcClient
 			.listByFollower(signal)
 			.then((result) => {
-				this.cachedGroups = result
-				this.cacheTimestamp = Date.now()
+				// Only write to cache if invalidateFollowerCache() has
+				// NOT been called since this RPC was issued — otherwise
+				// the stale result would repopulate the just-cleared cache.
+				if (generationAtIssue === this.cacheGeneration) {
+					this.cachedGroups = result
+					this.cacheTimestamp = Date.now()
+				}
 				return result
 			})
 			.finally(() => {
 				this.inFlightListByFollower = null
 			})
-		return this.inFlightListByFollower
+		if (signal === undefined) {
+			this.inFlightListByFollower = promise
+		}
+		return await promise
 	}
 
 	public invalidateFollowerCache(): void {
 		this.cachedGroups = null
 		this.cacheTimestamp = null
+		this.cacheGeneration++
 	}
 
 	public async listWithProximity(

--- a/src/services/concert-service.ts
+++ b/src/services/concert-service.ts
@@ -38,8 +38,7 @@ export class ConcertServiceClient {
 	private cacheTimestamp: number | null = null
 	// Coalesces concurrent cache-miss calls onto a single RPC.
 	private inFlightListByFollower: Promise<ProximityGroup[]> | null = null
-	// Bumped on every invalidate; an in-flight .then() compares against
-	// it to detect that its cache write has been superseded.
+	// Bumped on invalidate; in-flight .then() checks it to fence superseded cache writes.
 	private cacheGeneration = 0
 
 	@observable public artistsWithConcerts = new Set<string>()
@@ -77,22 +76,19 @@ export class ConcertServiceClient {
 		) {
 			return this.cachedGroups
 		}
-		// Only dedup when no signal is provided: a shared in-flight
-		// promise honors only the first caller's AbortSignal, so coalescing
-		// signal-bearing callers would let one caller's abort reject the
-		// other's awaited result. With signal=undefined the cancellation
-		// concern doesn't apply, so dedup is safe and useful for the
-		// common dashboard concurrent-render case.
+		// Signal-less callers coalesce safely; signal-bearing ones can't (shared promise honors only first caller's signal).
 		if (this.inFlightListByFollower !== null && signal === undefined) {
 			return await this.inFlightListByFollower
 		}
 		const generationAtIssue = this.cacheGeneration
-		const promise = this.rpcClient
+		// `promise` is captured in both .then() (for the generation
+		// fence) and .finally() (for the own-promise identity check
+		// that prevents this stale finally from evicting a newer
+		// in-flight registered post-invalidate).
+		const promise: Promise<ProximityGroup[]> = this.rpcClient
 			.listByFollower(signal)
 			.then((result) => {
-				// Only write to cache if invalidateFollowerCache() has
-				// NOT been called since this RPC was issued — otherwise
-				// the stale result would repopulate the just-cleared cache.
+				// Skip cache write if invalidated since RPC issued.
 				if (generationAtIssue === this.cacheGeneration) {
 					this.cachedGroups = result
 					this.cacheTimestamp = Date.now()
@@ -100,7 +96,13 @@ export class ConcertServiceClient {
 				return result
 			})
 			.finally(() => {
-				this.inFlightListByFollower = null
+				// Own-promise identity check: only clear the slot if
+				// it still points at THIS promise. Without the guard,
+				// a stale finally would clobber a post-invalidate
+				// in-flight (RPC-2) that legitimately occupies the slot.
+				if (this.inFlightListByFollower === promise) {
+					this.inFlightListByFollower = null
+				}
 			})
 		if (signal === undefined) {
 			this.inFlightListByFollower = promise
@@ -112,11 +114,7 @@ export class ConcertServiceClient {
 		this.cachedGroups = null
 		this.cacheTimestamp = null
 		this.cacheGeneration++
-		// Also clear the in-flight slot so post-invalidate signal-less
-		// callers issue a fresh RPC instead of joining the now-stale
-		// in-flight promise. The generation guard already prevents the
-		// stale .then() from writing to the cache, but a coalesced
-		// reader would still RECEIVE the stale payload for its render.
+		// Post-invalidate callers must issue a fresh RPC, not join the now-stale in-flight.
 		this.inFlightListByFollower = null
 	}
 

--- a/src/services/follow-service-client.spec.ts
+++ b/src/services/follow-service-client.spec.ts
@@ -15,6 +15,9 @@ const mockRpcClient = {
 	unfollow: vi.fn(),
 	setHype: vi.fn(),
 }
+const mockConcertService = {
+	invalidateFollowerCache: vi.fn(),
+}
 
 vi.mock('aurelia', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('aurelia')>()
@@ -26,6 +29,7 @@ vi.mock('aurelia', async (importOriginal) => {
 				IAuthService: mockAuth,
 				IGuestService: mockGuest,
 				IFollowRpcClient: mockRpcClient,
+				IConcertService: mockConcertService,
 			}
 			const tokenAny = token as { friendlyName?: string }
 			return map[tokenAny.friendlyName ?? ''] ?? {}
@@ -52,6 +56,51 @@ describe('FollowServiceClient', () => {
 		mockAuth.isAuthenticated = true
 		mockGuest.follows = []
 		sut = new FollowServiceClient()
+	})
+
+	describe('follow — cache invalidation', () => {
+		it('calls invalidateFollowerCache on successful follow', async () => {
+			mockRpcClient.follow.mockResolvedValueOnce(undefined)
+			const artist = makeArtist('a1', 'Artist One')
+
+			await sut.follow(artist)
+
+			expect(mockConcertService.invalidateFollowerCache).toHaveBeenCalledOnce()
+		})
+
+		it('does NOT call invalidateFollowerCache when follow RPC fails', async () => {
+			mockRpcClient.follow.mockRejectedValueOnce(new Error('network error'))
+			const artist = makeArtist('a1', 'Artist One')
+
+			await expect(sut.follow(artist)).rejects.toThrow('network error')
+
+			expect(mockConcertService.invalidateFollowerCache).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('getFollowedArtistMap — RPC skip when state in memory', () => {
+		it('calls listFollowed RPC when followedArtists is empty', async () => {
+			mockRpcClient.listFollowed.mockResolvedValueOnce([
+				makeFollowedArtist('a1', 'Artist One'),
+			])
+
+			await sut.getFollowedArtistMap()
+
+			expect(mockRpcClient.listFollowed).toHaveBeenCalledTimes(1)
+		})
+
+		it('calls listFollowed RPC on each call (hype data lives in RPC response)', async () => {
+			mockRpcClient.listFollowed.mockResolvedValue([
+				makeFollowedArtist('a1', 'Artist One'),
+			])
+			// Even with followedArtists populated, listFollowed must be called
+			// to retrieve per-artist hype values which are not stored in followedArtists.
+			sut.followedArtists = [makeArtist('a1', 'Artist One')]
+
+			await sut.getFollowedArtistMap()
+
+			expect(mockRpcClient.listFollowed).toHaveBeenCalledTimes(1)
+		})
 	})
 
 	describe('listFollowed', () => {

--- a/src/services/follow-service-client.spec.ts
+++ b/src/services/follow-service-client.spec.ts
@@ -78,6 +78,27 @@ describe('FollowServiceClient', () => {
 		})
 	})
 
+	describe('unfollow — cache invalidation', () => {
+		it('calls invalidateFollowerCache on successful unfollow', async () => {
+			mockRpcClient.unfollow.mockResolvedValueOnce(undefined)
+			// Seed followedArtists so the filter doesn't no-op into empty
+			sut.followedArtists = [makeArtist('a1', 'Artist One')]
+
+			await sut.unfollow('a1')
+
+			expect(mockConcertService.invalidateFollowerCache).toHaveBeenCalledOnce()
+		})
+
+		it('does NOT call invalidateFollowerCache when unfollow RPC fails', async () => {
+			mockRpcClient.unfollow.mockRejectedValueOnce(new Error('network error'))
+			sut.followedArtists = [makeArtist('a1', 'Artist One')]
+
+			await expect(sut.unfollow('a1')).rejects.toThrow('network error')
+
+			expect(mockConcertService.invalidateFollowerCache).not.toHaveBeenCalled()
+		})
+	})
+
 	describe('getFollowedArtistMap — always issues RPC (hype data not cached)', () => {
 		it('calls listFollowed RPC when followedArtists is empty', async () => {
 			mockRpcClient.listFollowed.mockResolvedValueOnce([

--- a/src/services/follow-service-client.spec.ts
+++ b/src/services/follow-service-client.spec.ts
@@ -78,7 +78,7 @@ describe('FollowServiceClient', () => {
 		})
 	})
 
-	describe('getFollowedArtistMap — RPC skip when state in memory', () => {
+	describe('getFollowedArtistMap — always issues RPC (hype data not cached)', () => {
 		it('calls listFollowed RPC when followedArtists is empty', async () => {
 			mockRpcClient.listFollowed.mockResolvedValueOnce([
 				makeFollowedArtist('a1', 'Artist One'),

--- a/src/services/follow-service-client.ts
+++ b/src/services/follow-service-client.ts
@@ -3,6 +3,7 @@ import { IFollowRpcClient } from '../adapter/rpc/client/follow-client'
 import type { Artist } from '../entities/artist'
 import type { FollowedArtist, Hype } from '../entities/follow'
 import { IAuthService } from './auth-service'
+import { IConcertService } from './concert-service'
 import { IGuestService } from './guest-service'
 
 export const IFollowServiceClient = DI.createInterface<IFollowServiceClient>(
@@ -17,6 +18,7 @@ export class FollowServiceClient {
 	private readonly authService = resolve(IAuthService)
 	private readonly guest = resolve(IGuestService)
 	private readonly rpcClient = resolve(IFollowRpcClient)
+	private readonly concertService = resolve(IConcertService)
 
 	@observable public followedArtists: Artist[] = []
 
@@ -58,6 +60,7 @@ export class FollowServiceClient {
 
 		try {
 			await this.rpcClient.follow(artist.id)
+			this.concertService.invalidateFollowerCache()
 			this.logger.info('Artist followed', {
 				followed: this.followedCount,
 			})

--- a/src/services/follow-service-client.ts
+++ b/src/services/follow-service-client.ts
@@ -88,6 +88,7 @@ export class FollowServiceClient {
 			return
 		}
 		await this.rpcClient.unfollow(artistId)
+		this.concertService.invalidateFollowerCache()
 		this.followedArtists = this.followedArtists.filter((a) => a.id !== artistId)
 	}
 


### PR DESCRIPTION
## Summary

- Add 24h in-memory TTL cache to `ConcertServiceClient.listByFollower()` — repeated dashboard navigations within a session skip the RPC entirely
- Invalidate the cache on successful `follow()` so the next navigation re-fetches and picks up newly searched concerts for the newly followed artist
- Add unit tests covering cache hit, miss, TTL expiry, explicit invalidation, and follow-driven invalidation

## Motivation

Concert data changes only via two triggers: a weekly cron job and an async `SearchNewConcerts` goroutine fired on the first follow of an artist. Issuing a fresh RPC on every dashboard navigation was wasteful; the data is stable within a session. A 24h TTL matches the weekly cron cadence as a natural upper bound.

## Implementation Notes

- Cache lives in `ConcertServiceClient` as `cachedGroups`/`cacheTimestamp` (singleton — cleared on page reload)
- `FollowServiceClient` injects `IConcertService` (one-way; no circular DI) and calls `invalidateFollowerCache()` inside the `try` block after a successful RPC follow — failures do NOT invalidate
- `getFollowedArtistMap()` continues to call `listFollowed()` on every invocation; `followedArtists: Artist[]` has no hype data so skipping is deferred to a future refactor

close: #330
