### PR TITLE
feat(ticket,entry)!: inject user_id into Mint/ListTickets/GetMerklePath

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
 			"dependencies": {
 				"@aurelia/i18n": "^2.0.0-rc.1",
 				"@aurelia/router": "^2.0.0-rc.1",
-				"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260417090337-40bc5aa2dcee.1",
-				"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260417090337-40bc5aa2dcee.2",
+				"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260421074642-d769c71c8006.1",
+				"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260421074642-d769c71c8006.2",
 				"@bufbuild/protobuf": "^1.10.1",
 				"@connectrpc/connect": "^1.7.0",
 				"@connectrpc/connect-web": "^1.7.0",
@@ -2162,8 +2162,8 @@
 			}
 		},
 		"node_modules/@buf/liverty-music_schema.bufbuild_es": {
-			"version": "1.10.0-20260417090337-40bc5aa2dcee.1",
-			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.bufbuild_es/-/liverty-music_schema.bufbuild_es-1.10.0-20260417090337-40bc5aa2dcee.1.tgz",
+			"version": "1.10.0-20260421074642-d769c71c8006.1",
+			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.bufbuild_es/-/liverty-music_schema.bufbuild_es-1.10.0-20260421074642-d769c71c8006.1.tgz",
 			"dependencies": {
 				"@buf/bufbuild_protovalidate.bufbuild_es": "1.10.0-20250717185734-6c6e0d3c608e.1",
 				"@buf/googleapis_googleapis.bufbuild_es": "1.10.0-20250411203938-61b203b9a916.1"
@@ -2173,12 +2173,12 @@
 			}
 		},
 		"node_modules/@buf/liverty-music_schema.connectrpc_es": {
-			"version": "1.6.1-20260417090337-40bc5aa2dcee.2",
-			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.connectrpc_es/-/liverty-music_schema.connectrpc_es-1.6.1-20260417090337-40bc5aa2dcee.2.tgz",
+			"version": "1.6.1-20260421074642-d769c71c8006.2",
+			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.connectrpc_es/-/liverty-music_schema.connectrpc_es-1.6.1-20260421074642-d769c71c8006.2.tgz",
 			"dependencies": {
 				"@buf/bufbuild_protovalidate.connectrpc_es": "1.6.1-20250717185734-6c6e0d3c608e.2",
 				"@buf/googleapis_googleapis.connectrpc_es": "1.6.1-20250411203938-61b203b9a916.2",
-				"@buf/liverty-music_schema.bufbuild_es": "1.10.0-20260417090337-40bc5aa2dcee.1"
+				"@buf/liverty-music_schema.bufbuild_es": "1.10.0-20260421074642-d769c71c8006.1"
 			},
 			"peerDependencies": {
 				"@connectrpc/connect": "^1.6.1"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
 	"dependencies": {
 		"@aurelia/i18n": "^2.0.0-rc.1",
 		"@aurelia/router": "^2.0.0-rc.1",
-		"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260417090337-40bc5aa2dcee.1",
-		"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260417090337-40bc5aa2dcee.2",
+		"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260421074642-d769c71c8006.1",
+		"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260421074642-d769c71c8006.2",
 		"@bufbuild/protobuf": "^1.10.1",
 		"@connectrpc/connect": "^1.7.0",
 		"@connectrpc/connect-web": "^1.7.0",

--- a/src/adapter/rpc/client/entry-client.ts
+++ b/src/adapter/rpc/client/entry-client.ts
@@ -1,3 +1,4 @@
+import { UserId } from '@buf/liverty-music_schema.bufbuild_es/liverty_music/entity/v1/user_pb.js'
 import { EntryService } from '@buf/liverty-music_schema.connectrpc_es/liverty_music/rpc/entry/v1/entry_service_connect.js'
 import { createClient } from '@connectrpc/connect'
 import { DI, ILogger, resolve } from 'aurelia'
@@ -24,12 +25,16 @@ export class EntryRpcClient {
 
 	public async getMerklePath(
 		eventId: string,
+		userId: string,
 		signal?: AbortSignal,
 	): Promise<MerklePath> {
 		this.logger.info('Fetching Merkle path', { eventId })
 		try {
 			const response = await this.entryClient.getMerklePath(
-				{ eventId: { value: eventId } },
+				{
+					eventId: { value: eventId },
+					userId: new UserId({ value: userId }),
+				},
 				{ signal },
 			)
 			return {

--- a/src/adapter/rpc/client/ticket-client.ts
+++ b/src/adapter/rpc/client/ticket-client.ts
@@ -1,3 +1,4 @@
+import { UserId } from '@buf/liverty-music_schema.bufbuild_es/liverty_music/entity/v1/user_pb.js'
 import { TicketService } from '@buf/liverty-music_schema.connectrpc_es/liverty_music/rpc/ticket/v1/ticket_service_connect.js'
 import { createClient } from '@connectrpc/connect'
 import { DI, ILogger, resolve } from 'aurelia'
@@ -23,10 +24,16 @@ export class TicketRpcClient {
 		),
 	)
 
-	public async listTickets(signal?: AbortSignal): Promise<Ticket[]> {
+	public async listTickets(
+		userId: string,
+		signal?: AbortSignal,
+	): Promise<Ticket[]> {
 		this.logger.info('Listing tickets for current user')
 		try {
-			const response = await this.ticketClient.listTickets({}, { signal })
+			const response = await this.ticketClient.listTickets(
+				{ userId: new UserId({ value: userId }) },
+				{ signal },
+			)
 			return response.tickets.map(ticketFrom)
 		} catch (err) {
 			this.logger.warn('Ticket list failed', { error: err })

--- a/src/routes/tickets/tickets-route.ts
+++ b/src/routes/tickets/tickets-route.ts
@@ -3,6 +3,7 @@ import QRCode from 'qrcode'
 import { ITicketRpcClient } from '../../adapter/rpc/client/ticket-client'
 import type { Ticket } from '../../entities/ticket'
 import { IProofService } from '../../services/proof-service'
+import { IUserService } from '../../services/user-service'
 
 export class TicketsRoute {
 	public tickets: Ticket[] = []
@@ -18,6 +19,7 @@ export class TicketsRoute {
 	private readonly logger = resolve(ILogger).scopeTo('TicketsRoute')
 	private readonly ticketClient = resolve(ITicketRpcClient)
 	private readonly proofService = resolve(IProofService)
+	private readonly userService = resolve(IUserService)
 	private abortController: AbortController | null = null
 
 	public async loading(): Promise<void> {
@@ -26,7 +28,14 @@ export class TicketsRoute {
 		this.abortController = new AbortController()
 
 		try {
+			const userId = this.userService.current?.id
+			if (!userId) {
+				this.error = 'Not signed in.'
+				return
+			}
+
 			this.tickets = await this.ticketClient.listTickets(
+				userId,
 				this.abortController.signal,
 			)
 			this.logger.info('Tickets loaded', { count: this.tickets.length })

--- a/src/services/proof-service.ts
+++ b/src/services/proof-service.ts
@@ -33,7 +33,7 @@ export class ProofServiceClient {
 
 	public async generateEntryProof(
 		eventId: string,
-		_userId: string,
+		userId: string,
 		onProgress?: (stage: string) => void,
 		signal?: AbortSignal,
 	): Promise<ProofOutput> {
@@ -41,7 +41,11 @@ export class ProofServiceClient {
 
 		onProgress?.('Fetching Merkle path...')
 
-		const merklePath = await this.entryClient.getMerklePath(eventId, signal)
+		const merklePath = await this.entryClient.getMerklePath(
+			eventId,
+			userId,
+			signal,
+		)
 
 		const pathElements = merklePath.pathElements.map((bytes) =>
 			bytesToDecimal(bytes),

--- a/test/routes/tickets-route.spec.ts
+++ b/test/routes/tickets-route.spec.ts
@@ -6,6 +6,7 @@ import { createMockTicketService } from '../helpers/mock-ticket-service'
 
 const mockITicketRpcClient = DI.createInterface('ITicketRpcClient')
 const mockIProofService = DI.createInterface('IProofService')
+const mockIUserService = DI.createInterface('IUserService')
 
 vi.mock('../../src/adapter/rpc/client/ticket-client', () => ({
 	ITicketRpcClient: mockITicketRpcClient,
@@ -13,6 +14,10 @@ vi.mock('../../src/adapter/rpc/client/ticket-client', () => ({
 
 vi.mock('../../src/services/proof-service', () => ({
 	IProofService: mockIProofService,
+}))
+
+vi.mock('../../src/services/user-service', () => ({
+	IUserService: mockIUserService,
 }))
 
 vi.mock('qrcode', () => {
@@ -29,14 +34,17 @@ describe('TicketsRoute', () => {
 	let sut: InstanceType<typeof TicketsRoute>
 	let mockTicketService: ReturnType<typeof createMockTicketService>
 	let mockProofService: ReturnType<typeof createMockProofService>
+	let mockUserService: { current: { id: string } | undefined }
 
 	beforeEach(() => {
 		mockTicketService = createMockTicketService()
 		mockProofService = createMockProofService()
+		mockUserService = { current: { id: 'u1' } }
 
 		const container = createTestContainer(
 			Registration.instance(mockITicketRpcClient, mockTicketService),
 			Registration.instance(mockIProofService, mockProofService),
+			Registration.instance(mockIUserService, mockUserService),
 		)
 		container.register(TicketsRoute)
 		sut = container.get(TicketsRoute)
@@ -123,6 +131,15 @@ describe('TicketsRoute', () => {
 			await sut.loading()
 
 			expect(sut.error).toBe('')
+		})
+
+		it('should set "Not signed in" error when user service has no current user', async () => {
+			mockUserService.current = undefined
+
+			await sut.loading()
+
+			expect(sut.error).toBe('Not signed in.')
+			expect(mockTicketService.listTickets).not.toHaveBeenCalled()
 		})
 	})
 


### PR DESCRIPTION
## Description

Follows `liverty-music/specification#418` / v0.39.0. Implements the frontend side of the `align-ticket-rpcs-with-auth-scoping` OpenSpec change, bringing ticket/entry RPC call sites onto the `rpc-auth-scoping` convention established by `standardize-user-scoped-rpc-auth`.

**BREAKING** (frontend side of a coordinated release) — `MintTicket`, `ListTickets`, `GetMerklePath` now include a required `user_id` in the request body. The backend verifies it against the JWT-derived userID; this PR adds the client-side injection using the existing `IUserService.current.id` (populated on boot by the `standardize-user-scoped-rpc-auth` cache infrastructure).

### Code changes

- `ticket-client.listTickets(userId, signal)` — accepts the caller's internal user_id and wraps it as `entity.v1.UserId`
- `entry-client.getMerklePath(eventId, userId, signal)` — same pattern
- `tickets-route.loading()` resolves `user_id` via `IUserService.current` and renders `"Not signed in."` if the user is unavailable before the RPC fires (pre-flight bail-out so we never send a malformed request)
- `proof-service.generateEntryProof` now forwards the `userId` it already received (previously named `_userId` and unused) to `getMerklePath`
- `MintTicket` has no frontend call site yet (the ticket MVP UI has not shipped a mint button) — no code change needed

### Dependency bumps (pinned to v1 channel)

- `@buf/liverty-music_schema.bufbuild_es` → `1.10.0-20260421074642-d769c71c8006.1`
- `@buf/liverty-music_schema.connectrpc_es` → `1.6.1-20260421074642-d769c71c8006.2`

> Pinned to the v1 series because BSR's `bufbuild_es` plugin now has a v2.11 output on the default `@latest` channel, which would require a project-wide migration from `@bufbuild/protobuf@1.x` to `2.x`. That migration is out of scope here — it belongs in its own change.

### Deliberately **unchanged**

- `GetTicket` — no frontend call site (identifier-scoped anyway; spec keeps it as-is)
- `VerifyEntry` — used by the QR scanner payload; unauthenticated by design

## Type of Change

- [x] feat: A new feature
- [x] build: Changes that affect the build system or external dependencies

## Verification

### Automated Tests

- [x] `make check` passes locally (biome lint + format, stylelint, tsc, full vitest suite with coverage)
- [x] Existing `TicketsRoute.loading` tests updated to mock `IUserService.current`; new test asserts the `"Not signed in"` bail-out path does not fire the RPC
- [x] No lint or typecheck regressions

### Manual Verification

- Pending after deployment — will run the dev-env smoke test described in `openspec/changes/align-ticket-rpcs-with-auth-scoping/tasks.md` §8 (curl + real-user smoke):
  - `ListTickets` with missing `user_id` → `INVALID_ARGUMENT`
  - `GetMerklePath` with mismatched `user_id` → `PERMISSION_DENIED`
  - `/tickets` page renders + QR generation works end-to-end

## Checklist

- [x] Follows style guidelines (biome clean)
- [x] Self-review performed
- [x] Minimal change — no new abstractions, reuses existing `IUserService` cache
- [x] No new warnings (1 pre-existing stylelint warning in `bottom-sheet.css` unrelated to this change)
