### PR TITLE
feat(i18n): establish entity.* namespace and brand-vocabulary lint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
   <responsibilities>Aurelia 2 single-page PWA for music fans. Vite build, CUBE CSS methodology,
   Biome linter, Zitadel OIDC auth, Vitest + Playwright testing.</responsibilities>
   <essential-commands>
-    make lint              # Biome lint + format check + stylelint + typecheck (matches CI)
+    make lint              # Biome lint + format check + stylelint + typecheck + brand-vocabulary (matches CI)
     make fix               # Auto-fix formatting (biome check --write)
     make test              # Unit tests with coverage (vitest)
     make check             # Full pre-commit check (lint + test)

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
-.PHONY: lint lint-no-style lint-no-class-ternary lint-no-data-interpolation lint-no-bind-ternary lint-no-div-popover lint-no-div-role-status lint-templates fix test check
+.PHONY: lint lint-brand-vocabulary lint-no-style lint-no-class-ternary lint-no-data-interpolation lint-no-bind-ternary lint-no-div-popover lint-no-div-role-status lint-templates fix test check
 
-## lint: biome lint + format check + stylelint + typecheck (matches CI)
-lint:
+## lint: biome lint + format check + stylelint + typecheck + brand-vocabulary (matches CI)
+lint: lint-brand-vocabulary
 	npx biome lint src test
 	npx biome format src test
 	npm run lint:css
 	npx tsc --noEmit
+
+## lint-brand-vocabulary: enforce entity.* i18n namespace parity and known-entity rules
+lint-brand-vocabulary:
+	npx tsx scripts/check-brand-vocabulary.ts
 
 ## fix: auto-fix formatting and lint issues
 fix:

