### PR TITLE
fix(scripts): swallow SecurityError during OIDC redirect polling

### DIFF
--- a/scripts/capture-auth-state.ts
+++ b/scripts/capture-auth-state.ts
@@ -16,9 +16,10 @@
  * to complete the OIDC login flow. Once authenticated, it saves the browser
  * state to .auth/storageState.json for use with Playwright MCP.
  */
-import { chromium } from '@playwright/test'
+
 import * as fs from 'node:fs'
 import * as path from 'node:path'
+import { chromium } from '@playwright/test'
 
 const APP_URL = process.env.APP_URL || 'http://localhost:9000'
 const OUTPUT_DIR = path.join(import.meta.dirname, '..', '.auth')
@@ -40,22 +41,36 @@ async function captureAuthState(): Promise<void> {
 	console.log('Please complete the login flow in the browser window.')
 	console.log('Waiting for authentication to complete...')
 	console.log('(Checking storage every 1 second for oidc.user: key...)')
-	console.log('⚠️  DO NOT CLOSE THE BROWSER - wait for "Storage state saved" message')
+	console.log(
+		'⚠️  DO NOT CLOSE THE BROWSER - wait for "Storage state saved" message',
+	)
 
 	// Wait for the app to redirect after successful OIDC login.
-	// oidc-client-ts can use either localStorage or sessionStorage
+	// oidc-client-ts can use either localStorage or sessionStorage.
+	// Some intermediate pages (Zitadel Login V2 UI, about:blank during redirects)
+	// throw SecurityError when reading storage — swallow those and keep polling.
 	await page.waitForFunction(
 		() => {
-			const localKeys = Object.keys(localStorage)
-			const sessionKeys = Object.keys(sessionStorage)
-			const userKey =
-				localKeys.find((key) => key.startsWith('oidc.user:')) ||
-				sessionKeys.find((key) => key.startsWith('oidc.user:'))
-			if (!userKey) {
-				console.log(`[${new Date().toISOString()}] localStorage:`, localKeys.join(', ') || '(empty)')
-				console.log(`[${new Date().toISOString()}] sessionStorage:`, sessionKeys.join(', ') || '(empty)')
+			try {
+				const localKeys = Object.keys(localStorage)
+				const sessionKeys = Object.keys(sessionStorage)
+				const userKey =
+					localKeys.find((key) => key.startsWith('oidc.user:')) ||
+					sessionKeys.find((key) => key.startsWith('oidc.user:'))
+				if (!userKey) {
+					console.log(
+						`[${new Date().toISOString()}] localStorage:`,
+						localKeys.join(', ') || '(empty)',
+					)
+					console.log(
+						`[${new Date().toISOString()}] sessionStorage:`,
+						sessionKeys.join(', ') || '(empty)',
+					)
+				}
+				return userKey !== undefined
+			} catch {
+				return false
 			}
-			return userKey !== undefined
 		},
 		{ polling: 1000 }, // Check every 1 second (timeout set at page level)
 	)
@@ -66,9 +81,7 @@ async function captureAuthState(): Promise<void> {
 
 	console.log(`Storage state saved to ${OUTPUT_PATH}`)
 	console.log('You can now use this with Playwright MCP:')
-	console.log(
-		'  --isolated --storage-state=.auth/storageState.json',
-	)
+	console.log('  --isolated --storage-state=.auth/storageState.json')
 
 	await browser.close()
 }


### PR DESCRIPTION
## Summary

`scripts/capture-auth-state.ts` polls `localStorage` / `sessionStorage` waiting for the `oidc.user:` key. Intermediate pages during the OIDC dance — Zitadel Login V2 UI cross-origin frames, `about:blank` during redirects — throw `SecurityError` when `Object.keys()` touches storage on a page the script can't see. The throw aborts the `waitForFunction` polling cycle, causing the capture flow to time out before the redirect lands on the app origin where storage is readable.

Wrap the polling body with try/catch and return `false` on any thrown error. The poll keeps running until storage becomes accessible on the app's own origin.

## Refs

- liverty-music/frontend#345 — broader E2E password test user + WSL2-friendly capture flow. This PR is a small standalone hardening of the existing script that is independently useful regardless of how #345 resolves.

## Test plan

- [x] `make check` (Biome lint + format + stylelint + tsc + 1026 vitest tests) → green locally
- [ ] Smoke-test the script after merge: rerun `npx tsx scripts/capture-auth-state.ts` against `auth.dev.liverty-music.app` and confirm the polling no longer aborts mid-redirect

## Note on diff size

The PR includes a small amount of auto-format drift that biome surfaced (import order, long-line wraps in surrounding `console.log` calls). Kept in scope because the file was already being touched and reverting the format-only changes would just trigger them again on the next biome run.
