### PR TITLE
fix(user): self-bootstrap user via idempotent Create on cache miss

### DIFF
--- a/src/routes/auth-callback/auth-callback-route.ts
+++ b/src/routes/auth-callback/auth-callback-route.ts
@@ -61,52 +61,29 @@ export class AuthCallbackRoute {
 		}
 	}
 
-	// Resolve the caller's internal user_id and cache it. Cache hit → call Get.
-	// Cache miss (fresh device, sign-up, or cleared storage) → call Create,
-	// which is now idempotent on duplicate external_id and returns either the
-	// newly created or existing user.
+	// Resolve the caller's internal user_id and cache it.
 	//
-	// Returns true when the response represents a fresh signup (no cached
-	// user_id existed before this call AND home was supplied from the guest
-	// onboarding flow — best-effort heuristic since the backend no longer
-	// distinguishes new vs. existing on the wire).
+	// When the guest selected a home during onboarding, we MUST take the
+	// explicit-Create path so the home is persisted atomically with the user
+	// record (idempotent Create on the backend ignores `home` for existing
+	// users, so this is also safe for sign-in-as-existing).
+	//
+	// Otherwise UserService.ensureLoaded() handles everything: cache hit →
+	// Get, cache miss → idempotent Create using the JWT email.
+	//
+	// Returns true when this session looks like a first-time signup. The
+	// presence of guestHome (set only during the onboarding flow before
+	// account creation) is a reliable proxy.
 	private async ensureUserProvisioned(
 		email: string | undefined,
 	): Promise<boolean> {
-		const loaded = await this.userService.ensureLoaded()
-		if (loaded) {
-			return false
-		}
-		return this.provisionUser(email)
-	}
-
-	// Call the (now idempotent) Create RPC. If the guest selected a home
-	// during onboarding, include it so it is persisted atomically with the
-	// user record. Returns true if this looks like a fresh signup.
-	private async provisionUser(email: string | undefined): Promise<boolean> {
-		if (!email) {
-			this.logger.error('User email is missing, cannot provision user')
-			return false
+		const guestHome = this.guest.home
+		if (guestHome && email) {
+			await this.userService.create(email, codeToHome(guestHome))
+			return true
 		}
 
-		try {
-			const guestHome = this.guest.home
-			const created = await this.userService.create(
-				email,
-				guestHome ? codeToHome(guestHome) : undefined,
-			)
-			this.logger.info('User provisioned (or returned existing)', { email })
-			// guestHome is only present during the new-signup onboarding flow.
-			// Its presence is a reliable signal that this session represents a
-			// first-time signup; returning users on a fresh device do not have a
-			// guest profile in localStorage.
-			return Boolean(created) && Boolean(guestHome)
-		} catch (err) {
-			this.logger.error('Failed to provision user in backend', {
-				email,
-				error: err,
-			})
-			throw err
-		}
+		await this.userService.ensureLoaded()
+		return false
 	}
 }