--- a/scripts/check-brand-vocabulary.ts
+++ b/scripts/check-brand-vocabulary.ts
@@ -1,0 +1,163 @@
+/**
+ * Brand-vocabulary lint: enforces invariants on the i18n `entity.*` namespace.
+ *
+ * Verifies that:
+ *   1. Every key path under `entity.*` in one locale exists in the other locale.
+ *   2. Every second-segment stem (the entity name) appears in the curated
+ *      KNOWN_ENTITY_STEMS list.
+ *
+ * Asymmetric values (different surface labels per locale, e.g. JA "Stage" vs
+ * EN "Hype" for `entity.hype.label`) are intentionally permitted and not
+ * flagged — that is normal localization, not drift.
+ *
+ * Exits 0 on success, 1 on failure. Run via `npx tsx scripts/check-brand-vocabulary.ts`.
+ */
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { KNOWN_ENTITY_STEMS } from './known-entities'
+
+const REPO_ROOT = path.join(import.meta.dirname, '..')
+const JA_TRANSLATION_PATH = path.join(
+	REPO_ROOT,
+	'src/locales/ja/translation.json',
+)
+const EN_TRANSLATION_PATH = path.join(
+	REPO_ROOT,
+	'src/locales/en/translation.json',
+)
+
+type EntityTree = Record<string, unknown>
+
+/**
+ * Extract the `entity` subtree from a parsed translation JSON. Returns an
+ * empty object when the namespace is absent or empty. Throws when the
+ * namespace exists but is not a plain object.
+ */
+export function extractEntityTree(parsed: unknown): EntityTree {
+	if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+		throw new Error('translation file root must be a JSON object')
+	}
+	const entity = (parsed as Record<string, unknown>).entity
+	if (entity === undefined) return {}
+	if (entity === null || typeof entity !== 'object' || Array.isArray(entity)) {
+		throw new Error('top-level "entity" must be an object')
+	}
+	return entity as EntityTree
+}
+
+/**
+ * Recursively flatten an entity subtree into dot-delimited key paths
+ * (relative to `entity`, so "hype.label", "hype.values.watch", etc.).
+ * Leaf values are strings; non-string leaves are rejected.
+ */
+export function collectKeyPaths(node: unknown, prefix = ''): string[] {
+	if (typeof node === 'string') {
+		if (prefix === '') {
+			throw new Error('entity tree root may not be a string')
+		}
+		return [prefix]
+	}
+	if (node === null || typeof node !== 'object' || Array.isArray(node)) {
+		throw new Error(
+			`entity.${prefix || '(root)'}: must be an object or string, got ${
+				Array.isArray(node) ? 'array' : typeof node
+			}`,
+		)
+	}
+	const out: string[] = []
+	for (const [k, v] of Object.entries(node)) {
+		const next = prefix ? `${prefix}.${k}` : k
+		out.push(...collectKeyPaths(v, next))
+	}
+	return out
+}
+
+/** Locale parity: every key in one locale must exist in the other. */
+export function checkParity(
+	jaPaths: ReadonlySet<string>,
+	enPaths: ReadonlySet<string>,
+): string[] {
+	const errors: string[] = []
+	for (const p of jaPaths) {
+		if (!enPaths.has(p)) {
+			errors.push(
+				`entity.${p}: present in ja/translation.json but missing in en/translation.json`,
+			)
+		}
+	}
+	for (const p of enPaths) {
+		if (!jaPaths.has(p)) {
+			errors.push(
+				`entity.${p}: present in en/translation.json but missing in ja/translation.json`,
+			)
+		}
+	}
+	return errors
+}
+
+/** Every second-segment stem must be a known entity. */
+export function checkKnownEntities(
+	allPaths: ReadonlySet<string>,
+	known: ReadonlySet<string> = KNOWN_ENTITY_STEMS,
+): string[] {
+	const errors: string[] = []
+	const seen = new Set<string>()
+	for (const p of allPaths) {
+		const stem = p.split('.')[0]
+		if (seen.has(stem)) continue
+		seen.add(stem)
+		if (!known.has(stem)) {
+			errors.push(
+				`entity.${stem}: unknown entity stem (add it to scripts/known-entities.ts if it corresponds to a real protobuf entity)`,
+			)
+		}
+	}
+	return errors
+}
+
+/** Pure validation pipeline — exposed for unit tests. */
+export function validate(
+	jaParsed: unknown,
+	enParsed: unknown,
+	known: ReadonlySet<string> = KNOWN_ENTITY_STEMS,
+): string[] {
+	const jaTree = extractEntityTree(jaParsed)
+	const enTree = extractEntityTree(enParsed)
+	const jaPaths = new Set(collectKeyPaths(jaTree))
+	const enPaths = new Set(collectKeyPaths(enTree))
+	const errors: string[] = []
+	errors.push(...checkParity(jaPaths, enPaths))
+	const all = new Set<string>([...jaPaths, ...enPaths])
+	errors.push(...checkKnownEntities(all, known))
+	return errors
+}
+
+function readJson(filePath: string): unknown {
+	const raw = fs.readFileSync(filePath, 'utf-8')
+	return JSON.parse(raw)
+}
+
+function main(): void {
+	const jaParsed = readJson(JA_TRANSLATION_PATH)
+	const enParsed = readJson(EN_TRANSLATION_PATH)
+	const errors = validate(jaParsed, enParsed)
+
+	if (errors.length > 0) {
+		console.error('brand-vocabulary lint failed:')
+		for (const e of errors) {
+			console.error(`  - ${e}`)
+		}
+		process.exit(1)
+	}
+
+	const jaTree = extractEntityTree(jaParsed)
+	const count = collectKeyPaths(jaTree).length
+	console.log(
+		`brand-vocabulary lint OK (${count} entity.* keys verified across JA + EN)`,
+	)
+}
+
+// Only execute when invoked as the entry script, not when imported by tests.
+if (import.meta.url === `file://${process.argv[1]}`) {
+	main()
+}

