### PR TITLE
fix(auth): clear user cache on sign-out from auth-status component

### DIFF
--- a/src/components/auth-status.ts
+++ b/src/components/auth-status.ts
@@ -1,8 +1,10 @@
 import { ILogger, resolve } from 'aurelia'
 import { IAuthService } from '../services/auth-service'
+import { IUserService } from '../services/user-service'
 
 export class AuthStatus {
 	public readonly auth = resolve(IAuthService)
+	private readonly userService = resolve(IUserService)
 	private readonly logger = resolve(ILogger).scopeTo('AuthStatus')
 
 	public async signIn(): Promise<void> {
@@ -17,6 +19,12 @@ export class AuthStatus {
 
 	public async signOut(): Promise<void> {
 		this.logger.debug('Sign Out clicked')
+		// Drop the cached user_id (and in-memory current user) BEFORE the
+		// signoutRedirect so the localStorage entry does not outlive the
+		// session — mirrors the pattern in settings-route.signOut(). Required
+		// by the user-account-sync spec scenario "Cached userID is cleared on
+		// sign-out".
+		this.userService.clear()
 		await this.auth.signOut()
 	}
 }

--- a/test/components/auth-status.spec.ts
+++ b/test/components/auth-status.spec.ts
@@ -1,18 +1,22 @@
 import { Registration } from 'aurelia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { AuthStatus } from '../../src/components/auth-status'
 import { IAuthService } from '../../src/services/auth-service'
+import { IUserService } from '../../src/services/user-service'
 import { createTestContainer } from '../helpers/create-container'
 import { createMockAuth } from '../helpers/mock-auth'
 
 describe('AuthStatus', () => {
 	let sut: AuthStatus
 	let mockAuth: ReturnType<typeof createMockAuth>
+	let mockUserService: { clear: ReturnType<typeof vi.fn> }
 
 	beforeEach(() => {
 		mockAuth = createMockAuth()
+		mockUserService = { clear: vi.fn() }
 		const container = createTestContainer(
 			Registration.instance(IAuthService, mockAuth as IAuthService),
+			Registration.instance(IUserService, mockUserService as never),
 		)
 		container.register(AuthStatus)
 		sut = container.get(AuthStatus)
@@ -40,6 +44,20 @@ describe('AuthStatus', () => {
 
 		// Assert
 		expect(mockAuth.signOut).toHaveBeenCalled()
+	})
+
+	it('clears the user cache before signing out', async () => {
+		// Act
+		await sut.signOut()
+
+		// Assert: both called, with clear preceding signOut so the localStorage
+		// entry does not outlive the session.
+		expect(mockUserService.clear).toHaveBeenCalledOnce()
+		expect(mockAuth.signOut).toHaveBeenCalledOnce()
+		expect(mockUserService.clear.mock.invocationCallOrder[0]).toBeLessThan(
+			(mockAuth.signOut as ReturnType<typeof vi.fn>).mock
+				.invocationCallOrder[0],
+		)
 	})
 
 	it('should expose auth service for template bindings', () => {


### PR DESCRIPTION
## Summary

Sign-out paths must clear the cached `liverty:userId:<sub>` localStorage entry per the `user-account-sync` spec scenario *"Cached userID is cleared on sign-out"*. [`settings-route.signOut()`](https://github.com/liverty-music/frontend/blob/main/src/routes/settings/settings-route.ts#L196-L204) already does this; [`<auth-status>`](https://github.com/liverty-music/frontend/blob/main/src/components/auth-status.ts#L18-L21) bypassed the clear, leaving stale entries behind.

This was discovered by the `/opsx:verify` audit on the just-merged change `standardize-user-scoped-rpc-auth` (issue #410, PRs #336 / #337). Functional impact is small — cache keys are namespaced by `external_id` so entries never collide across users — but the spec is unambiguous, and consistent sign-out behavior matters for future debug / privacy work.

Refs liverty-music/specification#410.

## Why mirror `settings-route` rather than move into `AuthService.signOut()`

The natural-feeling fix is to move the `userService.clear()` call into `AuthService.signOut()` so every caller benefits automatically. That introduces a DI cycle: `UserServiceClient` already resolves `IAuthService` to read `external_id`, and adding a reverse dependency would make the graph circular. Aurelia's lazy `resolve()` may tolerate it at runtime but the architectural smell is real, and the resulting test setup gets harder.

Mirroring the settings-route pattern (`userService.clear()` → `auth.signOut()` at the call site) is a one-line per call site, no DI graph change, and the regression test asserts both invocation AND order. If a third sign-out path appears, repeat the pattern.

## Changes

### `src/components/auth-status.ts`
- Resolve `IUserService` in addition to `IAuthService`
- `signOut()` now calls `this.userService.clear()` before `this.auth.signOut()` (with comment referencing the spec scenario)

### `test/components/auth-status.spec.ts`
- Wire a `mockUserService` into the test container
- Add `clears the user cache before signing out` case asserting:
  - `clear()` called once
  - `signOut()` called once
  - `clear()` invocation order precedes `signOut()` (proves ordering, not just co-occurrence)

## Test plan

- [x] `make check` (lint + format + stylelint + tsc + 1005 vitest cases) passes locally; `auth-status.ts` coverage 100%
- [ ] CI passes
- [ ] Manual smoke on dev: sign in → DevTools confirm `liverty:userId:<sub>` exists → sign out via `<auth-status>` → confirm key removed (separate from settings-route path which already worked)
