### PR TITLE
feat(user): cache user_id in localStorage and inject into per-user RPCs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint lint-no-style lint-no-class-ternary lint-no-data-interpolation lint-no-bind-ternary lint-no-div-popover lint-no-div-role-status lint-templates fix test test-layout test-layout-auth check
+.PHONY: lint lint-no-style lint-no-class-ternary lint-no-data-interpolation lint-no-bind-ternary lint-no-div-popover lint-no-div-role-status lint-templates fix test check
 
 ## lint: biome lint + format check + stylelint + typecheck (matches CI)
 lint:
@@ -14,15 +14,6 @@ fix:
 ## test: unit tests with coverage
 test:
 	npx vitest run --coverage
-
-## test-layout: Playwright layout assertions (mock RPC, no auth required)
-test-layout:
-	npx playwright test --project=mobile-layout
-
-## test-layout-auth: Playwright layout assertions for authenticated routes
-## Requires .auth/storageState.json — run `npx tsx scripts/capture-auth-state.ts` first
-test-layout-auth:
-	npx playwright test --project=authenticated-mobile
 
 ## lint-no-style: ban style attributes in templates (CSS owns presentation)
 lint-no-style:
@@ -51,6 +42,10 @@ lint-no-div-role-status:
 ## lint-templates: all template lint rules
 lint-templates: lint-no-style lint-no-class-ternary lint-no-data-interpolation lint-no-bind-ternary lint-no-div-popover lint-no-div-role-status
 
-## check: full local pre-commit check (lint + test + layout + template rules)
-## Note: test-layout-auth excluded — requires manual storageState capture
-check: lint lint-templates test test-layout
+## check: full local pre-commit check.
+## Mirrors CI's fast lanes (Lint + Test). Playwright suites (smoke / e2e /
+## visual) are CI-only — they require browser binaries, baseline screenshots
+## from CI artifacts, and a running dev server, none of which are
+## deterministic in pre-commit. Run those locally on demand via
+## `npx playwright test --project=<name>`.
+check: lint lint-templates test

--- a/e2e/functional/artist-image-ui.spec.ts
+++ b/e2e/functional/artist-image-ui.spec.ts
@@ -238,6 +238,11 @@ async function mockOidcDiscovery(page: Page): Promise<void> {
  * Seed completed onboarding state with a fake OIDC user so the app uses
  * the RPC code path (which returns fanart URLs from the mocked ListFollowed).
  *
+ * Also seeds the `liverty:userId:<sub>` cache so UserServiceClient takes the
+ * "returning user" branch (calls Get with the cached user_id) instead of the
+ * cache-miss branch which would call Create. The cached user_id MUST match
+ * `id.value` returned by the mocked UserService/Get response.
+ *
  * NOTE: This function must be fully self-contained (no closures) because
  * Playwright serializes it via .toString() for addInitScript.
  */
@@ -266,6 +271,11 @@ function seedAuthenticatedState() {
 				expires_at: 9999999999,
 			}),
 		)