--- a/scripts/known-entities.ts
+++ b/scripts/known-entities.ts
@@ -1,0 +1,25 @@
+/**
+ * Curated list of entity stems permitted under the i18n `entity.*` namespace.
+ *
+ * Each stem corresponds to a protobuf entity defined in the specification repo
+ * (`liverty-music/specification:proto/liverty_music/entity/v1/`). The stem is
+ * derived from the entity name per the brand-vocabulary spec mirroring rule:
+ *
+ *   - `HypeLevel` (enum, drops the `Level` suffix) → `hype`
+ *   - `Concert`   (message)                        → `concert`
+ *   - `Artist`    (message)                        → `artist`
+ *   - `User.HomeArea` (nested concept)             → `homeArea`
+ *
+ * When a new protobuf entity needs a UI label, add its stem here in the same
+ * change that introduces the label. The brand-vocabulary lint script exits
+ * non-zero if an `entity.<unknown>` key appears.
+ */
+export const KNOWN_ENTITY_STEMS: ReadonlySet<string> = new Set([
+	'hype',
+	'concert',
+	'artist',
+	'homeArea',
+	'user',
+	'venue',
+	'event',
+])

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -3,6 +3,7 @@
 		"dismiss": "Dismiss",
 		"createAccount": "Create Account"
 	},
