### PR TITLE
feat(push-notification)!: derive settings toggle from backend + self-heal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
 			"dependencies": {
 				"@aurelia/i18n": "^2.0.0-rc.1",
 				"@aurelia/router": "^2.0.0-rc.1",
-				"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260322065617-21a7b92878d1.1",
-				"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260322065617-21a7b92878d1.2",
+				"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260414100656-ecef81c85ce8.1",
+				"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260414100656-ecef81c85ce8.2",
 				"@bufbuild/protobuf": "^1.10.1",
 				"@connectrpc/connect": "^1.7.0",
 				"@connectrpc/connect-web": "^1.7.0",
@@ -2162,8 +2162,8 @@
 			}
 		},
 		"node_modules/@buf/liverty-music_schema.bufbuild_es": {
-			"version": "1.10.0-20260322065617-21a7b92878d1.1",
-			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.bufbuild_es/-/liverty-music_schema.bufbuild_es-1.10.0-20260322065617-21a7b92878d1.1.tgz",
+			"version": "1.10.0-20260414100656-ecef81c85ce8.1",
+			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.bufbuild_es/-/liverty-music_schema.bufbuild_es-1.10.0-20260414100656-ecef81c85ce8.1.tgz",
 			"dependencies": {
 				"@buf/bufbuild_protovalidate.bufbuild_es": "1.10.0-20250717185734-6c6e0d3c608e.1",
 				"@buf/googleapis_googleapis.bufbuild_es": "1.10.0-20250411203938-61b203b9a916.1"
@@ -2173,12 +2173,12 @@
 			}
 		},
 		"node_modules/@buf/liverty-music_schema.connectrpc_es": {
-			"version": "1.6.1-20260322065617-21a7b92878d1.2",
-			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.connectrpc_es/-/liverty-music_schema.connectrpc_es-1.6.1-20260322065617-21a7b92878d1.2.tgz",
+			"version": "1.6.1-20260414100656-ecef81c85ce8.2",
+			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.connectrpc_es/-/liverty-music_schema.connectrpc_es-1.6.1-20260414100656-ecef81c85ce8.2.tgz",
 			"dependencies": {
 				"@buf/bufbuild_protovalidate.connectrpc_es": "1.6.1-20250717185734-6c6e0d3c608e.2",
 				"@buf/googleapis_googleapis.connectrpc_es": "1.6.1-20250411203938-61b203b9a916.2",
-				"@buf/liverty-music_schema.bufbuild_es": "1.10.0-20260322065617-21a7b92878d1.1"
+				"@buf/liverty-music_schema.bufbuild_es": "1.10.0-20260414100656-ecef81c85ce8.1"
 			},
 			"peerDependencies": {
 				"@connectrpc/connect": "^1.6.1"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
 	"dependencies": {
 		"@aurelia/i18n": "^2.0.0-rc.1",
 		"@aurelia/router": "^2.0.0-rc.1",
-		"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260322065617-21a7b92878d1.1",
-		"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260322065617-21a7b92878d1.2",
+		"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260414100656-ecef81c85ce8.1",
+		"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260414100656-ecef81c85ce8.2",
 		"@bufbuild/protobuf": "^1.10.1",
 		"@connectrpc/connect": "^1.7.0",
 		"@connectrpc/connect-web": "^1.7.0",

--- a/src/adapter/rpc/client/push-client.ts
+++ b/src/adapter/rpc/client/push-client.ts
@@ -1,3 +1,9 @@
+import {
+	PushEndpoint,
+	PushKeys,
+	type PushSubscription,
+} from '@buf/liverty-music_schema.bufbuild_es/liverty_music/entity/v1/push_subscription_pb.js'
+import { UserId } from '@buf/liverty-music_schema.bufbuild_es/liverty_music/entity/v1/user_pb.js'
 import { PushNotificationService } from '@buf/liverty-music_schema.connectrpc_es/liverty_music/rpc/push_notification/v1/push_notification_service_connect.js'
 import { createClient } from '@connectrpc/connect'
 import { DI, ILogger, resolve } from 'aurelia'
@@ -20,15 +26,56 @@ export class PushRpcClient {
 		),
 	)
 
-	public async subscribe(subscription: {
+	/**
+	 * Registers the calling browser's push subscription. UPSERT by endpoint.
+	 * The backend resolves the owning user from the JWT — no user_id is sent.
+	 */
+	public async create(subscription: {
 		endpoint: string
 		p256dh: string
 		auth: string
-	}): Promise<void> {
-		await this.pushClient.subscribe(subscription)
+	}): Promise<PushSubscription> {
+		const resp = await this.pushClient.create({
+			endpoint: new PushEndpoint({ value: subscription.endpoint }),
+			keys: new PushKeys({
+				p256dh: subscription.p256dh,
+				auth: subscription.auth,
+			}),
+		})
+		if (!resp.subscription) {
+			throw new Error('Create response missing subscription')
+		}
+		return resp.subscription
 	}
 
-	public async unsubscribe(): Promise<void> {
-		await this.pushClient.unsubscribe({})
+	/**
+	 * Retrieves the push subscription for (userId, endpoint). Throws
+	 * `ConnectError` with `Code.NotFound` when no row matches so callers can
+	 * branch on the error path for self-healing.
+	 */
+	public async get(
+		userId: string,
+		endpoint: string,
+	): Promise<PushSubscription> {
+		const resp = await this.pushClient.get({
+			userId: new UserId({ value: userId }),
+			endpoint: new PushEndpoint({ value: endpoint }),
+		})
+		if (!resp.subscription) {
+			throw new Error('Get response missing subscription')
+		}
+		return resp.subscription
+	}
+
+	/**
+	 * Removes the push subscription for (userId, endpoint). Only the
+	 * specified browser's row is deleted; other browsers registered by
+	 * the same user remain active. Idempotent.
+	 */
+	public async delete(userId: string, endpoint: string): Promise<void> {
+		await this.pushClient.delete({
+			userId: new UserId({ value: userId }),
+			endpoint: new PushEndpoint({ value: endpoint }),
+		})
 	}
 }

--- a/src/adapter/rpc/mapper/user-mapper.ts
+++ b/src/adapter/rpc/mapper/user-mapper.ts
@@ -4,6 +4,7 @@ import type { User } from '../../../entities/user'
 export function userFrom(proto: ProtoUser): User {
 	const home = proto.home
 	return {
+		id: proto.id?.value ?? '',
 		home: home
 			? {
 					countryCode: home.countryCode,

--- a/src/components/notification-prompt/notification-prompt.ts
+++ b/src/components/notification-prompt/notification-prompt.ts
@@ -49,7 +49,7 @@ export class NotificationPrompt {
 	public async enable(): Promise<void> {
 		this.isLoading = true
 		try {
-			await this.pushService.subscribe()
+			await this.pushService.create()
 			if (this.notificationManager.permission === 'granted') {
 				this.isVisible = false
 				localStorage.setItem(StorageKeys.uiNotificationPromptDismissed, 'true')

--- a/src/components/post-signup-dialog/post-signup-dialog.spec.ts
+++ b/src/components/post-signup-dialog/post-signup-dialog.spec.ts
@@ -16,7 +16,7 @@ const fakePwaInstall = {
 }
 
 const fakeNotificationManager = { permission: 'default' }
-const fakePushService = { subscribe: vi.fn().mockResolvedValue(undefined) }
+const fakePushService = { create: vi.fn().mockResolvedValue(null) }
 const fakePromptCoordinator = { markShown: vi.fn() }
 
 vi.mock('aurelia', async (importOriginal) => {
@@ -124,7 +124,7 @@ describe('PostSignupDialog', () => {
 		})
 
 		it('sets notificationError on failure', async () => {
-			fakePushService.subscribe.mockRejectedValueOnce(new Error('denied'))
+			fakePushService.create.mockRejectedValueOnce(new Error('denied'))
 
 			await sut.onEnableNotifications()
 

--- a/src/components/post-signup-dialog/post-signup-dialog.spec.ts
+++ b/src/components/post-signup-dialog/post-signup-dialog.spec.ts
@@ -16,7 +16,9 @@ const fakePwaInstall = {
 }
 
 const fakeNotificationManager = { permission: 'default' }
-const fakePushService = { create: vi.fn().mockResolvedValue(null) }
+const fakePushService = {
+	create: vi.fn().mockResolvedValue('https://push.example.com/endpoint'),
+}
 const fakePromptCoordinator = { markShown: vi.fn() }
 
 vi.mock('aurelia', async (importOriginal) => {
@@ -47,8 +49,11 @@ describe('PostSignupDialog', () => {
 		fakeIsIos = false
 		fakeNotificationManager.permission = 'default'
 		vi.clearAllMocks()
-		// Restore scopeTo after clearAllMocks resets mock implementations
+		// Restore default mock implementations after clearAllMocks resets them.
 		fakeLogger.scopeTo.mockReturnValue(fakeLogger)
+		fakePushService.create.mockResolvedValue(
+			'https://push.example.com/endpoint',
+		)
 		sut = new PostSignupDialog()
 	})
 
@@ -120,6 +125,16 @@ describe('PostSignupDialog', () => {
 			await sut.onEnableNotifications()
 
 			expect(sut.notificationDone).toBe(true)
+			expect(sut.notificationLoading).toBe(false)
+		})
+
+		it('keeps notificationDone false when permission is denied (create returns null)', async () => {
+			fakePushService.create.mockResolvedValueOnce(null)
+
+			await sut.onEnableNotifications()
+
+			expect(sut.notificationDone).toBe(false)
+			expect(sut.notificationError).toBe(false)
 			expect(sut.notificationLoading).toBe(false)
 		})
 

--- a/src/components/post-signup-dialog/post-signup-dialog.ts
+++ b/src/components/post-signup-dialog/post-signup-dialog.ts
@@ -43,7 +43,7 @@ export class PostSignupDialog {
 		this.notificationLoading = true
 		this.notificationError = false
 		try {
-			await this.pushService.subscribe()
+			await this.pushService.create()
 			this.notificationDone = true
 		} catch (err) {
 			this.logger.error('PostSignupDialog: failed to enable notifications', err)

--- a/src/components/post-signup-dialog/post-signup-dialog.ts
+++ b/src/components/post-signup-dialog/post-signup-dialog.ts
@@ -43,7 +43,13 @@ export class PostSignupDialog {
 		this.notificationLoading = true
 		this.notificationError = false
 		try {
-			await this.pushService.create()
+			const endpoint = await this.pushService.create()
+			if (!endpoint) {
+				// `create()` returns null when the user denies the browser
+				// permission prompt or VAPID is not configured — no subscription
+				// was registered, so the dialog must not show a success state.
+				return
+			}
 			this.notificationDone = true
 		} catch (err) {
 			this.logger.error('PostSignupDialog: failed to enable notifications', err)

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -1,5 +1,4 @@
 export const StorageKeys = {
-	userNotificationsEnabled: 'user.notificationsEnabled',
 	uiNotificationPromptDismissed: 'ui.notificationPromptDismissed',
 	uiSessionCount: 'ui.sessionCount',
 	uiOnboardingCompletedSessionCount: 'ui.onboardingCompletedSessionCount',

--- a/src/entities/user.ts
+++ b/src/entities/user.ts
@@ -13,6 +13,8 @@ export interface UserHome {
  * @source proto/liverty_music/entity/v1/user.proto — User
  */
 export interface User {
+	/** The internal UUID assigned by the backend. Used on per-user RPC requests. */
+	readonly id: string
 	readonly home?: UserHome
 }
 

--- a/src/routes/settings/settings-route.ts
+++ b/src/routes/settings/settings-route.ts
@@ -4,7 +4,6 @@ import { IEventAggregator, ILogger, resolve } from 'aurelia'
 import { Snack } from '../../components/snack-bar/snack'
 import { UserHomeSelector } from '../../components/user-home-selector/user-home-selector'
 import { translationKey } from '../../constants/iso3166'
-import { StorageKeys } from '../../constants/storage-keys'
 import { IAuthService } from '../../services/auth-service'
 import { INotificationManager } from '../../services/notification-manager'
 import { IPushService } from '../../services/push-service'
@@ -39,21 +38,69 @@ export class SettingsRoute {
 			: 'settings.notSet'
 	}
 
-	public loading(): void {
+	public async loading(): Promise<void> {
 		this.currentLocale = this.i18n.getLocale()
 		const homeLevel1 = this.userService.current?.home?.level1
 		const code = homeLevel1 ?? UserHomeSelector.getStoredHome()
 		this.currentHome = code ? translationKey(code) : null
-		const storedPref =
-			localStorage.getItem(StorageKeys.userNotificationsEnabled) === 'true'
-		// If the browser permission was revoked externally, override the stored preference
-		this.notificationsEnabled =
-			storedPref && this.notificationManager.permission === 'granted'
 
 		// Read email_verified from OIDC profile claims
 		this.emailVerified =
 			(this.auth.user?.profile as Record<string, unknown>)?.email_verified ===
 			true
+
+		await this.resolveNotificationToggleState()
+	}
+
+	/**
+	 * Derives the push notifications toggle state from (1) the browser's
+	 * `PushManager` subscription and (2) the backend's `push_subscriptions`
+	 * row. When the browser has a subscription but the backend does not —
+	 * e.g., a prior Create RPC failed silently or another device unsubscribed
+	 * globally in an older build — this method self-heals by re-registering
+	 * the existing browser subscription via the `Create` RPC.
+	 */
+	private async resolveNotificationToggleState(): Promise<void> {
+		if (this.notificationManager.permission !== 'granted') {
+			this.notificationsEnabled = false
+			return
+		}
+
+		const browserSub = await this.pushService.getBrowserSubscription()
+		if (!browserSub) {
+			this.notificationsEnabled = false
+			return
+		}
+
+		const userId = this.userService.current?.id ?? ''
+		if (!userId) {
+			this.logger.warn(
+				'Cannot resolve push toggle state without authenticated userId',
+			)
+			this.notificationsEnabled = false
+			return
+		}
+
+		try {
+			const exists = await this.pushService.existsOnBackend(
+				userId,
+				browserSub.endpoint,
+			)
+			if (exists) {
+				this.notificationsEnabled = true
+				return
+			}
+			// Self-heal: browser has subscription but backend is missing the row.
+			// Re-register using the existing material — no permission prompt needed.
+			this.logger.info(
+				'Push subscription exists on browser but not on backend; self-healing via Create',
+			)
+			await this.pushService.createFrom(browserSub)
+			this.notificationsEnabled = true
+		} catch (err) {
+			this.logger.error('Failed to resolve push notification toggle state', err)
+			this.notificationsEnabled = false
+		}
 	}
 
 	public openHomeSelector(): void {
@@ -91,23 +138,29 @@ export class SettingsRoute {
 
 		try {
 			const newValue = !this.notificationsEnabled
+			const userId = this.userService.current?.id ?? ''
+			if (!userId) {
+				this.logger.warn(
+					'Cannot toggle push notifications without authenticated userId',
+				)
+				return
+			}
 
 			if (newValue) {
-				await this.pushService.subscribe()
-				if (this.notificationManager.permission !== 'granted') {
-					this.logger.info('Notification permission not granted, keeping OFF')
+				const endpoint = await this.pushService.create()
+				if (!endpoint) {
+					// User declined the permission prompt or VAPID key is missing.
+					this.notificationsEnabled = false
 					return
 				}
 				this.notificationsEnabled = true
-				localStorage.setItem(StorageKeys.userNotificationsEnabled, 'true')
 			} else {
 				try {
-					await this.pushService.unsubscribe()
+					await this.pushService.delete(userId)
 				} catch (err) {
 					this.logger.error('Failed to unsubscribe push notifications', err)
 				}
 				this.notificationsEnabled = false
-				localStorage.setItem(StorageKeys.userNotificationsEnabled, 'false')
 			}
 		} catch (err) {
 			this.logger.error('Failed to toggle push notifications', err)

--- a/src/services/push-service.ts
+++ b/src/services/push-service.ts
@@ -1,3 +1,4 @@
+import { Code, ConnectError } from '@connectrpc/connect'
 import { DI, ILogger, resolve } from 'aurelia'
 import { IPushRpcClient } from '../adapter/rpc/client/push-client'
 import { INotificationManager } from './notification-manager'
@@ -8,6 +9,18 @@ export const IPushService = DI.createInterface<IPushService>(
 )
 
 export interface IPushService extends PushServiceClient {}
+
+/**
+ * Describes the current browser's subscription state as resolved from the
+ * browser's `PushManager`. `null` means the browser has no active push
+ * subscription object, in which case the user cannot have an enabled toggle
+ * regardless of what the backend stores.
+ */
+export type BrowserPushSubscription = {
+	endpoint: string
+	p256dh: string
+	auth: string
+}
 
 export class PushServiceClient {
 	private static readonly SW_READY_TIMEOUT_MS = 10_000
@@ -29,25 +42,48 @@ export class PushServiceClient {
 		return Promise.race([navigator.serviceWorker.ready, timeout])
 	}
 
-	public async subscribe(): Promise<void> {
+	/**
+	 * Returns the browser's current push subscription material, or `null`
+	 * when the browser has no active subscription. The endpoint here
+	 * uniquely identifies this browser session and is used as the key for
+	 * all subsequent Get/Delete backend calls.
+	 */
+	public async getBrowserSubscription(): Promise<BrowserPushSubscription | null> {
+		const registration = await this.getRegistration()
+		const sub = await registration.pushManager.getSubscription()
+		if (!sub) return null
+		const json = sub.toJSON()
+		return {
+			endpoint: json.endpoint ?? '',
+			p256dh: json.keys?.p256dh ?? '',
+			auth: json.keys?.auth ?? '',
+		}
+	}
+
+	/**
+	 * Requests notification permission (if needed), subscribes via
+	 * `PushManager`, and registers the resulting subscription with the
+	 * backend via the `Create` RPC.
+	 *
+	 * Returns the endpoint on success, or `null` when the user denied the
+	 * permission prompt or VAPID is missing.
+	 */
+	public async create(): Promise<string | null> {
 		if (!this.vapidPublicKey) {
 			this.logger.warn(
 				'VITE_VAPID_PUBLIC_KEY is not set, cannot subscribe to push',
 			)
-			return
+			return null
 		}
 
 		const permission = await this.notificationManager.requestPermission()
 		if (permission !== 'granted') {
-			this.logger.info('Notification permission not granted', {
-				permission,
-			})
-			return
+			this.logger.info('Notification permission not granted', { permission })
+			return null
 		}
 
 		const registration = await this.getRegistration()
 		let subscription = await registration.pushManager.getSubscription()
-
 		if (!subscription) {
 			this.logger.info('Creating new push subscription')
 			subscription = await registration.pushManager.subscribe({
@@ -64,8 +100,9 @@ export class PushServiceClient {
 		this.logger.info('Sending push subscription to backend', { endpoint })
 
 		try {
-			await this.rpcClient.subscribe({ endpoint, p256dh, auth })
+			await this.rpcClient.create({ endpoint, p256dh, auth })
 			this.logger.info('Push subscription registered successfully')
+			return endpoint
 		} catch (err) {
 			this.logger.error(
 				'Failed to register push subscription with backend',
@@ -75,21 +112,60 @@ export class PushServiceClient {
 		}
 	}
 
-	public async unsubscribe(): Promise<void> {
+	/**
+	 * Checks whether the backend has the current browser's subscription on file.
+	 * Returns `true` when the `(userId, endpoint)` pair resolves to a row,
+	 * `false` when the backend returns `NOT_FOUND`. Any other error is rethrown.
+	 */
+	public async existsOnBackend(
+		userId: string,
+		endpoint: string,
+	): Promise<boolean> {
+		try {
+			await this.rpcClient.get(userId, endpoint)
+			return true
+		} catch (err) {
+			if (err instanceof ConnectError && err.code === Code.NotFound) {
+				return false
+			}
+			throw err
+		}
+	}
+
+	/**
+	 * Registers the supplied browser subscription material with the backend
+	 * without re-requesting notification permission. Used by the settings
+	 * self-heal flow where the browser already has a subscription but the
+	 * backend does not.
+	 */
+	public async createFrom(sub: BrowserPushSubscription): Promise<void> {
+		await this.rpcClient.create(sub)
+	}
+
+	/**
+	 * Removes the browser's push subscription and instructs the backend to
+	 * delete the matching `(userId, endpoint)` row. Only this browser is
+	 * affected; other browsers registered by the same user remain active.
+	 */
+	public async delete(userId: string): Promise<void> {
 		const registration = await this.getRegistration()
 		const subscription = await registration.pushManager.getSubscription()
 
-		if (subscription) {
-			await subscription.unsubscribe()
-			this.logger.info('Browser push subscription removed')
+		if (!subscription) {
+			this.logger.info('No browser subscription to delete')
+			return
 		}
+		const endpoint = subscription.toJSON().endpoint ?? ''
 
 		try {
-			await this.rpcClient.unsubscribe()
+			await this.rpcClient.delete(userId, endpoint)
 			this.logger.info('Push subscription removed from backend successfully')
 		} catch (err) {
 			this.logger.error('Failed to remove push subscription from backend', err)
 			throw err
 		}
+
+		await subscription.unsubscribe()
+		this.logger.info('Browser push subscription removed')
 	}
 }

--- a/test/components/post-signup-dialog.spec.ts
+++ b/test/components/post-signup-dialog.spec.ts
@@ -26,7 +26,7 @@ const { PostSignupDialog } = await import(
 
 describe('PostSignupDialog', () => {
 	let sut: InstanceType<typeof PostSignupDialog>
-	let mockPush: { subscribe: ReturnType<typeof vi.fn> }
+	let mockPush: { create: ReturnType<typeof vi.fn> }
 	let mockPwa: {
 		canShowFab: boolean
 		isIos: boolean
@@ -36,7 +36,7 @@ describe('PostSignupDialog', () => {
 	let mockNotification: { permission: string }
 
 	beforeEach(() => {
-		mockPush = { subscribe: vi.fn().mockResolvedValue(undefined) }
+		mockPush = { create: vi.fn().mockResolvedValue(null) }
 		mockPwa = {
 			canShowFab: false,
 			isIos: false,
@@ -87,13 +87,13 @@ describe('PostSignupDialog', () => {
 		it('subscribes to push and sets done on success', async () => {
 			await sut.onEnableNotifications()
 
-			expect(mockPush.subscribe).toHaveBeenCalledOnce()
+			expect(mockPush.create).toHaveBeenCalledOnce()
 			expect(sut.notificationDone).toBe(true)
 			expect(sut.notificationLoading).toBe(false)
 		})
 
 		it('sets error on failure', async () => {
-			mockPush.subscribe.mockRejectedValue(new Error('denied'))
+			mockPush.create.mockRejectedValue(new Error('denied'))
 
 			await sut.onEnableNotifications()
 

--- a/test/components/post-signup-dialog.spec.ts
+++ b/test/components/post-signup-dialog.spec.ts
@@ -36,7 +36,9 @@ describe('PostSignupDialog', () => {
 	let mockNotification: { permission: string }
 
 	beforeEach(() => {
-		mockPush = { create: vi.fn().mockResolvedValue(null) }
+		mockPush = {
+			create: vi.fn().mockResolvedValue('https://push.example.com/endpoint'),
+		}
 		mockPwa = {
 			canShowFab: false,
 			isIos: false,
@@ -89,6 +91,17 @@ describe('PostSignupDialog', () => {
 
 			expect(mockPush.create).toHaveBeenCalledOnce()
 			expect(sut.notificationDone).toBe(true)
+			expect(sut.notificationLoading).toBe(false)
+		})
+
+		it('keeps notificationDone false when permission is denied (create returns null)', async () => {
+			mockPush.create.mockResolvedValue(null)
+
+			await sut.onEnableNotifications()
+
+			expect(mockPush.create).toHaveBeenCalledOnce()
+			expect(sut.notificationDone).toBe(false)
+			expect(sut.notificationError).toBe(false)
 			expect(sut.notificationLoading).toBe(false)
 		})
 

--- a/test/routes/settings-route.spec.ts
+++ b/test/routes/settings-route.spec.ts
@@ -1,4 +1,5 @@
 import { I18N } from '@aurelia/i18n'
+import { Code, ConnectError } from '@connectrpc/connect'
 import { DI, IEventAggregator, Registration } from 'aurelia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createTestContainer } from '../helpers/create-container'
@@ -40,14 +41,19 @@ describe('SettingsRoute', () => {
 		signOut: ReturnType<typeof vi.fn>
 	}
 	let mockUser: {
-		current: { home?: { level1: string } } | undefined
+		current:
+			| { id: string; home?: { level1: string } }
+			| undefined
 		resendEmailVerification: ReturnType<typeof vi.fn>
 		clear: ReturnType<typeof vi.fn>
 	}
 	let mockNotification: { permission: string }
 	let mockPush: {
-		subscribe: ReturnType<typeof vi.fn>
-		unsubscribe: ReturnType<typeof vi.fn>
+		getBrowserSubscription: ReturnType<typeof vi.fn>
+		existsOnBackend: ReturnType<typeof vi.fn>
+		createFrom: ReturnType<typeof vi.fn>
+		create: ReturnType<typeof vi.fn>
+		delete: ReturnType<typeof vi.fn>
 	}
 	let mockEa: { publish: ReturnType<typeof vi.fn> }
 
@@ -58,14 +64,17 @@ describe('SettingsRoute', () => {
 			signOut: vi.fn().mockResolvedValue(undefined),
 		}
 		mockUser = {
-			current: undefined,
+			current: { id: 'user-uuid-1' },
 			resendEmailVerification: vi.fn().mockResolvedValue(undefined),
 			clear: vi.fn(),
 		}
 		mockNotification = { permission: 'default' }
 		mockPush = {
-			subscribe: vi.fn().mockResolvedValue(undefined),
-			unsubscribe: vi.fn().mockResolvedValue(undefined),
+			getBrowserSubscription: vi.fn().mockResolvedValue(null),
+			existsOnBackend: vi.fn().mockResolvedValue(false),
+			createFrom: vi.fn().mockResolvedValue(undefined),
+			create: vi.fn().mockResolvedValue('https://push.example.com/endpoint'),
+			delete: vi.fn().mockResolvedValue(undefined),
 		}
 		mockEa = { publish: vi.fn() }
 
@@ -87,34 +96,79 @@ describe('SettingsRoute', () => {
 	})
 
 	describe('loading', () => {
-		it('sets emailVerified from user profile', () => {
-			sut.loading()
+		it('sets emailVerified from user profile', async () => {
+			await sut.loading()
 			expect(sut.emailVerified).toBe(true)
 		})
 
-		it('sets emailVerified false when profile has no claim', () => {
+		it('sets emailVerified false when profile has no claim', async () => {
 			mockAuth.user = { profile: {} }
-			sut.loading()
+			await sut.loading()
 			expect(sut.emailVerified).toBe(false)
 		})
 
-		it('sets currentHome from user service', () => {
-			mockUser.current = { home: { level1: 'JP-13' } }
-			sut.loading()
+		it('sets currentHome from user service', async () => {
+			mockUser.current = { id: 'user-uuid-1', home: { level1: 'JP-13' } }
+			await sut.loading()
 			expect(sut.currentHome).toBe('tokyo')
 		})
 
-		it('reads notification preference from localStorage', () => {
-			localStorage.setItem('user.notificationsEnabled', 'true')
+		it('sets toggle OFF when permission is not granted', async () => {
+			mockNotification.permission = 'denied'
+			await sut.loading()
+			expect(sut.notificationsEnabled).toBe(false)
+			expect(mockPush.getBrowserSubscription).not.toHaveBeenCalled()
+		})
+
+		it('sets toggle OFF when browser has no subscription', async () => {
 			mockNotification.permission = 'granted'
-			sut.loading()
+			mockPush.getBrowserSubscription.mockResolvedValue(null)
+			await sut.loading()
+			expect(sut.notificationsEnabled).toBe(false)
+			expect(mockPush.existsOnBackend).not.toHaveBeenCalled()
+		})
+
+		it('sets toggle ON when browser subscription exists on backend', async () => {
+			mockNotification.permission = 'granted'
+			mockPush.getBrowserSubscription.mockResolvedValue({
+				endpoint: 'https://push.example.com/endpoint',
+				p256dh: 'key',
+				auth: 'secret',
+			})
+			mockPush.existsOnBackend.mockResolvedValue(true)
+			await sut.loading()
+			expect(sut.notificationsEnabled).toBe(true)
+			expect(mockPush.existsOnBackend).toHaveBeenCalledWith(
+				'user-uuid-1',
+				'https://push.example.com/endpoint',
+			)
+			expect(mockPush.createFrom).not.toHaveBeenCalled()
+		})
+
+		it('self-heals via createFrom when browser has subscription but backend does not', async () => {
+			mockNotification.permission = 'granted'
+			const sub = {
+				endpoint: 'https://push.example.com/endpoint',
+				p256dh: 'key',
+				auth: 'secret',
+			}
+			mockPush.getBrowserSubscription.mockResolvedValue(sub)
+			mockPush.existsOnBackend.mockResolvedValue(false)
+			await sut.loading()
+			expect(mockPush.createFrom).toHaveBeenCalledWith(sub)
 			expect(sut.notificationsEnabled).toBe(true)
 		})
 
-		it('overrides stored pref when browser permission revoked', () => {
-			localStorage.setItem('user.notificationsEnabled', 'true')
-			mockNotification.permission = 'denied'
-			sut.loading()
+		it('sets toggle OFF when self-heal fails', async () => {
+			mockNotification.permission = 'granted'
+			mockPush.getBrowserSubscription.mockResolvedValue({
+				endpoint: 'https://push.example.com/endpoint',
+				p256dh: 'key',
+				auth: 'secret',
+			})
+			mockPush.existsOnBackend.mockResolvedValue(false)
+			mockPush.createFrom.mockRejectedValue(new Error('boom'))
+			await sut.loading()
 			expect(sut.notificationsEnabled).toBe(false)
 		})
 	})
@@ -143,35 +197,55 @@ describe('SettingsRoute', () => {
 	})
 
 	describe('toggleNotifications', () => {
-		it('subscribes and enables when toggling on with granted permission', async () => {
+		it('creates and enables when toggling on with granted permission', async () => {
 			mockNotification.permission = 'granted'
 			sut.notificationsEnabled = false
 
 			await sut.toggleNotifications()
 
-			expect(mockPush.subscribe).toHaveBeenCalledOnce()
+			expect(mockPush.create).toHaveBeenCalledOnce()
 			expect(sut.notificationsEnabled).toBe(true)
 		})
 
-		it('unsubscribes when toggling off', async () => {
+		it('keeps toggle OFF when create returns null (permission denied)', async () => {
+			mockPush.create.mockResolvedValue(null)
+			sut.notificationsEnabled = false
+
+			await sut.toggleNotifications()
+
+			expect(mockPush.create).toHaveBeenCalledOnce()
+			expect(sut.notificationsEnabled).toBe(false)
+		})
+
+		it('deletes the current browser subscription when toggling off', async () => {
 			sut.notificationsEnabled = true
 
 			await sut.toggleNotifications()
 
-			expect(mockPush.unsubscribe).toHaveBeenCalledOnce()
+			expect(mockPush.delete).toHaveBeenCalledWith('user-uuid-1')
 			expect(sut.notificationsEnabled).toBe(false)
 		})
 
 		it('prevents concurrent toggles', async () => {
-			mockPush.subscribe.mockImplementation(
-				() => new Promise((r) => setTimeout(r, 100)),
+			mockPush.create.mockImplementation(
+				() => new Promise((r) => setTimeout(() => r('ep'), 100)),
 			)
 
 			const p1 = sut.toggleNotifications()
 			const p2 = sut.toggleNotifications()
 			await Promise.all([p1, p2])
 
-			expect(mockPush.subscribe).toHaveBeenCalledOnce()
+			expect(mockPush.create).toHaveBeenCalledOnce()
+		})
+
+		it('skips toggle when userId is not yet available', async () => {
+			mockUser.current = undefined
+			sut.notificationsEnabled = false
+
+			await sut.toggleNotifications()
+
+			expect(mockPush.create).not.toHaveBeenCalled()
+			expect(mockPush.delete).not.toHaveBeenCalled()
 		})
 	})
 
@@ -180,6 +254,15 @@ describe('SettingsRoute', () => {
 			await sut.resendVerification()
 			expect(mockUser.resendEmailVerification).toHaveBeenCalledOnce()
 			expect(sut.resendSuccess).toBe(true)
+		})
+
+		it('publishes rate-limit snack on ResourceExhausted', async () => {
+			mockUser.resendEmailVerification.mockRejectedValue(
+				new ConnectError('rate limited', Code.ResourceExhausted),
+			)
+			await sut.resendVerification()
+			expect(sut.resendSuccess).toBe(false)
+			expect(mockEa.publish).toHaveBeenCalled()
 		})
 	})
 

--- a/test/routes/settings-route.spec.ts
+++ b/test/routes/settings-route.spec.ts
@@ -41,9 +41,7 @@ describe('SettingsRoute', () => {
 		signOut: ReturnType<typeof vi.fn>
 	}
 	let mockUser: {
-		current:
-			| { id: string; home?: { level1: string } }
-			| undefined
+		current: { id: string; home?: { level1: string } } | undefined
 		resendEmailVerification: ReturnType<typeof vi.fn>
 		clear: ReturnType<typeof vi.fn>
 	}


### PR DESCRIPTION
## Summary
- Fixes the push notification toggle desync bug: enabling push from the PostSignupDialog no longer shows OFF in the settings page after navigation.
- Drops the `localStorage.userNotificationsEnabled` flag entirely. Toggle state is now derived from the browser's `PushManager.getSubscription()` combined with the backend's `PushNotificationService.Get` RPC.
- Settings page **self-heals** when the browser has an active subscription but the backend row is missing — silently re-registers via `Create` with no re-prompt.
- All enable paths (PostSignupDialog, NotificationPrompt, Settings) now share a single code path and cannot "forget" to write state — the structural source of the original bug is gone.

## Breaking
- Consumes liverty-music/specification `v0.36.0` (PR #404 merged): `Subscribe`/`Unsubscribe` RPCs are removed; `Create`/`Get`/`Delete` are added. `Delete` is now scoped to the current browser only.
- BSR packages upgraded to:
  - `@buf/liverty-music_schema.bufbuild_es@1.10.0-20260414100656-ecef81c85ce8.1`
  - `@buf/liverty-music_schema.connectrpc_es@1.6.1-20260414100656-ecef81c85ce8.2`

## Depends on
- liverty-music/backend#278 (implements the new RPC surface)

## Test plan
- [x] `make lint` clean
- [x] `make test` passes (987 tests, 96 files)
- [x] TypeScript compiles against new BSR types
- [ ] Manual: enable push from PostSignupDialog → navigate to `/settings` → toggle shows ON
- [ ] Manual: delete DB row while browser keeps subscription → reload `/settings` → toggle auto-restores to ON (self-heal via Create)
- [ ] Manual: two browsers enabled → toggle OFF in browser A → browser B still receives notifications

## State matrix handled by self-heal
| Browser sub | Backend row | Toggle result |
|-------------|-------------|---------------|
| yes | yes | ON |
| yes | no | ON (self-heal via Create) |
| no | any | OFF |
| yes, expired | any | OFF (`getSubscription()` returns null for expired) |

See `specification/openspec/changes/fix-push-notification-toggle-sync/design.md` for full rationale.

Refs: liverty-music/specification#403
