### PR TITLE
fix(e2e): update OIDC mock in artist-image-ui to new Zitadel authority

### DIFF
--- a/e2e/functional/artist-image-ui.spec.ts
+++ b/e2e/functional/artist-image-ui.spec.ts
@@ -254,8 +254,9 @@ function seedAuthenticatedState() {
 
 		// Fake OIDC user stored by oidc-client-ts WebStorageStateStore
 		// Key format: {prefix}user:{authority}:{client_id} (default prefix: "oidc.")
+		// MUST match runtime config in .env (VITE_ZITADEL_ISSUER + VITE_ZITADEL_CLIENT_ID).
 		const oidcKey =
-			'oidc.user:https://dev-svijfm.us1.zitadel.cloud:358723495233859681'
+			'oidc.user:https://auth.dev.liverty-music.app:370552773634163460'
 		localStorage.setItem(
 			oidcKey,
 			JSON.stringify({

--- a/e2e/functional/artist-image-ui.spec.ts
+++ b/e2e/functional/artist-image-ui.spec.ts
@@ -21,8 +21,8 @@ const FANART_BG_URL =
 const FANART_THUMB_URL =
 	'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
 
-const OIDC_AUTHORITY = 'https://dev-svijfm.us1.zitadel.cloud'
-const OIDC_CLIENT_ID = '358723495233859681'
+const OIDC_AUTHORITY = 'https://auth.dev.liverty-music.app'
+const OIDC_CLIENT_ID = '370552773634163460'
 
 const tomorrow = new Date()
 tomorrow.setDate(tomorrow.getDate() + 1)


### PR DESCRIPTION
## Summary

- Two-line fix in `e2e/functional/artist-image-ui.spec.ts`: update the hardcoded `OIDC_AUTHORITY` and `OIDC_CLIENT_ID` constants to match the runtime Zitadel config introduced in #342
- Without this, the OIDC discovery mock never matches, real OIDC discovery calls leak through, auth never initializes, the dashboard never loads RPC data, and `[data-live-card]` never resolves — failing all 4 tests in this file
- Discovered while running CI on #344 (the first PR after #342 to touch enough files to trigger Smoke; #342 itself only modified `.env`, which the `dorny/paths-filter` `changes` job skipped)

Closes #346

## Test plan

- [x] `make lint` passes
- [x] `make check` passes (no new tests; this only changes hardcoded constants in an existing E2E spec)
- [ ] Smoke job passes the artist-image-ui tests (5.1a / 5.1b / 5.2a / 5.2b)
- [ ] All required CI checks green