+	"entity": {},
 	"welcome": {
 		"hero": {
 			"title": "Never miss a live show from the bands you love.",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -3,6 +3,7 @@
 		"dismiss": "閉じる",
 		"createAccount": "アカウント作成"
 	},
+	"entity": {},
 	"welcome": {
 		"hero": {
 			"title": "大好きなあのバンドのライブ、もう二度と見逃さない。",

--- a/test/scripts/check-brand-vocabulary.spec.ts
+++ b/test/scripts/check-brand-vocabulary.spec.ts
@@ -1,0 +1,134 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vitest'
+import {
+	checkKnownEntities,
+	checkParity,
+	collectKeyPaths,
+	extractEntityTree,
+	validate,
+} from '../../scripts/check-brand-vocabulary'
+
+const KNOWN = new Set(['hype', 'concert'])
+
+describe('extractEntityTree', () => {
+	it('returns the entity subtree when present', () => {
+		const tree = extractEntityTree({ entity: { hype: { label: 'Stage' } } })
+		expect(tree).toEqual({ hype: { label: 'Stage' } })
+	})
+
+	it('returns an empty object when entity namespace is absent', () => {
+		expect(extractEntityTree({ welcome: {} })).toEqual({})
+	})
+
+	it('throws when entity is not an object', () => {
+		expect(() => extractEntityTree({ entity: 'oops' })).toThrow(
+			/must be an object/,
+		)
+		expect(() => extractEntityTree({ entity: [] })).toThrow(/must be an object/)
+		expect(() => extractEntityTree({ entity: null })).toThrow(
+			/must be an object/,
+		)
+	})
+
+	it('throws when root is not an object', () => {
+		expect(() => extractEntityTree(null)).toThrow(/must be a JSON object/)
+		expect(() => extractEntityTree('hi')).toThrow(/must be a JSON object/)
+	})
+})
+
+describe('collectKeyPaths', () => {
+	it('flattens a nested entity tree into dot-delimited paths', () => {
+		const paths = collectKeyPaths({
+			hype: {
+				label: 'Stage',
+				values: { watch: 'Watching', home: 'Home' },
+			},
+			concert: { label: 'ライブ' },
+		})
+		expect(paths.sort()).toEqual([
+			'concert.label',
+			'hype.label',
+			'hype.values.home',
+			'hype.values.watch',
+		])
+	})
+
+	it('returns an empty array for an empty tree', () => {
+		expect(collectKeyPaths({})).toEqual([])
+	})
+
+	it('rejects array nodes', () => {
+		expect(() => collectKeyPaths({ hype: ['Stage'] })).toThrow(/got array/)
+	})
+
+	it('rejects non-string leaves', () => {
+		expect(() => collectKeyPaths({ hype: { label: 42 } })).toThrow(/got number/)
+	})
+})
+
+describe('checkParity', () => {
+	it('returns no errors when both locales have the same key set', () => {
+		const same = new Set(['hype.label', 'hype.values.watch'])
+		expect(checkParity(same, same)).toEqual([])
+	})
+
+	it('reports keys present in JA but missing in EN', () => {
+		const ja = new Set(['hype.label', 'hype.values.watch'])
+		const en = new Set(['hype.label'])
+		const errors = checkParity(ja, en)
+		expect(errors).toHaveLength(1)
+		expect(errors[0]).toMatch(/entity\.hype\.values\.watch/)
+		expect(errors[0]).toMatch(/missing in en/)
+	})
+
+	it('reports keys present in EN but missing in JA', () => {
+		const ja = new Set(['hype.label'])
+		const en = new Set(['hype.label', 'hype.values.away'])
+		const errors = checkParity(ja, en)
+		expect(errors).toHaveLength(1)
+		expect(errors[0]).toMatch(/entity\.hype\.values\.away/)
+		expect(errors[0]).toMatch(/missing in ja/)
+	})
+})
+
+describe('checkKnownEntities', () => {
+	it('returns no errors when every stem is known', () => {
+		const paths = new Set(['hype.label', 'concert.label'])
+		expect(checkKnownEntities(paths, KNOWN)).toEqual([])
+	})
+
+	it('reports unknown stems', () => {
+		const paths = new Set(['hype.label', 'mystery.label'])
+		const errors = checkKnownEntities(paths, KNOWN)
+		expect(errors).toHaveLength(1)
+		expect(errors[0]).toMatch(/entity\.mystery/)
+		expect(errors[0]).toMatch(/unknown entity stem/)
+	})
+
+	it('reports each unknown stem only once', () => {
+		const paths = new Set(['mystery.label', 'mystery.values.foo'])
+		const errors = checkKnownEntities(paths, KNOWN)
+		expect(errors).toHaveLength(1)
+	})
+})
+
+describe('validate (end-to-end pipeline)', () => {
+	it('passes when entity is empty in both locales', () => {
+		expect(validate({ entity: {} }, { entity: {} }, KNOWN)).toEqual([])
+	})
+
+	it('passes when locales agree on key set with asymmetric values', () => {
+		const ja = { entity: { hype: { label: 'Stage' } } }
+		const en = { entity: { hype: { label: 'Hype' } } }
+		expect(validate(ja, en, KNOWN)).toEqual([])
+	})
+
+	it('aggregates parity and known-entity violations', () => {
+		const ja = { entity: { hype: { label: 'Stage' }, mystery: { label: 'X' } } }
+		const en = { entity: { hype: { label: 'Hype' } } }
+		const errors = validate(ja, en, KNOWN)
+		expect(errors.some((e) => /entity\.mystery\.label/.test(e))).toBe(true)
+		expect(errors.some((e) => /entity\.mystery: unknown/.test(e))).toBe(true)
+	})
+})


### PR DESCRIPTION
## Summary

- Adds an empty `"entity": {}` namespace scaffold to both JA and EN translation JSONs (no migration of existing keys yet — that's a follow-up)
- New `scripts/check-brand-vocabulary.ts` lint enforces locale parity for `entity.*` keys and validates each second-segment stem against a curated entity list (`scripts/known-entities.ts`)
- Asymmetric values across locales are intentionally permitted — the lint silent on value differences (e.g. JA "Stage" vs EN "Hype" for `entity.hype.label`)
- Wires `lint-brand-vocabulary` into `make lint` so violations block CI
- 17 new unit tests cover parity, known-entity, and end-to-end paths
- Updates AGENTS.md `<essential-commands>` to mention the new lint step

Closes #343
Spec: liverty-music/specification#430

## Test plan

- [x] `make lint` passes (biome + stylelint + typecheck + brand-vocabulary)
- [x] `make check` passes (1028 tests including 17 new lint-script tests)
- [x] `npx tsx scripts/check-brand-vocabulary.ts` reports `OK (0 entity.* keys verified across JA + EN)` against the empty scaffold
- [ ] CI passes