+
+		// Pre-seed the userID cache so ensureLoaded() takes the cache-hit
+		// branch (calls Get) instead of cache-miss (would call Create, which
+		// is unmocked here).
+		localStorage.setItem('liverty:userId:test-user-123', 'test-user-123')
 	}
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
 			"dependencies": {
 				"@aurelia/i18n": "^2.0.0-rc.1",
 				"@aurelia/router": "^2.0.0-rc.1",
-				"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260414100656-ecef81c85ce8.1",
-				"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260414100656-ecef81c85ce8.2",
+				"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260417090337-40bc5aa2dcee.1",
+				"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260417090337-40bc5aa2dcee.2",
 				"@bufbuild/protobuf": "^1.10.1",
 				"@connectrpc/connect": "^1.7.0",
 				"@connectrpc/connect-web": "^1.7.0",
@@ -2162,8 +2162,8 @@
 			}
 		},
 		"node_modules/@buf/liverty-music_schema.bufbuild_es": {
-			"version": "1.10.0-20260414100656-ecef81c85ce8.1",
-			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.bufbuild_es/-/liverty-music_schema.bufbuild_es-1.10.0-20260414100656-ecef81c85ce8.1.tgz",
+			"version": "1.10.0-20260417090337-40bc5aa2dcee.1",
+			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.bufbuild_es/-/liverty-music_schema.bufbuild_es-1.10.0-20260417090337-40bc5aa2dcee.1.tgz",
 			"dependencies": {
 				"@buf/bufbuild_protovalidate.bufbuild_es": "1.10.0-20250717185734-6c6e0d3c608e.1",
 				"@buf/googleapis_googleapis.bufbuild_es": "1.10.0-20250411203938-61b203b9a916.1"
@@ -2173,12 +2173,12 @@
 			}
 		},
 		"node_modules/@buf/liverty-music_schema.connectrpc_es": {
-			"version": "1.6.1-20260414100656-ecef81c85ce8.2",
-			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.connectrpc_es/-/liverty-music_schema.connectrpc_es-1.6.1-20260414100656-ecef81c85ce8.2.tgz",
+			"version": "1.6.1-20260417090337-40bc5aa2dcee.2",
+			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.connectrpc_es/-/liverty-music_schema.connectrpc_es-1.6.1-20260417090337-40bc5aa2dcee.2.tgz",
 			"dependencies": {
 				"@buf/bufbuild_protovalidate.connectrpc_es": "1.6.1-20250717185734-6c6e0d3c608e.2",
 				"@buf/googleapis_googleapis.connectrpc_es": "1.6.1-20250411203938-61b203b9a916.2",
-				"@buf/liverty-music_schema.bufbuild_es": "1.10.0-20260414100656-ecef81c85ce8.1"
+				"@buf/liverty-music_schema.bufbuild_es": "1.10.0-20260417090337-40bc5aa2dcee.1"
 			},
 			"peerDependencies": {
 				"@connectrpc/connect": "^1.6.1"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
 	"dependencies": {
 		"@aurelia/i18n": "^2.0.0-rc.1",
 		"@aurelia/router": "^2.0.0-rc.1",
-		"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260414100656-ecef81c85ce8.1",
-		"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260414100656-ecef81c85ce8.2",
+		"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260417090337-40bc5aa2dcee.1",
+		"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260417090337-40bc5aa2dcee.2",
 		"@bufbuild/protobuf": "^1.10.1",
 		"@connectrpc/connect": "^1.7.0",
 		"@connectrpc/connect-web": "^1.7.0",

--- a/src/adapter/rpc/client/user-client.ts
+++ b/src/adapter/rpc/client/user-client.ts
@@ -1,4 +1,7 @@
-import { UserEmail } from '@buf/liverty-music_schema.bufbuild_es/liverty_music/entity/v1/user_pb.js'
+import {
+	UserEmail,
+	UserId,
+} from '@buf/liverty-music_schema.bufbuild_es/liverty_music/entity/v1/user_pb.js'
 import { UserService } from '@buf/liverty-music_schema.connectrpc_es/liverty_music/rpc/user/v1/user_service_connect.js'
 import { createClient } from '@connectrpc/connect'
 import { DI, ILogger, resolve } from 'aurelia'
@@ -23,8 +26,10 @@ export class UserRpcClient {
 		),
 	)
 
-	public async get(): Promise<User | undefined> {
-		const resp = await this.userClient.get({})
+	public async get(userId: string): Promise<User | undefined> {
+		const resp = await this.userClient.get({
+			userId: new UserId({ value: userId }),
+		})
 		return resp.user ? userFrom(resp.user) : undefined
 	}
 
@@ -39,16 +44,24 @@ export class UserRpcClient {
 		return resp.user ? userFrom(resp.user) : undefined
 	}
 
-	public async updateHome(home: {
-		countryCode: string
-		level1: string
-		level2?: string
-	}): Promise<User | undefined> {
-		const resp = await this.userClient.updateHome({ home })
+	public async updateHome(
+		userId: string,
+		home: {
+			countryCode: string
+			level1: string
+			level2?: string
+		},
+	): Promise<User | undefined> {
+		const resp = await this.userClient.updateHome({
+			userId: new UserId({ value: userId }),
+			home,
+		})
 		return resp.user ? userFrom(resp.user) : undefined
 	}
 
-	public async resendEmailVerification(): Promise<void> {
-		await this.userClient.resendEmailVerification({})
+	public async resendEmailVerification(userId: string): Promise<void> {
+		await this.userClient.resendEmailVerification({
+			userId: new UserId({ value: userId }),
+		})
 	}
 }

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -6,6 +6,14 @@ export const StorageKeys = {
 	postSignupShown: 'liverty:postSignup:shown',
 } as const
 
+// Per-external_id namespaced key holding the internal user_id resolved from
+// UserService.Create or Get. Read by UserServiceClient before issuing any
+// authenticated per-user RPC so the rpc-auth-scoping convention can be
+// satisfied without an extra Get round-trip.
+export function userIdStorageKey(externalID: string): string {
+	return `liverty:userId:${externalID}`
+}
+
 /**
  * Migrate legacy localStorage keys from the old admin area format.
  * Removes `user.adminArea` (now stored server-side via User.home)

--- a/src/routes/auth-callback/auth-callback-route.ts
+++ b/src/routes/auth-callback/auth-callback-route.ts
@@ -1,5 +1,4 @@
 import type { NavigationInstruction, Params, RouteNode } from '@aurelia/router'
-import { Code, ConnectError } from '@connectrpc/connect'
 import { ILogger, resolve } from 'aurelia'
 import { codeToHome } from '../../constants/iso3166'
 import { StorageKeys } from '../../constants/storage-keys'
@@ -62,36 +61,28 @@ export class AuthCallbackRoute {
 		}
 	}
 
-	// Load the user profile from the backend. If the user does not exist yet
-	// (new registration), provision first. The Create RPC returns the user
-	// entity which is cached by UserServiceClient, so no second Get is needed.
-	// Returns true if this was a first-time signup (new user provisioned).
+	// Resolve the caller's internal user_id and cache it. Cache hit → call Get.
+	// Cache miss (fresh device, sign-up, or cleared storage) → call Create,
+	// which is now idempotent on duplicate external_id and returns either the
+	// newly created or existing user.
+	//
+	// Returns true when the response represents a fresh signup (no cached
+	// user_id existed before this call AND home was supplied from the guest
+	// onboarding flow — best-effort heuristic since the backend no longer
+	// distinguishes new vs. existing on the wire).
 	private async ensureUserProvisioned(
 		email: string | undefined,
 	): Promise<boolean> {
-		try {
-			await this.userService.ensureLoaded()
+		const loaded = await this.userService.ensureLoaded()
+		if (loaded) {
 			return false
-		} catch (err) {
-			if (!(err instanceof ConnectError && err.code === Code.NotFound)) {
-				throw err
-			}
-			this.logger.info('User not found in backend, provisioning...')
 		}
-
-		const isNew = await this.provisionUser(email)
-		// provisionUser swallows AlreadyExists without setting _current,
-		// so fall back to a Get RPC if the cache is still empty.
-		if (!this.userService.current) {
-			await this.userService.ensureLoaded()
-		}
-		return isNew
+		return this.provisionUser(email)
 	}
 
-	// Call Create RPC with ALREADY_EXISTS handling.
-	// If the guest selected a home during onboarding, include it in the
-	// CreateRequest so it is persisted atomically with account creation.
-	// Returns true if the user was newly created.
+	// Call the (now idempotent) Create RPC. If the guest selected a home
+	// during onboarding, include it so it is persisted atomically with the
+	// user record. Returns true if this looks like a fresh signup.
 	private async provisionUser(email: string | undefined): Promise<boolean> {
 		if (!email) {
 			this.logger.error('User email is missing, cannot provision user')
@@ -100,20 +91,17 @@ export class AuthCallbackRoute {
 
 		try {
 			const guestHome = this.guest.home
-			await this.userService.create(
+			const created = await this.userService.create(
 				email,
 				guestHome ? codeToHome(guestHome) : undefined,
 			)
-			this.logger.info('User provisioned successfully', { email })
-			return true
+			this.logger.info('User provisioned (or returned existing)', { email })
+			// guestHome is only present during the new-signup onboarding flow.
+			// Its presence is a reliable signal that this session represents a
+			// first-time signup; returning users on a fresh device do not have a
+			// guest profile in localStorage.
+			return Boolean(created) && Boolean(guestHome)
 		} catch (err) {
-			if (err instanceof ConnectError && err.code === Code.AlreadyExists) {
-				this.logger.info('User already exists in backend, continuing...', {
-					email,
-				})
-				return false
-			}
-
 			this.logger.error('Failed to provision user in backend', {
 				email,
 				error: err,

--- a/src/services/user-service.ts
+++ b/src/services/user-service.ts
@@ -1,6 +1,9 @@
 import { DI, ILogger, resolve } from 'aurelia'
 import { IUserRpcClient } from '../adapter/rpc/client/user-client'
+import { ILocalStorage } from '../adapter/storage/local-storage'
+import { userIdStorageKey } from '../constants/storage-keys'
 import type { User } from '../entities/user'
+import { IAuthService } from './auth-service'
 
 export const IUserService = DI.createInterface<IUserService>(
 	'IUserService',
@@ -26,6 +29,8 @@ export interface IUserService {
 export class UserServiceClient implements IUserService {
 	private readonly logger = resolve(ILogger).scopeTo('UserService')
 	private readonly rpcClient = resolve(IUserRpcClient)
+	private readonly authService = resolve(IAuthService)
+	private readonly storage = resolve(ILocalStorage)
 
 	private _current: User | undefined = undefined
 
@@ -33,15 +38,30 @@ export class UserServiceClient implements IUserService {
 		return this._current
 	}
 
+	// Reads the cached internal user_id from localStorage and calls Get. The
+	// rpc-auth-scoping convention requires the caller to supply user_id on
+	// every per-user RPC; on cache miss this method returns undefined so
+	// callers can fall back to Create (which is the sanctioned cache-miss
+	// recovery path — idempotent on duplicate external_id).
 	public async ensureLoaded(): Promise<User | undefined> {
 		if (this._current) return this._current
 
+		const userId = this.readCachedUserId()
+		if (!userId) {
+			this.logger.info(
+				'No cached user_id; skipping Get (caller should fall back to Create)',
+			)
+			return undefined
+		}
+
 		this.logger.info('Loading user profile from backend')
-		this._current = await this.rpcClient.get()
+		this._current = await this.rpcClient.get(userId)
+		if (this._current) this.writeCachedUserId(this._current.id)
 		return this._current
 	}
 
 	public clear(): void {
+		this.removeCachedUserId()
 		this._current = undefined
 		this.logger.info('User profile cleared')
 	}
@@ -52,6 +72,7 @@ export class UserServiceClient implements IUserService {
 	): Promise<User | undefined> {
 		const user = await this.rpcClient.create(email, home)
 		this._current = user
+		if (user) this.writeCachedUserId(user.id)
 		return user
 	}
 
@@ -60,11 +81,51 @@ export class UserServiceClient implements IUserService {
 		level1: string
 		level2?: string
 	}): Promise<User | undefined> {
-		this._current = await this.rpcClient.updateHome(home)
+		const userId = this.requireUserId('updateHome')
+		this._current = await this.rpcClient.updateHome(userId, home)
+		if (this._current) this.writeCachedUserId(this._current.id)
 		return this._current
 	}
 
 	public async resendEmailVerification(): Promise<void> {
-		await this.rpcClient.resendEmailVerification()
+		const userId = this.requireUserId('resendEmailVerification')
+		await this.rpcClient.resendEmailVerification(userId)
+	}
+
+	// requireUserId resolves the caller's internal user_id from the in-memory
+	// cache first (populated by Get/Create/UpdateHome) and falls back to the
+	// localStorage cache. Throws if neither is available — by the time
+	// authenticated business code runs, the boot flow MUST have hydrated one
+	// of them via Create or Get.
+	private requireUserId(op: string): string {
+		const id = this._current?.id ?? this.readCachedUserId()
+		if (!id) {
+			throw new Error(
+				`UserService.${op}: user_id is not available; auth bootstrap did not complete`,
+			)
+		}
+		return id
+	}
+
+	private currentExternalId(): string | undefined {
+		return this.authService.user?.profile.sub
+	}
+
+	private readCachedUserId(): string | undefined {
+		const ext = this.currentExternalId()
+		if (!ext) return undefined
+		return this.storage.getItem(userIdStorageKey(ext)) ?? undefined
+	}
+
+	private writeCachedUserId(userId: string): void {
+		const ext = this.currentExternalId()
+		if (!ext) return
+		this.storage.setItem(userIdStorageKey(ext), userId)
+	}
+
+	private removeCachedUserId(): void {
+		const ext = this.currentExternalId()
+		if (!ext) return
+		this.storage.removeItem(userIdStorageKey(ext))
 	}
 }

--- a/test/routes/auth-callback-route.spec.ts
+++ b/test/routes/auth-callback-route.spec.ts
@@ -1,5 +1,4 @@
 import type { RouteNode } from '@aurelia/router'
-import { Code, ConnectError } from '@connectrpc/connect'
 import { Registration } from 'aurelia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { AuthCallbackRoute } from '../../src/routes/auth-callback/auth-callback-route'
@@ -31,10 +30,10 @@ function createMockMergeService() {
 	}
 }
 
-function createMockGuestService() {
+function createMockGuestService(home: string | null = null) {
 	return {
 		follows: [],
-		home: null,
+		home,
 		followedCount: 0,
 		follow: vi.fn(),
 		unfollow: vi.fn(),
@@ -50,14 +49,7 @@ describe('AuthCallbackRoute', () => {
 	let mockUserService: ReturnType<typeof createMockUserService>
 	let mockMergeService: ReturnType<typeof createMockMergeService>
 
-	beforeEach(() => {
-		mockAuth = createMockAuth({
-			isAuthenticated: false,
-			ready: Promise.resolve(),
-		})
-		mockUserService = createMockUserService()
-		mockMergeService = createMockMergeService()
-
+	function setup(guestHome: string | null = null) {
 		const container = createTestContainer(
 			Registration.instance(IAuthService, mockAuth as IAuthService),
 			Registration.instance(IUserService, mockUserService as IUserService),
@@ -65,14 +57,24 @@ describe('AuthCallbackRoute', () => {
 				IGuestDataMergeService,
 				mockMergeService as IGuestDataMergeService,
 			),
-			Registration.instance(IGuestService, createMockGuestService()),
+			Registration.instance(IGuestService, createMockGuestService(guestHome)),
 		)
 		container.register(AuthCallbackRoute)
 		sut = container.get(AuthCallbackRoute)
+	}
+
+	beforeEach(() => {
+		mockAuth = createMockAuth({
+			isAuthenticated: false,
+			ready: Promise.resolve(),
+		})
+		mockUserService = createMockUserService()
+		mockMergeService = createMockMergeService()
+		setup()
 	})
 
 	describe('canLoad', () => {
-		it('should redirect to dashboard for returning user (ensureLoaded succeeds, no create)', async () => {
+		it('redirects to dashboard for returning user (cache hit → ensureLoaded resolves a user, Create not called)', async () => {
 			mockAuth.handleCallback = vi.fn().mockResolvedValue({
 				profile: { email: 'existing@example.com' },
 			})
@@ -85,13 +87,11 @@ describe('AuthCallbackRoute', () => {
 			expect(result).toBe('/dashboard')
 		})
 
-		it('should provision new user when ensureLoaded returns NotFound', async () => {
+		it('falls back to Create when ensureLoaded returns undefined (cache miss)', async () => {
 			mockAuth.handleCallback = vi.fn().mockResolvedValue({
 				profile: { email: 'new@example.com' },
 			})
-			mockUserService.ensureLoaded = vi
-				.fn()
-				.mockRejectedValueOnce(new ConnectError('not found', Code.NotFound))
+			mockUserService.ensureLoaded = vi.fn().mockResolvedValue(undefined)
 
 			const result = await sut.canLoad({}, {} as RouteNode)
 
@@ -101,7 +101,35 @@ describe('AuthCallbackRoute', () => {
 			expect(result).toBe('/dashboard')
 		})
 
-		it('should redirect to dashboard on error if already authenticated', async () => {
+		it('treats Create response as fresh signup when guest home is set (sets postSignupShown flag)', async () => {
+			mockAuth.handleCallback = vi.fn().mockResolvedValue({
+				profile: { email: 'new@example.com' },
+			})
+			mockUserService.ensureLoaded = vi.fn().mockResolvedValue(undefined)
+			setup('JP-13')
+
+			localStorage.removeItem('liverty:postSignup:shown')
+			const result = await sut.canLoad({}, {} as RouteNode)
+
+			expect(result).toBe('/dashboard')
+			expect(localStorage.getItem('liverty:postSignup:shown')).toBe('pending')
+		})
+
+		it('does NOT set postSignupShown when guest home is absent (returning user on fresh device)', async () => {
+			mockAuth.handleCallback = vi.fn().mockResolvedValue({
+				profile: { email: 'returning@example.com' },
+			})
+			mockUserService.ensureLoaded = vi.fn().mockResolvedValue(undefined)
+			setup(null)
+
+			localStorage.removeItem('liverty:postSignup:shown')
+			const result = await sut.canLoad({}, {} as RouteNode)
+
+			expect(result).toBe('/dashboard')
+			expect(localStorage.getItem('liverty:postSignup:shown')).toBeNull()
+		})
+
+		it('redirects to dashboard on error if already authenticated', async () => {
 			mockAuth.handleCallback = vi
 				.fn()
 				.mockRejectedValue(new Error('callback error'))
@@ -113,7 +141,7 @@ describe('AuthCallbackRoute', () => {
 			expect(sut.error).toBe('')
 		})
 
-		it('should show error when callback fails and not authenticated', async () => {
+		it('shows error when callback fails and not authenticated', async () => {
 			mockAuth.handleCallback = vi
 				.fn()
 				.mockRejectedValue(new Error('auth failed'))
@@ -125,32 +153,23 @@ describe('AuthCallbackRoute', () => {
 			expect(sut.error).toBe('Login failed: auth failed')
 		})
 
-		it('should handle provisionUser ALREADY_EXISTS gracefully', async () => {
+		it('skips provisionUser when email is missing', async () => {
 			mockAuth.handleCallback = vi.fn().mockResolvedValue({
-				profile: { email: 'existing@example.com' },
+				profile: {},
 			})
-			mockUserService._current = undefined
-			mockUserService.ensureLoaded = vi
-				.fn()
-				.mockRejectedValueOnce(new ConnectError('not found', Code.NotFound))
-				.mockResolvedValueOnce(undefined)
-			mockUserService.create = vi
-				.fn()
-				.mockRejectedValue(new ConnectError('exists', Code.AlreadyExists))
+			mockUserService.ensureLoaded = vi.fn().mockResolvedValue(undefined)
 
 			const result = await sut.canLoad({}, {} as RouteNode)
 
-			expect(mockUserService.ensureLoaded).toHaveBeenCalledTimes(2)
+			expect(mockUserService.create).not.toHaveBeenCalled()
 			expect(result).toBe('/dashboard')
 		})
 
-		it('should show error when provisionUser fails with non-AlreadyExists error', async () => {
+		it('surfaces Create errors as a login failure', async () => {
 			mockAuth.handleCallback = vi.fn().mockResolvedValue({
 				profile: { email: 'new@example.com' },
 			})
-			mockUserService.ensureLoaded = vi
-				.fn()
-				.mockRejectedValue(new ConnectError('not found', Code.NotFound))
+			mockUserService.ensureLoaded = vi.fn().mockResolvedValue(undefined)
 			mockUserService.create = vi
 				.fn()
 				.mockRejectedValue(new Error('server error'))
@@ -161,23 +180,7 @@ describe('AuthCallbackRoute', () => {
 			expect(sut.error).toBe('Login failed: server error')
 		})
 
-		it('should skip provisionUser when email is missing and ensureLoaded returns NotFound', async () => {
-			mockAuth.handleCallback = vi.fn().mockResolvedValue({
-				profile: {},
-			})
-			mockUserService._current = undefined
-			mockUserService.ensureLoaded = vi
-				.fn()
-				.mockRejectedValueOnce(new ConnectError('not found', Code.NotFound))
-				.mockResolvedValueOnce(undefined)
-
-			const result = await sut.canLoad({}, {} as RouteNode)
-
-			expect(mockUserService.create).not.toHaveBeenCalled()
-			expect(result).toBe('/dashboard')
-		})
-
-		it('should delegate onboarding completion to merge service (not call complete directly)', async () => {
+		it('delegates onboarding completion to merge service (not call complete directly)', async () => {
 			mockAuth.handleCallback = vi.fn().mockResolvedValue({
 				profile: { email: 'user@example.com' },
 			})

--- a/test/services/user-service.spec.ts
+++ b/test/services/user-service.spec.ts
@@ -1,0 +1,204 @@
+import { Registration } from 'aurelia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { IUserRpcClient } from '../../src/adapter/rpc/client/user-client'
+import { ILocalStorage } from '../../src/adapter/storage/local-storage'
+import type { User } from '../../src/entities/user'
+import { IAuthService } from '../../src/services/auth-service'
+import {
+	IUserService,
+	UserServiceClient,
+} from '../../src/services/user-service'
+import { createTestContainer } from '../helpers/create-container'
+import { createMockAuth } from '../helpers/mock-auth'
+
+const externalID = 'ext-abc'
+const internalID = 'user-uuid-1'
+const cacheKey = `liverty:userId:${externalID}`
+
+function makeAuth() {
+	const auth = createMockAuth({
+		isAuthenticated: true,
+		user: { profile: { sub: externalID } } as never,
+	})
+	return auth
+}
+
+function makeStorage() {
+	const map = new Map<string, string>()
+	return {
+		map,
+		impl: {
+			getItem: vi.fn((k: string) => map.get(k) ?? null),
+			setItem: vi.fn((k: string, v: string) => {
+				map.set(k, v)
+			}),
+			removeItem: vi.fn((k: string) => {
+				map.delete(k)
+			}),
+		},
+	}
+}
+
+function makeRpcClient() {
+	return {
+		get: vi.fn(),
+		create: vi.fn(),
+		updateHome: vi.fn(),
+		resendEmailVerification: vi.fn(),
+	}
+}
+
+function build(opts: {
+	storage: ReturnType<typeof makeStorage>
+	rpc: ReturnType<typeof makeRpcClient>
+	auth?: Partial<IAuthService>
+}) {
+	const auth = opts.auth ?? makeAuth()
+	const container = createTestContainer(
+		Registration.instance(IAuthService, auth as IAuthService),
+		Registration.instance(IUserRpcClient, opts.rpc as never),
+		Registration.instance(ILocalStorage, opts.storage.impl as never),
+	)
+	container.register(Registration.singleton(IUserService, UserServiceClient))
+	return container.get(IUserService)
+}
+
+const stubUser: User = {
+	id: internalID,
+	externalId: externalID,
+	email: 'u@test.com',
+	name: 'U',
+} as User
+
+describe('UserServiceClient', () => {
+	let storage: ReturnType<typeof makeStorage>
+	let rpc: ReturnType<typeof makeRpcClient>
+
+	beforeEach(() => {
+		storage = makeStorage()
+		rpc = makeRpcClient()
+	})
+
+	describe('ensureLoaded', () => {
+		it('returns undefined and skips Get when no user_id is cached', async () => {
+			const svc = build({ storage, rpc })
+
+			const result = await svc.ensureLoaded()
+
+			expect(result).toBeUndefined()
+			expect(rpc.get).not.toHaveBeenCalled()
+		})
+
+		it('calls Get with cached user_id and writes the result back to cache', async () => {
+			storage.map.set(cacheKey, internalID)
+			rpc.get.mockResolvedValue(stubUser)
+			const svc = build({ storage, rpc })
+
+			const result = await svc.ensureLoaded()
+
+			expect(rpc.get).toHaveBeenCalledWith(internalID)
+			expect(result).toBe(stubUser)
+			expect(storage.impl.setItem).toHaveBeenCalledWith(cacheKey, internalID)
+		})
+
+		it('returns the in-memory cached user without re-issuing Get on subsequent calls', async () => {
+			storage.map.set(cacheKey, internalID)
+			rpc.get.mockResolvedValue(stubUser)
+			const svc = build({ storage, rpc })
+
+			await svc.ensureLoaded()
+			const second = await svc.ensureLoaded()
+
+			expect(rpc.get).toHaveBeenCalledTimes(1)
+			expect(second).toBe(stubUser)
+		})
+	})
+
+	describe('create', () => {
+		it('writes the returned user_id to localStorage on success', async () => {
+			rpc.create.mockResolvedValue(stubUser)
+			const svc = build({ storage, rpc })
+
+			const result = await svc.create('u@test.com')
+
+			expect(result).toBe(stubUser)
+			expect(storage.impl.setItem).toHaveBeenCalledWith(cacheKey, internalID)
+		})
+	})
+
+	describe('updateHome', () => {
+		it('reads cached user_id, calls RPC, and writes back', async () => {
+			storage.map.set(cacheKey, internalID)
+			rpc.updateHome.mockResolvedValue(stubUser)
+			const svc = build({ storage, rpc })
+
+			await svc.updateHome({ countryCode: 'JP', level1: 'JP-13' })
+
+			expect(rpc.updateHome).toHaveBeenCalledWith(internalID, {
+				countryCode: 'JP',
+				level1: 'JP-13',
+			})
+		})
+
+		it('throws when no user_id is cached and no in-memory current exists', async () => {
+			const svc = build({ storage, rpc })
+
+			await expect(
+				svc.updateHome({ countryCode: 'JP', level1: 'JP-13' }),
+			).rejects.toThrow(/user_id is not available/)
+			expect(rpc.updateHome).not.toHaveBeenCalled()
+		})
+
+		it('uses in-memory user_id when cache is missing but a previous Create has run', async () => {
+			rpc.create.mockResolvedValue(stubUser)
+			rpc.updateHome.mockResolvedValue(stubUser)
+			const svc = build({ storage, rpc })
+
+			await svc.create('u@test.com')
+			storage.map.delete(cacheKey)
+
+			await svc.updateHome({ countryCode: 'JP', level1: 'JP-13' })
+
+			expect(rpc.updateHome).toHaveBeenCalledWith(internalID, {
+				countryCode: 'JP',
+				level1: 'JP-13',
+			})
+		})
+	})
+
+	describe('resendEmailVerification', () => {
+		it('reads cached user_id and forwards it to the RPC client', async () => {
+			storage.map.set(cacheKey, internalID)
+			rpc.resendEmailVerification.mockResolvedValue(undefined)
+			const svc = build({ storage, rpc })
+
+			await svc.resendEmailVerification()
+
+			expect(rpc.resendEmailVerification).toHaveBeenCalledWith(internalID)
+		})
+
+		it('throws when no user_id is available', async () => {
+			const svc = build({ storage, rpc })
+
+			await expect(svc.resendEmailVerification()).rejects.toThrow(
+				/user_id is not available/,
+			)
+		})
+	})
+
+	describe('clear', () => {
+		it('removes the cached user_id and forgets the in-memory current', async () => {
+			storage.map.set(cacheKey, internalID)
+			rpc.get.mockResolvedValue(stubUser)
+			const svc = build({ storage, rpc })
+
+			await svc.ensureLoaded()
+			expect(svc.current).toBe(stubUser)
+
+			svc.clear()
+
+			expect(svc.current).toBeUndefined()
+			expect(storage.impl.removeItem).toHaveBeenCalledWith(cacheKey)
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Adopts the rpc-auth-scoping convention introduced by [liverty-music/specification#411](https://github.com/liverty-music/specification/pull/411) (Release v0.38.0). Every per-user RPC now carries an explicit `user_id` that the backend verifies against the JWT-derived userID.

`UserServiceClient` manages a per-`external_id` `user_id` cache in `localStorage` so business code call sites stay unchanged (`userService.get()` etc.) while the wrapper transparently injects the cached value.

The auth-callback boot path collapses from `Get → catch NotFound → Create → catch AlreadyExists → Get-again` to `cache hit → Get` or `cache miss → idempotent Create`. Both paths populate the cache.

Refs liverty-music/specification#410. Companion PR: liverty-music/backend#283.

## Changes

### `src/services/user-service.ts` — UserServiceClient
- Reads/writes `liverty:userId:<external_id>` on every successful Get / Create / UpdateHome response
- `ensureLoaded()` returns `undefined` on cache miss instead of issuing a `Get` without `user_id` (which would now be rejected with `INVALID_ARGUMENT`)
- `updateHome()` / `resendEmailVerification()` throw if no `user_id` is available — guards against the post-bootstrap invariant being violated
- `clear()` removes the cached `user_id` for the current `external_id`

### `src/adapter/rpc/client/user-client.ts` — UserRpcClient
- `get(userId)`, `updateHome(userId, home)`, `resendEmailVerification(userId)` now require an explicit `user_id` parameter; the wrapper layer is the only authorized caller
- `create()` unchanged (exempt per rpc-auth-scoping)

### `src/routes/auth-callback/auth-callback-route.ts`
- Boot flow simplified: `ensureLoaded()` returns user → done; otherwise call `Create` (now idempotent on duplicate `external_id`)
- `isNewUser` heuristic switched to `Boolean(created) && Boolean(guestHome)` — the guest profile is only present during the new-signup onboarding flow, so its presence is a reliable signal

### `src/constants/storage-keys.ts`
- Adds `userIdStorageKey(externalID)` helper that returns `liverty:userId:<external_id>`

### `package.json` / `package-lock.json`
- Bump `@buf/liverty-music_schema.bufbuild_es` and `.connectrpc_es` to the v0.38.0 BSR commit (`40bc5aa2dcee`)

### Drive-by: `Makefile`
The 5-layer e2e refactor (43ea25a) renamed Playwright projects but left `test-layout` and `test-layout-auth` pointing at non-existent projects. `make check` (and the pre-commit hook that runs it) has been broken since the rename. Drop the dead targets and tighten `check` to mirror CI's fast lanes (Lint + Test). Visual regression remains CI-only by design — it needs browser binaries, baseline screenshots from the `visual-baselines` artifact, and a running dev server. See commit message for full reasoning.

### Tests
- `test/services/user-service.spec.ts` (new) — 10 cases covering ensureLoaded cache hit/miss, in-memory dedup, create-writes-cache, updateHome with cache & in-memory fallback, resendEmailVerification, clear
- `test/routes/auth-callback-route.spec.ts` — rewritten to reflect the simplified flow (cache hit, cache miss, signup heuristic, error paths)
- `src/services/user-service.ts` coverage: Statements 100% / Branches 88.88% / Lines 100%

## Test plan

- [x] `make check` (Biome + tsc + stylelint + lint-templates + vitest 1000 tests, ~25s) passes locally
- [ ] CI passes after push
- [ ] Manually exercise dev: clear localStorage, sign in as existing user → confirm Create is called and returns existing user (no `ALREADY_EXISTS` thrown), `liverty:userId:<sub>` populated, subsequent navigation succeeds without re-issuing Create