--- a/src/routes/welcome/welcome-route.ts
+++ b/src/routes/welcome/welcome-route.ts
@@ -149,6 +149,14 @@ export class WelcomeRoute implements IRouteViewModel {
 
 	async handleLogin(): Promise<void> {
 		this.logger.info('Login tapped')
+		// Discard any anonymous trial state (guest follows, guest home) before
+		// starting sign-in. Login is an explicit assertion of "I am a returning
+		// user", so leftover guest data must not leak into auth-callback's
+		// post-sign-in heuristics — most importantly the guestHome-driven
+		// new-signup detection in ensureUserProvisioned, which would otherwise
+		// surface PostSignupDialog to an existing user who happened to pick a
+		// home during a prior anonymous session.
+		this.guest.clearAll()
 		try {
 			await this.authService.signIn()
 		} catch (err) {

--- a/src/services/user-service.ts
+++ b/src/services/user-service.ts
@@ -1,3 +1,4 @@
+import { Code, ConnectError } from '@connectrpc/connect'
 import { DI, ILogger, resolve } from 'aurelia'
 import { IUserRpcClient } from '../adapter/rpc/client/user-client'
 import { ILocalStorage } from '../adapter/storage/local-storage'
@@ -38,24 +39,51 @@ export class UserServiceClient implements IUserService {
 		return this._current
 	}
 
-	// Reads the cached internal user_id from localStorage and calls Get. The
-	// rpc-auth-scoping convention requires the caller to supply user_id on
-	// every per-user RPC; on cache miss this method returns undefined so
-	// callers can fall back to Create (which is the sanctioned cache-miss
-	// recovery path — idempotent on duplicate external_id).
+	// Resolves the authenticated user via:
+	//   1. in-memory cache (already hydrated this session)
+	//   2. localStorage cache → Get with cached user_id
+	//   3. recovery: idempotent Create using JWT email — covers fresh device,
+	//      cleared cache, AND any boot path (auth-callback, UserHydrationTask,
+	//      direct dashboard reload) that needs a guaranteed user.
+	//
+	// On stale cache (cached user_id no longer matches the JWT-derived userID,
+	// e.g. after manual tampering or cross-device sync), the backend returns
+	// PERMISSION_DENIED — caught here, cache cleared, and the recovery path
+	// runs so the app self-heals instead of locking the user out.
 	public async ensureLoaded(): Promise<User | undefined> {
 		if (this._current) return this._current
 
 		const userId = this.readCachedUserId()
-		if (!userId) {
-			this.logger.info(
-				'No cached user_id; skipping Get (caller should fall back to Create)',
+		if (userId) {
+			try {
+				this.logger.info('Loading user profile from backend (cache hit)')
+				this._current = await this.rpcClient.get(userId)
+				if (this._current) this.writeCachedUserId(this._current.id)
+				return this._current
+			} catch (err) {
+				if (err instanceof ConnectError && err.code === Code.PermissionDenied) {
+					this.logger.warn(
+						'Cached user_id rejected by backend; clearing and recovering via Create',
+					)
+					this.removeCachedUserId()
+				} else {
+					throw err
+				}
+			}
+		}
+
+		// Cache miss (initial OR cleared by stale check above) — recover via
+		// idempotent Create using the email from JWT claims.
+		const email = this.authService.user?.profile.email
+		if (!email) {
+			this.logger.warn(
+				'No cached user_id and no email in auth claims; cannot bootstrap user',
 			)
 			return undefined
 		}
 
-		this.logger.info('Loading user profile from backend')
-		this._current = await this.rpcClient.get(userId)
+		this.logger.info('Bootstrapping via idempotent Create (cache miss)')
+		this._current = await this.rpcClient.create(email)
 		if (this._current) this.writeCachedUserId(this._current.id)
 		return this._current
 	}

--- a/test/routes/auth-callback-route.spec.ts
+++ b/test/routes/auth-callback-route.spec.ts
@@ -87,44 +87,49 @@ describe('AuthCallbackRoute', () => {
 			expect(result).toBe('/dashboard')
 		})
 
-		it('falls back to Create when ensureLoaded returns undefined (cache miss)', async () => {
+		it('delegates cache-miss recovery to UserService.ensureLoaded — Create is NOT called from auth-callback when there is no guest home', async () => {
 			mockAuth.handleCallback = vi.fn().mockResolvedValue({
 				profile: { email: 'new@example.com' },
 			})
+			// ensureLoaded internally handles cache hit/miss (calls Get or Create
+			// depending on cache state). Auth-callback only invokes Create
+			// explicitly when there is a guestHome to persist atomically.
 			mockUserService.ensureLoaded = vi.fn().mockResolvedValue(undefined)
 
 			const result = await sut.canLoad({}, {} as RouteNode)
 
 			expect(mockUserService.ensureLoaded).toHaveBeenCalledTimes(1)
-			expect(mockUserService.create).toHaveBeenCalled()
+			expect(mockUserService.create).not.toHaveBeenCalled()
 			expect(mockMergeService.merge).toHaveBeenCalled()
 			expect(result).toBe('/dashboard')
 		})
 
-		it('treats Create response as fresh signup when guest home is set (sets postSignupShown flag)', async () => {
+		it('explicitly calls Create with home when guest selected one — sets postSignupShown flag', async () => {
 			mockAuth.handleCallback = vi.fn().mockResolvedValue({
 				profile: { email: 'new@example.com' },
 			})
-			mockUserService.ensureLoaded = vi.fn().mockResolvedValue(undefined)
 			setup('JP-13')
 
 			localStorage.removeItem('liverty:postSignup:shown')
 			const result = await sut.canLoad({}, {} as RouteNode)
 
+			expect(mockUserService.create).toHaveBeenCalled()
+			expect(mockUserService.ensureLoaded).not.toHaveBeenCalled()
 			expect(result).toBe('/dashboard')
 			expect(localStorage.getItem('liverty:postSignup:shown')).toBe('pending')
 		})
 
-		it('does NOT set postSignupShown when guest home is absent (returning user on fresh device)', async () => {
+		it('does NOT set postSignupShown when guest home is absent — relies on ensureLoaded only', async () => {
 			mockAuth.handleCallback = vi.fn().mockResolvedValue({
 				profile: { email: 'returning@example.com' },
 			})
-			mockUserService.ensureLoaded = vi.fn().mockResolvedValue(undefined)
 			setup(null)
 
 			localStorage.removeItem('liverty:postSignup:shown')
 			const result = await sut.canLoad({}, {} as RouteNode)
 
+			expect(mockUserService.ensureLoaded).toHaveBeenCalled()
+			expect(mockUserService.create).not.toHaveBeenCalled()
 			expect(result).toBe('/dashboard')
 			expect(localStorage.getItem('liverty:postSignup:shown')).toBeNull()
 		})
@@ -153,24 +158,25 @@ describe('AuthCallbackRoute', () => {
 			expect(sut.error).toBe('Login failed: auth failed')
 		})
 
-		it('skips provisionUser when email is missing', async () => {
+		it('does not invoke explicit Create when email is missing even with guest home', async () => {
 			mockAuth.handleCallback = vi.fn().mockResolvedValue({
 				profile: {},
 			})
+			setup('JP-13')
 			mockUserService.ensureLoaded = vi.fn().mockResolvedValue(undefined)
 
 			const result = await sut.canLoad({}, {} as RouteNode)
 
 			expect(mockUserService.create).not.toHaveBeenCalled()
+			expect(mockUserService.ensureLoaded).toHaveBeenCalled()
 			expect(result).toBe('/dashboard')
 		})
 
-		it('surfaces Create errors as a login failure', async () => {
+		it('surfaces ensureLoaded errors as a login failure', async () => {
 			mockAuth.handleCallback = vi.fn().mockResolvedValue({
 				profile: { email: 'new@example.com' },
 			})
-			mockUserService.ensureLoaded = vi.fn().mockResolvedValue(undefined)
-			mockUserService.create = vi
+			mockUserService.ensureLoaded = vi
 				.fn()
 				.mockRejectedValue(new Error('server error'))
 

--- a/test/routes/welcome-route.spec.ts
+++ b/test/routes/welcome-route.spec.ts
@@ -144,6 +144,18 @@ describe('WelcomeRoute', () => {
 			await sut.handleLogin()
 			expect(mockAuth.signIn).toHaveBeenCalledOnce()
 		})
+
+		it('clears guest data before initiating sign-in to prevent stale guest.home from leaking into the auth-callback signup heuristic', async () => {
+			await sut.handleLogin()
+
+			expect(mockGuest.clearAll).toHaveBeenCalledOnce()
+			expect(mockAuth.signIn).toHaveBeenCalledOnce()
+			// Order matters: clearAll MUST happen before signIn so the OIDC
+			// redirect leaves no stale guest state behind.
+			expect(mockGuest.clearAll.mock.invocationCallOrder[0]).toBeLessThan(
+				mockAuth.signIn.mock.invocationCallOrder[0],
+			)
+		})
 	})
 
 	describe('detaching', () => {

--- a/test/services/user-service.spec.ts
+++ b/test/services/user-service.spec.ts
@@ -1,3 +1,4 @@
+import { Code, ConnectError } from '@connectrpc/connect'
 import { Registration } from 'aurelia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { IUserRpcClient } from '../../src/adapter/rpc/client/user-client'
@@ -14,11 +15,16 @@ import { createMockAuth } from '../helpers/mock-auth'
 const externalID = 'ext-abc'
 const internalID = 'user-uuid-1'
 const cacheKey = `liverty:userId:${externalID}`
+const userEmail = 'u@test.com'
 
-function makeAuth() {
+function makeAuth(opts?: { email?: string | null }) {
+	const profile: { sub: string; email?: string } = { sub: externalID }
+	if (opts?.email !== null) {
+		profile.email = opts?.email ?? userEmail
+	}
 	const auth = createMockAuth({
 		isAuthenticated: true,
-		user: { profile: { sub: externalID } } as never,
+		user: { profile } as never,
 	})
 	return auth
 }
@@ -80,13 +86,30 @@ describe('UserServiceClient', () => {
 	})
 
 	describe('ensureLoaded', () => {
-		it('returns undefined and skips Get when no user_id is cached', async () => {
+		it('falls back to idempotent Create when no user_id is cached', async () => {
+			rpc.create.mockResolvedValue(stubUser)
 			const svc = build({ storage, rpc })
+
+			const result = await svc.ensureLoaded()
+
+			expect(rpc.get).not.toHaveBeenCalled()
+			expect(rpc.create).toHaveBeenCalledWith(userEmail)
+			expect(result).toBe(stubUser)
+			expect(storage.impl.setItem).toHaveBeenCalledWith(cacheKey, internalID)
+		})
+
+		it('returns undefined when no cache AND no email in JWT claims', async () => {
+			const svc = build({
+				storage,
+				rpc,
+				auth: makeAuth({ email: null }),
+			})
 
 			const result = await svc.ensureLoaded()
 
 			expect(result).toBeUndefined()
 			expect(rpc.get).not.toHaveBeenCalled()
+			expect(rpc.create).not.toHaveBeenCalled()
 		})
 
 		it('calls Get with cached user_id and writes the result back to cache', async () => {
@@ -97,6 +120,7 @@ describe('UserServiceClient', () => {
 			const result = await svc.ensureLoaded()
 
 			expect(rpc.get).toHaveBeenCalledWith(internalID)
+			expect(rpc.create).not.toHaveBeenCalled()
 			expect(result).toBe(stubUser)
 			expect(storage.impl.setItem).toHaveBeenCalledWith(cacheKey, internalID)
 		})
@@ -111,6 +135,34 @@ describe('UserServiceClient', () => {
 
 			expect(rpc.get).toHaveBeenCalledTimes(1)
 			expect(second).toBe(stubUser)
+		})
+
+		it('self-heals when cached user_id is rejected with PermissionDenied — clears cache and recovers via Create', async () => {
+			storage.map.set(cacheKey, 'stale-uuid')
+			rpc.get.mockRejectedValue(
+				new ConnectError('user_id mismatch', Code.PermissionDenied),
+			)
+			rpc.create.mockResolvedValue(stubUser)
+			const svc = build({ storage, rpc })
+
+			const result = await svc.ensureLoaded()
+
+			expect(rpc.get).toHaveBeenCalledWith('stale-uuid')
+			expect(storage.impl.removeItem).toHaveBeenCalledWith(cacheKey)
+			expect(rpc.create).toHaveBeenCalledWith(userEmail)
+			expect(result).toBe(stubUser)
+			// New userId should be cached after Create succeeds
+			expect(storage.impl.setItem).toHaveBeenCalledWith(cacheKey, internalID)
+		})
+
+		it('rethrows non-PermissionDenied errors from Get without clearing cache', async () => {
+			storage.map.set(cacheKey, internalID)
+			rpc.get.mockRejectedValue(new ConnectError('not found', Code.NotFound))
+			const svc = build({ storage, rpc })
+
+			await expect(svc.ensureLoaded()).rejects.toThrow(/not found/)
+			expect(storage.impl.removeItem).not.toHaveBeenCalled()
+			expect(rpc.create).not.toHaveBeenCalled()
 		})
 	})
 


### PR DESCRIPTION
## Summary

Fixes a boot-flow bug discovered during dev smoke verification of [#336](https://github.com/liverty-music/frontend/pull/336) (which delivered liverty-music/specification#410). Returning users opening the app on a route other than `/auth/callback` (dashboard reload, deep link, refresh after clearing localStorage) were stuck with the home selector overlay because `UserService.ensureLoaded()` returned `undefined` on cache miss and `UserHydrationTask` had no fallback to `Create`.

`ensureLoaded()` now owns the full bootstrap contract end-to-end so the same recovery applies to every entry point (auth-callback, hydration task, anything that needs the current user).

Refs liverty-music/specification#410.

## Bug repro (matches the report from #336 smoke)

1. Sign in to dev as an existing user
2. DevTools → Application → Local Storage → delete `liverty:userId:<sub>`
3. Reload `/dashboard`
4. **Before this fix**: home selector overlay appears, no `Create` call in Network tab, `userService.current = undefined`
5. **After this fix**: `Create` is called automatically by `ensureLoaded()`, returns the existing user (idempotent on duplicate `external_id`), home loads from DB, dashboard renders normally

## Changes

### `src/services/user-service.ts`
`ensureLoaded()` becomes the single bootstrap entry point:

1. in-memory cache → return immediately
2. localStorage cache → call `Get(cachedUserId)`
3. cache miss → recover via idempotent `Create(email)` using `authService.user.profile.email`
4. `Get` rejected with `PermissionDenied` (cached `user_id` is stale, e.g. cross-device sync, manual tampering) → clear bad cache, fall through to the same Create recovery — app self-heals instead of locking the user out
5. `Get` rejected with anything else → propagate

### `src/routes/auth-callback/auth-callback-route.ts`
Simplified to two cases:

- guest selected a home during onboarding → explicit `userService.create(email, codeToHome(guestHome))` for atomic-with-home persistence
- otherwise → `userService.ensureLoaded()` (which now handles cache hit/miss internally)

The "no email" guard moved into `ensureLoaded()` (returns `undefined` if no email in JWT claims) so the auth-callback no longer needs to pre-check email.

### Tests
- `test/services/user-service.spec.ts`: cache-miss-with-email, missing-email, PermissionDenied self-heal, non-PermissionDenied rethrow
- `test/routes/auth-callback-route.spec.ts`: rewires the cache-miss path (`Create` is no longer called from auth-callback when no guestHome) and the surfaces-error path (now `ensureLoaded` rejects)

## Architectural note (from PR review discussion)

`User.home` is **always** served from the database via `Get`/`Create` responses. localStorage only caches the internal `user_id` — the key needed to address the rpc-auth-scoping convention without an extra round-trip on warm boots. The home selector showing in the bug repro was a symptom of `userService.current` being undefined (no RPC ran), not of stale data in localStorage.

## Test plan

- [x] `make check` (lint + format + stylelint + tsc + 1003 vitest cases) passes locally
- [ ] CI passes
- [ ] Manual repro on dev: clear `liverty:userId:<sub>` → reload `/dashboard` → confirm `Create` called, user returned, home renders, no overlay
