### PR TITLE
feat(i18n): refine onboarding copy and migrate hype.* to entity.hype.*

### DIFF
--- a/e2e/functional/onboarding-flow.spec.ts
+++ b/e2e/functional/onboarding-flow.spec.ts
@@ -295,13 +295,14 @@ test.describe('Onboarding tutorial flow', () => {
 		).toBeAttached({ timeout: 5000 })
 	})
 
-	test('Step 0: preview peek is visible in the initial viewport', async ({
+	test('Step 0: Screen 2 sits at or below the fold on initial load', async ({
 		page,
 	}) => {
 		await page.goto('http://localhost:9000/')
 
-		// Screen 2 is attached and its top edge intersects the initial viewport
-		// (the ~5svh peek).
+		// Hero is now full-viewport (100svh). Screen 2 is attached but its top
+		// edge sits at or beyond the fold; the explicit `↓ サンプルを覗く` CTA
+		// carries the "more below" affordance instead of a partial peek.
 		const screen2 = page.locator('.welcome-screen-2')
 		await expect(screen2).toBeAttached({ timeout: 10_000 })
 
@@ -309,9 +310,7 @@ test.describe('Onboarding tutorial flow', () => {
 		const box = await screen2.boundingBox()
 		expect(box).not.toBeNull()
 		if (box && viewport) {
-			// Top edge of Screen 2 is within the viewport (not scrolled past it).
-			expect(box.y).toBeGreaterThan(0)
-			expect(box.y).toBeLessThan(viewport.height)
+			expect(box.y).toBeGreaterThanOrEqual(viewport.height)
 		}
 	})
 

--- a/e2e/functional/onboarding-flow.spec.ts
+++ b/e2e/functional/onboarding-flow.spec.ts
@@ -248,19 +248,19 @@ test.describe('Onboarding tutorial flow', () => {
 	}) => {
 		await page.goto('http://localhost:9000/')
 
-		// Screen 1 shows the [See how it works] scroll-affordance, not [Get Started]
+		// Screen 1 shows the [See how it works] scroll-affordance, not [Pick your artists]
 		const scrollCta = page.locator('.welcome-scroll-cta')
 		await expect(scrollCta).toBeVisible({ timeout: 10_000 })
 
-		// [Get Started] is attached (in Screen 2) but not within the initial
+		// [Pick your artists] is attached (in Screen 2) but not within the initial
 		// viewport — assert it exists via toBeAttached (DOM) and does NOT satisfy
 		// toBeInViewport (visual position).
-		const getStarted = page.locator('button').filter({ hasText: /get started/i }).first()
+		const getStarted = page.locator('button').filter({ hasText: /pick your artists/i }).first()
 		await expect(getStarted).toBeAttached()
 		await expect(getStarted).not.toBeInViewport()
 	})
 
-	test('Step 0 → Step 1: tapping See how it works scrolls to Screen 2, then Get Started navigates to Discover', async ({
+	test('Step 0 → Step 1: tapping See how it works scrolls to Screen 2, then Pick your artists navigates to Discover', async ({
 		page,
 	}) => {
 		await page.goto('http://localhost:9000/')
@@ -268,17 +268,17 @@ test.describe('Onboarding tutorial flow', () => {
 		// Tap scroll affordance on Screen 1
 		await page.locator('.welcome-scroll-cta').click()
 
-		// Screen 2's Get Started becomes visible after the smooth scroll completes
+		// Screen 2's primary CTA becomes visible after the smooth scroll completes
 		const getStarted = page
 			.locator('.welcome-screen-2 button')
-			.filter({ hasText: /get started/i })
+			.filter({ hasText: /pick your artists/i })
 		await expect(getStarted).toBeInViewport({ timeout: 3000 })
 
 		await getStarted.click()
 		await expect(page).toHaveURL(/discover/, { timeout: 10_000 })
 	})
 
-	test('Completed: welcome page still exposes Get Started on Screen 2', async ({
+	test('Completed: welcome page still exposes the primary CTA on Screen 2', async ({
 		page,
 	}) => {
 		await page.addInitScript(() => {
@@ -286,12 +286,12 @@ test.describe('Onboarding tutorial flow', () => {
 		})
 		await page.goto('http://localhost:9000/')
 
-		// Screen 2's Get Started is attached (accessible via scroll) even if not
+		// Screen 2's primary CTA is attached (accessible via scroll) even if not
 		// currently in viewport.
 		await expect(
 			page
 				.locator('.welcome-screen-2 button')
-				.filter({ hasText: /get started/i }),
+				.filter({ hasText: /pick your artists/i }),
 		).toBeAttached({ timeout: 5000 })
 	})
 
@@ -350,10 +350,10 @@ test.describe('Onboarding tutorial flow', () => {
 
 		await page.goto('http://localhost:9000/')
 
-		// In the fallback state, [Get Started] renders inline on Screen 1 and is
+		// In the fallback state, [Pick your artists] renders inline on Screen 1 and is
 		// visible in the initial viewport.
 		await expect(
-			page.locator('button').filter({ hasText: /get started/i }).first(),
+			page.locator('button').filter({ hasText: /pick your artists/i }).first(),
 		).toBeVisible({ timeout: 5000 })
 
 		// Preview section is absent (if.bind="dateGroups.length > 0")

--- a/src/adapter/view/hype-display.ts
+++ b/src/adapter/view/hype-display.ts
@@ -2,11 +2,13 @@ import type { Hype } from '../../entities/follow'
 
 /**
  * Display metadata for each hype tier.
- * Maps hype values to their UI label key and icon.
+ * Maps hype values to their UI label key and icon. Labels live in the
+ * canonical `entity.hype.values.*` i18n namespace per the brand-vocabulary
+ * capability mirror rule.
  */
 export const HYPE_TIERS: Record<Hype, { labelKey: string; icon: string }> = {
-	watch: { labelKey: 'myArtists.table.watch', icon: '👀' },
-	home: { labelKey: 'myArtists.table.home', icon: '🔥' },
-	nearby: { labelKey: 'myArtists.table.nearby', icon: '🔥🔥' },
-	away: { labelKey: 'myArtists.table.away', icon: '🔥🔥🔥' },
+	watch: { labelKey: 'entity.hype.values.watch', icon: '👀' },
+	home: { labelKey: 'entity.hype.values.home', icon: '🔥' },
+	nearby: { labelKey: 'entity.hype.values.nearby', icon: '🔥🔥' },
+	away: { labelKey: 'entity.hype.values.away', icon: '🔥🔥🔥' },
 }

--- a/src/components/bottom-nav-bar/bottom-nav-bar.css
+++ b/src/components/bottom-nav-bar/bottom-nav-bar.css
@@ -37,6 +37,8 @@
 		}
 
 		.nav-tab {
+			position: relative;
+
 			display: flex;
 			flex: 1;
 			flex-direction: column;
@@ -51,21 +53,6 @@
 				box-shadow var(--transition-normal);
 		}
 
-		.nav-tab[data-active="true"] {
-			color: var(--color-brand-accent);
-			box-shadow: inset 0 2px 8px
-				oklch(from var(--color-brand-accent) l c h / 20%);
-		}
-
-		.nav-tab[data-active="false"] {
-			color: var(--color-text-muted);
-		}
-
-		.nav-tab[data-dimmed] {
-			opacity: 0.3;
-			transition: opacity var(--transition-normal);
-		}
-
 		.nav-icon {
 			inline-size: 1.25rem;
 			block-size: 1.25rem;
@@ -75,6 +62,41 @@
 			font-size: var(--step--2);
 			font-weight: 500;
 			line-height: var(--leading-none);
+		}
+
+		/* Active tab: 3-layer treatment so "current page" reads instantly:
+		   1) brand-accent color, 2) bolder label weight,
+		   3) a 2px accent bar at the top edge as a visual anchor. */
+		.nav-tab[data-active="true"] {
+			color: var(--color-brand-accent);
+			box-shadow: inset 0 2px 8px
+				oklch(from var(--color-brand-accent) l c h / 20%);
+
+			&::before {
+				content: "";
+
+				position: absolute;
+				inset-block-start: 0;
+				inset-inline: 25%;
+
+				block-size: 2px;
+				border-radius: 0 0 var(--radius-sm) var(--radius-sm);
+
+				background: var(--color-brand-accent);
+			}
+
+			& .nav-label {
+				font-weight: 700;
+			}
+		}
+
+		.nav-tab[data-active="false"] {
+			color: var(--color-text-muted);
+		}
+
+		.nav-tab[data-dimmed] {
+			opacity: 0.3;
+			transition: opacity var(--transition-normal);
 		}
 	}
 }

--- a/src/components/bottom-sheet/bottom-sheet.css
+++ b/src/components/bottom-sheet/bottom-sheet.css
@@ -119,7 +119,6 @@
 			 * regression guard is the artist-filter chip-check E2E test.
 			 */
 			contain: layout;
-
 			overflow-y: auto;
 
 			max-block-size: 90dvh;

--- a/src/components/bottom-sheet/bottom-sheet.css
+++ b/src/components/bottom-sheet/bottom-sheet.css
@@ -131,7 +131,14 @@
 		.handle-bar {
 			display: flex;
 			justify-content: center;
-			padding-block: var(--space-2xs) var(--space-3xs);
+
+			/* Bottom padding establishes a baseline gap between the handle
+			   and the slotted content so consumers that don't add their
+			   own top padding (e.g. user-home-selector) still get
+			   breathing room. Consumers that DO add their own top padding
+			   (post-signup-dialog, page-help) keep their tighter / looser
+			   tone on top of this baseline. */
+			padding-block: var(--space-2xs) var(--space-xs);
 
 			&::after {
 				content: "";

--- a/src/components/page-header/page-header.css
+++ b/src/components/page-header/page-header.css
@@ -24,8 +24,8 @@
 				flex: 1;
 
 				font-family: var(--font-display);
-				font-size: var(--step-1);
-				font-weight: normal;
+				font-size: var(--step-2);
+				font-weight: 600;
 				color: var(--color-text-primary);
 				letter-spacing: -0.01em;
 			}

--- a/src/components/page-help/page-help.css
+++ b/src/components/page-help/page-help.css
@@ -1,9 +1,21 @@
 @layer block {
 	@scope (page-help) {
+		:scope {
+			/* Local alpha-on-white tokens, consistent with discovery-route's
+			   chip vocabulary so the inline chip demo matches reality. */
+			--_white-8: oklch(100% 0 0deg / 8%);
+			--_white-15: oklch(100% 0 0deg / 15%);
+			--_white-70: oklch(100% 0 0deg / 70%);
+		}
+
 		bottom-sheet {
 			--sheet-bg: var(--color-surface-overlay);
 		}
 
+		/* Help trigger reads as "tappable for guidance" — brand-accent
+		   coloring + soft glow so it's discoverable without dominating
+		   the header. The muted default made it look like a disabled UI
+		   chip, not an interactive affordance. */
 		.page-help-trigger {
 			cursor: pointer;
 
@@ -13,43 +25,140 @@
 
 			inline-size: 2rem;
 			block-size: 2rem;
-			border: 1.5px solid currentcolor;
+			border: 1.5px solid oklch(from var(--color-brand-accent) l c h / 50%);
 			border-radius: var(--radius-full);
 
 			font-size: var(--step-0);
-			font-weight: 600;
+			font-weight: 700;
 			line-height: var(--leading-none);
-			color: var(--color-text-muted);
+			color: var(--color-brand-accent);
 
-			background: transparent;
+			background: oklch(from var(--color-brand-accent) l c h / 8%);
 
-			transition: color var(--transition-fast);
+			transition:
+				color var(--transition-fast),
+				border-color var(--transition-fast),
+				background var(--transition-fast);
 		}
 
 		.page-help-trigger:hover {
-			color: var(--color-text-primary);
+			border-color: var(--color-brand-accent);
+			background: oklch(from var(--color-brand-accent) l c h / 18%);
 		}
 
 		.page-help-content {
 			padding: var(--space-m) var(--space-s) var(--space-l);
 		}
 
+		/* ── Header (icon + title with subtle divider) ──────────────────── */
+		.page-help-header {
+			display: flex;
+			gap: var(--space-2xs);
+			align-items: center;
+
+			margin-block-end: var(--space-s);
+			padding-block-end: var(--space-xs);
+			border-block-end: 1px solid var(--color-border-subtle);
+		}
+
+		.page-help-icon {
+			display: inline-flex;
+			flex-shrink: 0;
+			color: var(--color-brand-accent);
+		}
+
 		.page-help-title {
-			margin-block-end: var(--space-xs);
+			margin: 0;
 			font-family: var(--font-display);
 			font-size: var(--step-1);
 			font-weight: 700;
 		}
 
-		.page-help-lanes {
+		.page-help-desc {
+			margin-block-end: var(--space-s);
+			line-height: var(--leading-relaxed);
+			color: var(--color-text-primary);
+		}
+
+		/* ── Tip list (with brand-accent bullets) ───────────────────────── */
+		.page-help-tips {
 			display: flex;
 			flex-direction: column;
 			gap: var(--space-2xs);
 
-			margin-block: var(--space-xs);
+			margin-block-start: var(--space-s);
 			padding: 0;
 
+			color: var(--color-text-secondary);
 			list-style: none;
+		}
+
+		.page-help-tips li {
+			display: flex;
+			gap: var(--space-2xs);
+			align-items: flex-start;
+		}
+
+		.page-help-tips li::before {
+			content: "▸";
+			flex-shrink: 0;
+			font-weight: bold;
+			color: var(--color-brand-accent);
+		}
+
+		/* ── Inline genre-chip demo (mimics .genre-chip on discovery) ──── */
+		.page-help-chip-demo {
+			display: flex;
+			flex-wrap: wrap;
+			gap: var(--space-2xs);
+			margin-block: var(--space-xs) var(--space-s);
+		}
+
+		.page-help-chip {
+			padding: var(--space-3xs) var(--space-xs);
+			border: 1px solid var(--_white-15);
+			border-radius: var(--radius-full);
+
+			font-family: var(--font-display);
+			font-size: var(--step--2);
+			font-weight: 500;
+			color: var(--_white-70);
+			white-space: nowrap;
+
+			background: var(--_white-8);
+		}
+
+		/* Highlight one chip as "active" so the demo shows the toggle state */
+		.page-help-chip[data-active] {
+			border-color: var(--color-brand-accent);
+			color: var(--color-text-primary);
+			background: oklch(from var(--color-brand-accent) l c h / 18%);
+		}
+
+		/* ── Stage lanes block (HOME / NEAR / AWAY) ─────────────────────── */
+
+		/* Grid keeps the dt label column at intrinsic max-width (HOME
+		   determines the column) and the dd description column flush-left
+		   across all rows — flex would have left each "—" at a different
+		   x position because HOME / NEAR / AWAY have different widths. */
+		.page-help-lanes {
+			display: grid;
+			grid-template-columns: auto 1fr;
+			gap: var(--space-2xs) var(--space-s);
+
+			margin-block: var(--space-s);
+			padding: var(--space-s);
+			border-radius: var(--radius-card);
+
+			background: oklch(from var(--color-surface-overlay) calc(l + 0.04) c h);
+		}
+
+		.page-help-lanes dt {
+			font-weight: 700;
+		}
+
+		.page-help-lanes dd {
+			margin: 0;
 		}
 
 		.stage-home {
@@ -64,26 +173,15 @@
 			color: var(--color-stage-away);
 		}
 
-		.page-help-tips {
-			display: flex;
-			flex-direction: column;
-			gap: var(--space-3xs);
-
-			margin-block-start: var(--space-xs);
-			padding: 0;
-
-			color: var(--color-text-secondary);
-			list-style: none;
-		}
-
+		/* ── Hype table (My Artists) ────────────────────────────────────── */
 		.page-help-hype-table {
 			border-collapse: collapse;
 			inline-size: 100%;
-			margin-block: var(--space-xs);
+			margin-block: var(--space-s);
 		}
 
 		.page-help-hype-table :is(td, th) {
-			padding: var(--space-3xs) var(--space-2xs);
+			padding: var(--space-2xs);
 			vertical-align: top;
 		}
 
@@ -92,10 +190,15 @@
 			white-space: nowrap;
 		}
 
+		.page-help-hype-table tr + tr :is(td, th) {
+			border-block-start: 1px solid var(--color-border-subtle);
+		}
+
+		/* ── Note (footnote / caption) ──────────────────────────────────── */
 		.page-help-note {
-			margin-block-start: var(--space-xs);
+			margin-block-start: var(--space-s);
 			font-size: var(--step--1);
-			color: var(--color-text-secondary);
+			color: var(--color-text-muted);
 		}
 	}
 }

--- a/src/components/page-help/page-help.html
+++ b/src/components/page-help/page-help.html
@@ -13,8 +13,19 @@
   <template switch.bind="page">
 
     <section case="discovery" class="page-help-content" aria-labelledby="help-discovery-title">
-      <h2 id="help-discovery-title" class="page-help-title" t="pageHelp.discovery.title"></h2>
-      <p t="pageHelp.discovery.description"></p>
+      <header class="page-help-header">
+        <svg-icon name="info" class="page-help-icon" data-size="sm"></svg-icon>
+        <h2 id="help-discovery-title" class="page-help-title" t="pageHelp.discovery.title"></h2>
+      </header>
+      <p class="page-help-desc" t="pageHelp.discovery.description"></p>
+
+      <!-- Inline demo of the actual genre chips so the tip is shown, not just told. -->
+      <div class="page-help-chip-demo" aria-hidden="true">
+        <span class="page-help-chip">Rock</span>
+        <span class="page-help-chip" data-active>Pop</span>
+        <span class="page-help-chip">Jazz</span>
+      </div>
+
       <ul class="page-help-tips">
         <li t="pageHelp.discovery.genreTip"></li>
         <li t="pageHelp.discovery.searchTip"></li>
@@ -22,19 +33,28 @@
     </section>
 
     <section case="dashboard" class="page-help-content" aria-labelledby="help-dashboard-title">
-      <h2 id="help-dashboard-title" class="page-help-title" t="pageHelp.dashboard.title"></h2>
-      <p t="pageHelp.dashboard.description"></p>
-      <ul class="page-help-lanes">
-        <li><strong class="stage-home" t="pageHelp.dashboard.homeLabel"></strong><span t="pageHelp.dashboard.homeDesc"></span></li>
-        <li><strong class="stage-near" t="pageHelp.dashboard.nearLabel"></strong><span t="pageHelp.dashboard.nearDesc"></span></li>
-        <li><strong class="stage-away" t="pageHelp.dashboard.awayLabel"></strong><span t="pageHelp.dashboard.awayDesc"></span></li>
-      </ul>
+      <header class="page-help-header">
+        <svg-icon name="info" class="page-help-icon" data-size="sm"></svg-icon>
+        <h2 id="help-dashboard-title" class="page-help-title" t="pageHelp.dashboard.title"></h2>
+      </header>
+      <p class="page-help-desc" t="pageHelp.dashboard.description"></p>
+      <dl class="page-help-lanes">
+        <dt class="stage-home" t="pageHelp.dashboard.homeLabel"></dt>
+        <dd t="pageHelp.dashboard.homeDesc"></dd>
+        <dt class="stage-near" t="pageHelp.dashboard.nearLabel"></dt>
+        <dd t="pageHelp.dashboard.nearDesc"></dd>
+        <dt class="stage-away" t="pageHelp.dashboard.awayLabel"></dt>
+        <dd t="pageHelp.dashboard.awayDesc"></dd>
+      </dl>
       <p class="page-help-note" t="pageHelp.dashboard.cardTip"></p>
     </section>
 
     <section case="my-artists" class="page-help-content" aria-labelledby="help-my-artists-title">
-      <h2 id="help-my-artists-title" class="page-help-title" t="pageHelp.myArtists.title"></h2>
-      <p t="pageHelp.myArtists.description"></p>
+      <header class="page-help-header">
+        <svg-icon name="info" class="page-help-icon" data-size="sm"></svg-icon>
+        <h2 id="help-my-artists-title" class="page-help-title" t="pageHelp.myArtists.title"></h2>
+      </header>
+      <p class="page-help-desc" t="pageHelp.myArtists.description"></p>
       <table class="page-help-hype-table">
         <tbody>
           <tr>

--- a/src/components/post-signup-dialog/post-signup-dialog.css
+++ b/src/components/post-signup-dialog/post-signup-dialog.css
@@ -5,9 +5,15 @@
 		}
 
 		.post-signup-title {
-			margin-block-end: var(--space-m);
+			margin-block-end: var(--space-2xs);
 			font-size: var(--step-1);
 			font-weight: 700;
+		}
+
+		.post-signup-subtitle {
+			margin-block-end: var(--space-m);
+			font-size: var(--step-0);
+			color: var(--color-text-secondary);
 		}
 
 		.post-signup-row {

--- a/src/components/post-signup-dialog/post-signup-dialog.html
+++ b/src/components/post-signup-dialog/post-signup-dialog.html
@@ -3,14 +3,7 @@
 <bottom-sheet open.bind="isOpen" t="[aria-label]postSignup.ariaLabel" sheet-closed.trigger="onDefer()">
   <section class="post-signup-content">
     <h2 class="post-signup-title" t="postSignup.title"></h2>
-
-    <!-- Hype guide hint (always shown) -->
-    <div class="post-signup-row">
-      <span class="post-signup-row-icon">💡</span>
-      <div class="post-signup-row-body">
-        <p class="post-signup-row-label" t="postSignup.hypeGuideLabel"></p>
-      </div>
-    </div>
+    <p class="post-signup-subtitle" t="postSignup.subtitle"></p>
 
     <!-- Notification opt-in row -->
     <div class="post-signup-row" if.bind="notificationManager.permission === 'default'">

--- a/src/components/state-placeholder/state-placeholder.css
+++ b/src/components/state-placeholder/state-placeholder.css
@@ -10,14 +10,18 @@
 		.state-center {
 			display: flex;
 			flex-direction: column;
-			gap: var(--space-2xs);
+			gap: var(--space-s);
 			align-items: center;
 
 			text-align: center;
 		}
 
+		/* Brand-accent color so the empty state reads as "waiting /
+		   promised" instead of "broken / forgotten". Drop-shadow was
+		   tried but blurred the clock outline into a solid disk, so we
+		   rely on color alone for visibility. */
 		.state-icon {
-			color: var(--color-text-muted);
+			color: var(--color-brand-accent);
 		}
 	}
 }

--- a/src/components/svg-icon/svg-icon.css
+++ b/src/components/svg-icon/svg-icon.css
@@ -16,6 +16,15 @@
 			block-size: var(--_icon-size, 1.25rem);
 		}
 
+		/* The global reset (`:where(svg) { fill: currentcolor }`) overrides
+		   each SVG's `fill="none"` attribute because presentation attributes
+		   lose to even zero-specificity CSS in the cascade. Honor the
+		   attribute explicitly here so stroked-only icons (most Lucide
+		   icons) render correctly instead of as filled disks. */
+		.svg-icon[fill="none"] {
+			fill: none;
+		}
+
 		:scope[data-size="xs"] {
 			--_icon-size: 0.75rem;
 		}

--- a/src/components/user-home-selector/user-home-selector.css
+++ b/src/components/user-home-selector/user-home-selector.css
@@ -8,7 +8,7 @@
 		}
 
 		.selector-content {
-			padding-block-end: var(--space-l);
+			padding-block: var(--space-m) var(--space-l);
 			padding-inline: var(--space-l);
 		}
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -3,32 +3,52 @@
 		"dismiss": "Dismiss",
 		"createAccount": "Create Account"
 	},
-	"entity": {},
+	"entity": {
+		"hype": {
+			"label": "Hype",
+			"values": {
+				"watch": "Watching",
+				"home": "Home",
+				"nearby": "Near",
+				"away": "Away"
+			}
+		},
+		"concert": {
+			"label": "Concert"
+		},
+		"artist": {
+			"label": "Artist"
+		},
+		"homeArea": {
+			"label": "Home Area"
+		}
+	},
 	"welcome": {
 		"hero": {
+			"descriptor": "Follow your favorite artists. Build your personal timetable.",
 			"title": "Never miss a live show from the bands you love.",
 			"subtitle": "Just follow your favorite artists and we'll automatically collect live schedules nationwide.",
 			"seePreview": "See how it works"
 		},
 		"cta": {
-			"getStarted": "Get Started",
+			"getStarted": "Pick your artists",
 			"login": "Log In",
 			"loginHint": "Already have an account? Log in"
 		},
-		"guestFriendly": "Try it without creating an account",
+		"guestFriendly": "No account needed · 30 seconds to try",
 		"preview": {
 			"label": "Build your own concert timetable!"
 		},
 		"error": {
 			"navigation": "Navigation failed. Please try again.",
-			"login": "Failed to start login. Please try again."
+			"login": "Could not start login — your connection may be unstable. Wait a moment and try again."
 		}
 	},
 	"signup": {
-		"title": "Create Your Account",
-		"description": "Great job completing onboarding!<br>Create a secure account with Passkey<br>to save the artists you follow.",
-		"button": "Create Account with Passkey",
-		"error": "Account creation failed. Please try again."
+		"title": "One step away from never missing a show",
+		"description": "Create an account to:<br>🔔 Get notified the moment new lives are announced<br>📱 Open your timetable from any device<br>🎟 Save tickets you'll add along the way",
+		"button": "Create Account with Passkey (30s)",
+		"error": "Could not finish creating your account — your connection may be unstable. Wait a moment and try again."
 	},
 	"userHome": {
 		"title": "Select Your Home Area",
@@ -120,8 +140,8 @@
 		},
 		"loading": "Loading events…",
 		"empty": {
-			"title": "No upcoming events",
-			"subtitle": "Follow more artists to see their live schedules here.",
+			"title": "New shows will appear here as soon as we find them",
+			"subtitle": "Follow more artists to fill out your timetable.",
 			"discoverLink": "Discover Artists"
 		},
 		"error": {
@@ -155,24 +175,7 @@
 		"step3": "Tap \"Add\" to finish",
 		"close": "Close"
 	},
-	"hype": {
-		"watch": "Watch",
-		"home": "Home",
-		"nearby": "NearBy",
-		"away": "Away"
-	},
 	"myArtists": {
-		"coachMark": {
-			"setHype": "Try setting a hype level"
-		},
-		"hypeExplanation": {
-			"title": "Notification Scope",
-			"description": "Your hype level controls which concert notifications you receive.",
-			"watch": "Dashboard only — no push notifications",
-			"home": "Notified when concerts are in your home area",
-			"away": "Notified for all concerts nationwide",
-			"ok": "OK"
-		},
 		"empty": {
 			"title": "No artists followed yet",
 			"subtitle": "Discover and follow artists to see them here.",
@@ -180,24 +183,17 @@
 		},
 		"table": {
 			"artistCol": "Artist",
-			"unfollowCol": "Unfollow",
-			"watch": "Watch",
-			"home": "Home",
-			"nearby": "Nearby",
-			"away": "Away"
-		},
-		"spotlight": {
-			"setHypeMessage": "Raise the hype for artists you never want to miss"
+			"unfollowCol": "Unfollow"
 		},
 		"signupBanner": {
-			"message": "Save your followed artists and get concert notifications."
+			"message": "Save your followed artists and get live show notifications."
 		},
 		"unfollowed": "{{name}} unfollowed",
 		"undo": "Undo",
 		"unfollow": "Unfollow",
 		"unfollowArtist": "Unfollow {{name}}",
 		"failedUnfollow": "Failed to unfollow {{name}}",
-		"failedHype": "Failed to update hype level",
+		"failedHype": "Failed to update Hype",
 		"unfollowSheet": {
 			"confirm": "Unfollow",
 			"cancel": "Cancel",
@@ -208,13 +204,12 @@
 		"coachMark": {
 			"viewTimetable": "Check out your timetable!"
 		},
-		"popoverGuide": "Tap artists you want to follow to get their live concert updates",
-		"generateDashboard": "👉 Generate Dashboard",
+		"popoverGuide": "Tap the artists you care about — your picks become a timetable in the next step",
+		"generateDashboard": "👉 Generate Timetable",
 		"viewSchedule": "View Live Schedule ({{count}} artists)",
-		"orbLabel": "Music DNA",
 		"loadFailed": "Failed to load artists. Tap retry to try again.",
 		"retryFailed": "Still unable to load artists. Please try again later.",
-		"followFailed": "Failed to follow {{name}}. Please try again.",
+		"followFailed": "Couldn't save your follow of {{name}} — your connection may be unstable. Wait a moment and try again.",
 		"hasUpcomingEvents": "{{name}} has upcoming live events!",
 		"similarArtistsUnavailable": "No more similar artists available for {{name}}",
 		"similarArtistsError": "Couldn't find similar artists for {{name}}",
@@ -222,7 +217,7 @@
 		"searchPlaceholder": "Search artists...",
 		"clearSearch": "Clear search",
 		"searching": "Searching...",
-		"noResults": "No artists found",
+		"noResults": "No artists found — try alternate spellings or romaji",
 		"alreadyFollowing": "Already following",
 		"followArtist": "Follow {{name}}",
 		"srSearchResults": "{{count}} search results",
@@ -230,7 +225,7 @@
 		"srFollowed": "{{count}} artists followed",
 		"resetFailed": "Failed to reset discovery view",
 		"genreLoadFailed": "Couldn't load {{tag}} artists",
-		"searchFailed": "Search failed, please try again"
+		"searchFailed": "Search couldn't complete — your connection may be unstable. Wait a moment and try again."
 	},
 	"errorBanner": {
 		"copied": "Error details copied",
@@ -257,7 +252,7 @@
 		"resendVerification": "Resend",
 		"resending": "Sending...",
 		"resendSent": "Sent!",
-		"resendError": "Failed to send verification email. Please try again.",
+		"resendError": "Couldn't send the verification email — your connection may be unstable. Wait a moment and try again.",
 		"resendRateLimited": "Too many requests. Please try again later.",
 		"signOut": "Sign Out",
 		"signOutError": "Sign-out failed. Please try again."
@@ -274,9 +269,9 @@
 		"en": "English"
 	},
 	"postSignup": {
-		"title": "Account registration complete!",
+		"title": "🎉 You're all set — welcome to your timetable",
+		"subtitle": "New lives will show up here as we find them.",
 		"ariaLabel": "Account registration complete",
-		"hypeGuideLabel": "Change hype on the My Artists page to control which notifications you receive",
 		"notificationLabel": "Turn on new live notifications",
 		"notificationEnable": "Enable notifications",
 		"notificationEnabling": "Enabling…",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -25,10 +25,10 @@
 	},
 	"welcome": {
 		"hero": {
-			"descriptor": "Follow your favorite artists. Build your personal timetable.",
 			"title": "Never miss a live show from the bands you love.",
-			"subtitle": "Just follow your favorite artists and we'll automatically collect live schedules nationwide.",
-			"seePreview": "See how it works"
+			"subtitlePain": "Done patrolling official sites, socials, and ticket pages.",
+			"subtitleAction": "Liverty Music <strong>tracks</strong>. You just <strong>go</strong>.",
+			"seePreview": "Peek at a sample"
 		},
 		"cta": {
 			"getStarted": "Pick your artists",
@@ -37,7 +37,7 @@
 		},
 		"guestFriendly": "No account needed · 30 seconds to try",
 		"preview": {
-			"label": "Build your own concert timetable!"
+			"label": "↓ Pick your artists, and this becomes yours!"
 		},
 		"error": {
 			"navigation": "Navigation failed. Please try again.",
@@ -258,7 +258,7 @@
 		"signOutError": "Sign-out failed. Please try again."
 	},
 	"nav": {
-		"home": "Home",
+		"home": "Timetable",
 		"discovery": "Discovery",
 		"myArtists": "My Artists",
 		"tickets": "Tickets",
@@ -294,11 +294,11 @@
 			"title": "Reading the Timetable",
 			"description": "Your followed artists' lives are shown by distance.",
 			"homeLabel": "HOME",
-			"homeDesc": " — Lives in your home area",
+			"homeDesc": "Lives in your home area",
 			"nearLabel": "NEAR",
-			"nearDesc": " — Lives within reach",
+			"nearDesc": "Lives within reach",
 			"awayLabel": "AWAY",
-			"awayDesc": " — Lives anywhere",
+			"awayDesc": "Lives anywhere",
 			"cardTip": "Tap a card to see concert details"
 		},
 		"myArtists": {

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -25,10 +25,10 @@
 	},
 	"welcome": {
 		"hero": {
-			"descriptor": "推しのライブを集めて、あなただけのタイムテーブルに",
-			"title": "大好きなあのバンドのライブ、もう二度と見逃さない。",
-			"subtitle": "推しアーティストをフォローするだけで、全国のライブ日程をあなただけのタイムテーブルに。",
-			"seePreview": "使い方を見る"
+			"title": "大好きなあのバンドのライブ、絶対に見逃さない。",
+			"subtitlePain": "公式サイト、SNS、チケットサイトのパトロールはもう終わり。",
+			"subtitleAction": "Liverty Music が <strong>追う</strong>。あなたは <strong>行く</strong> だけ。",
+			"seePreview": "サンプルを覗く"
 		},
 		"cta": {
 			"getStarted": "推しを選んでみる",
@@ -37,7 +37,7 @@
 		},
 		"guestFriendly": "アカウント不要・30秒で体験",
 		"preview": {
-			"label": "あなただけのタイムテーブルが作れます！"
+			"label": "↓ 推しを選ぶと、あなただけのタイムテーブルに！"
 		},
 		"error": {
 			"navigation": "画面遷移に失敗しました。もう一度お試しください。",
@@ -258,7 +258,7 @@
 		"signOutError": "サインアウトに失敗しました。もう一度お試しください。"
 	},
 	"nav": {
-		"home": "Home",
+		"home": "Timetable",
 		"discovery": "Discovery",
 		"myArtists": "My Artists",
 		"tickets": "Tickets",
@@ -294,11 +294,11 @@
 			"title": "タイムテーブルの見方",
 			"description": "フォローしたアーティストのライブが距離ごとに表示されます。",
 			"homeLabel": "HOME",
-			"homeDesc": " — 居住エリアのライブ",
+			"homeDesc": "居住エリアのライブ",
 			"nearLabel": "NEAR",
-			"nearDesc": " — 少し足を伸ばせば行けるライブ",
+			"nearDesc": "少し足を伸ばせば行けるライブ",
 			"awayLabel": "AWAY",
-			"awayDesc": " — 遠征ライブ",
+			"awayDesc": "遠征ライブ",
 			"cardTip": "カードをタップすると詳細が見られます"
 		},
 		"myArtists": {

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -3,32 +3,52 @@
 		"dismiss": "閉じる",
 		"createAccount": "アカウント作成"
 	},
-	"entity": {},
+	"entity": {
+		"hype": {
+			"label": "Stage",
+			"values": {
+				"watch": "観測",
+				"home": "地元",
+				"nearby": "近郊",
+				"away": "全国"
+			}
+		},
+		"concert": {
+			"label": "ライブ"
+		},
+		"artist": {
+			"label": "アーティスト"
+		},
+		"homeArea": {
+			"label": "ホームエリア"
+		}
+	},
 	"welcome": {
 		"hero": {
+			"descriptor": "推しのライブを集めて、あなただけのタイムテーブルに",
 			"title": "大好きなあのバンドのライブ、もう二度と見逃さない。",
-			"subtitle": "あなたの推しアーティストを登録するだけで、全国のライブ日程を自動収集。",
+			"subtitle": "推しアーティストをフォローするだけで、全国のライブ日程をあなただけのタイムテーブルに。",
 			"seePreview": "使い方を見る"
 		},
 		"cta": {
-			"getStarted": "使ってみる",
+			"getStarted": "推しを選んでみる",
 			"login": "ログイン",
 			"loginHint": "アカウントをお持ちの方はログイン"
 		},
-		"guestFriendly": "アカウント不要でお試しいただけます",
+		"guestFriendly": "アカウント不要・30秒で体験",
 		"preview": {
 			"label": "あなただけのタイムテーブルが作れます！"
 		},
 		"error": {
 			"navigation": "画面遷移に失敗しました。もう一度お試しください。",
-			"login": "ログインの開始に失敗しました。もう一度お試しください。"
+			"login": "ログインを開始できませんでした。ネットワークが不安定なようです。少し時間を置いてもう一度お試しください。"
 		}
 	},
 	"signup": {
-		"title": "アカウントを作成しよう",
-		"description": "チュートリアルお疲れさまでした！<br>Passkeyで安全にアカウントを作成して、<br>フォローしたアーティストの情報を保存しましょう。",
-		"button": "Passkeyでアカウント作成",
-		"error": "アカウント作成に失敗しました。もう一度お試しください。"
+		"title": "あと一歩で、推しのライブを逃さなくなる",
+		"description": "アカウントを作ると：<br>🔔 新ライブが見つかったらすぐに通知<br>📱 どの端末からでもタイムテーブルを開ける<br>🎟 これから追加されるチケット情報も保存",
+		"button": "Passkeyでアカウント作成（30秒）",
+		"error": "アカウント作成を完了できませんでした。ネットワークが不安定なようです。少し時間を置いてもう一度お試しください。"
 	},
 	"userHome": {
 		"title": "ホームエリアを選択",
@@ -120,23 +140,23 @@
 		},
 		"loading": "イベントを読み込み中…",
 		"empty": {
-			"title": "予定されているイベントはありません",
-			"subtitle": "アーティストをフォローしてライブスケジュールを確認しましょう。",
+			"title": "新しいライブが見つかり次第、ここに並びます",
+			"subtitle": "もっと推しを増やすと、タイムテーブルが充実します。",
 			"discoverLink": "アーティストを探す"
 		},
 		"error": {
-			"load": "ライブイベントの読み込みに失敗しました"
+			"load": "ライブの読み込みに失敗しました"
 		}
 	},
 	"notification": {
-		"title": "ライブイベントを見逃さない",
-		"description": "フォローしたアーティストの新しいコンサートが見つかったら通知を受け取れます。",
+		"title": "ライブを見逃さない",
+		"description": "フォローしたアーティストの新しいライブが見つかったら通知を受け取れます。",
 		"notNow": "今はしない",
 		"enable": "通知を有効にする",
 		"enabling": "有効化中…",
 		"blocked": {
 			"title": "通知がブロックされています",
-			"description": "コンサートのお知らせを受け取るには、ブラウザの設定でこのサイトの通知を有効にしてください。",
+			"description": "ライブのお知らせを受け取るには、ブラウザの設定でこのサイトの通知を有効にしてください。",
 			"dismiss": "閉じる"
 		}
 	},
@@ -155,24 +175,7 @@
 		"step3": "「追加」をタップして完了",
 		"close": "閉じる"
 	},
-	"hype": {
-		"watch": "観測のみ",
-		"home": "地元のみ",
-		"nearby": "近郊まで",
-		"away": "遠征OK"
-	},
 	"myArtists": {
-		"coachMark": {
-			"setHype": "Hypeレベルを設定してみましょう"
-		},
-		"hypeExplanation": {
-			"title": "通知の範囲",
-			"description": "Hypeレベルに応じて、受け取るコンサート通知が変わります。",
-			"watch": "ダッシュボード表示のみ — プッシュ通知なし",
-			"home": "ホームエリアのコンサート時に通知",
-			"away": "全国すべてのコンサートを通知",
-			"ok": "OK"
-		},
 		"empty": {
 			"title": "フォロー中のアーティストはいません",
 			"subtitle": "アーティストを探してフォローしましょう。",
@@ -180,24 +183,17 @@
 		},
 		"table": {
 			"artistCol": "アーティスト",
-			"unfollowCol": "フォロー解除",
-			"watch": "チェック",
-			"home": "地元",
-			"nearby": "近くも",
-			"away": "どこでも！"
-		},
-		"spotlight": {
-			"setHypeMessage": "絶対に見逃したくないアーティストの熱量を上げておこう"
+			"unfollowCol": "フォロー解除"
 		},
 		"signupBanner": {
-			"message": "フォロー情報を保存してコンサート通知を受け取ろう！"
+			"message": "フォロー情報を保存してライブ通知を受け取ろう！"
 		},
 		"unfollowed": "{{name}}のフォローを解除しました",
 		"undo": "元に戻す",
 		"unfollow": "フォロー解除",
 		"unfollowArtist": "{{name}}のフォローを解除",
 		"failedUnfollow": "{{name}}のフォロー解除に失敗しました",
-		"failedHype": "Hypeレベルの更新に失敗しました",
+		"failedHype": "Stageの更新に失敗しました",
 		"unfollowSheet": {
 			"confirm": "フォロー解除",
 			"cancel": "キャンセル",
@@ -208,13 +204,12 @@
 		"coachMark": {
 			"viewTimetable": "タイムテーブルを見てみよう！"
 		},
-		"popoverGuide": "ライブ情報を追いかけたいアーティストをタップしてフォローしよう",
-		"generateDashboard": "👉 ダッシュボードを生成する",
+		"popoverGuide": "気になるアーティストをタップ — 選んだ推しのライブが、次のステップでタイムテーブルになります",
+		"generateDashboard": "👉 タイムテーブルを生成する",
 		"viewSchedule": "ライブスケジュールを見る（{{count}}アーティスト）",
-		"orbLabel": "Music DNA",
 		"loadFailed": "アーティストの読み込みに失敗しました。リトライしてください。",
 		"retryFailed": "読み込みに失敗しました。後ほど再度お試しください。",
-		"followFailed": "{{name}}のフォローに失敗しました。もう一度お試しください。",
+		"followFailed": "{{name}}のフォローを保存できませんでした。ネットワークが不安定なようです。少し時間を置いてもう一度お試しください。",
 		"hasUpcomingEvents": "{{name}}のライブが近日開催予定です！",
 		"similarArtistsUnavailable": "{{name}}の類似アーティストはこれ以上ありません",
 		"similarArtistsError": "{{name}}の類似アーティストが見つかりませんでした",
@@ -222,7 +217,7 @@
 		"searchPlaceholder": "アーティストを検索...",
 		"clearSearch": "検索をクリア",
 		"searching": "検索中...",
-		"noResults": "アーティストが見つかりません",
+		"noResults": "アーティストが見つかりません — 英語名やローマ字でも試せます",
 		"alreadyFollowing": "フォロー済み",
 		"followArtist": "{{name}}をフォロー",
 		"srSearchResults": "{{count}}件の検索結果",
@@ -230,7 +225,7 @@
 		"srFollowed": "{{count}}アーティストをフォロー中",
 		"resetFailed": "ディスカバリービューのリセットに失敗しました",
 		"genreLoadFailed": "{{tag}}のアーティストを読み込めませんでした",
-		"searchFailed": "検索に失敗しました。もう一度お試しください"
+		"searchFailed": "検索が完了しませんでした。ネットワークが不安定なようです。少し時間を置いてもう一度お試しください。"
 	},
 	"errorBanner": {
 		"copied": "エラー詳細をコピーしました",
@@ -257,7 +252,7 @@
 		"resendVerification": "再送信",
 		"resending": "送信中...",
 		"resendSent": "送信済み！",
-		"resendError": "認証メールの送信に失敗しました。もう一度お試しください。",
+		"resendError": "認証メールを送信できませんでした。ネットワークが不安定なようです。少し時間を置いてもう一度お試しください。",
 		"resendRateLimited": "リクエストが多すぎます。しばらくしてからお試しください。",
 		"signOut": "サインアウト",
 		"signOutError": "サインアウトに失敗しました。もう一度お試しください。"
@@ -274,9 +269,9 @@
 		"en": "English"
 	},
 	"postSignup": {
-		"title": "✅ アカウント登録完了！",
+		"title": "🎉 準備完了！ようこそ、あなたのタイムテーブルへ",
+		"subtitle": "新しいライブが見つかったら、ここでお知らせします。",
 		"ariaLabel": "アカウント登録完了",
-		"hypeGuideLabel": "My Artists ページで hype を変更すると通知の範囲をコントロールできます",
 		"notificationLabel": "新着ライブ通知をオンにしよう",
 		"notificationEnable": "通知をオンにする",
 		"notificationEnabling": "有効化中…",
@@ -307,8 +302,8 @@
 			"cardTip": "カードをタップすると詳細が見られます"
 		},
 		"myArtists": {
-			"title": "Hypeレベルについて",
-			"description": "Hypeレベルで通知の範囲が変わります。ドットをタップして切り替えられます。",
+			"title": "Stage について",
+			"description": "Stage で通知の範囲が変わります。ドットをタップして切り替えられます。",
 			"watchDesc": "通知なし",
 			"homeDesc": "居住エリアのライブを通知",
 			"nearbyDesc": "近くのライブも通知",

--- a/src/routes/my-artists/my-artists-route.html
+++ b/src/routes/my-artists/my-artists-route.html
@@ -31,10 +31,10 @@
       <thead>
         <tr class="artists-thead-row">
           <th scope="col" class="[ visually-hidden ]" t="myArtists.table.artistCol"></th>
-          <th scope="col" class="hype-col-header">👀<small t="myArtists.table.watch"></small></th>
-          <th scope="col" class="hype-col-header">🔥<small t="myArtists.table.home"></small></th>
-          <th scope="col" class="hype-col-header">🔥🔥<small t="myArtists.table.nearby"></small></th>
-          <th scope="col" class="hype-col-header">🔥🔥🔥<small t="myArtists.table.away"></small></th>
+          <th scope="col" class="hype-col-header">👀<small t="entity.hype.values.watch"></small></th>
+          <th scope="col" class="hype-col-header">🔥<small t="entity.hype.values.home"></small></th>
+          <th scope="col" class="hype-col-header">🔥🔥<small t="entity.hype.values.nearby"></small></th>
+          <th scope="col" class="hype-col-header">🔥🔥🔥<small t="entity.hype.values.away"></small></th>
           <th scope="col" class="[ visually-hidden ]" t="myArtists.table.unfollowCol"></th>
         </tr>
       </thead>

--- a/src/routes/my-artists/my-artists-route.html
+++ b/src/routes/my-artists/my-artists-route.html
@@ -1,6 +1,9 @@
 <import from="./my-artists-route.css"></import>
 
-<page-header if.bind="!isLoading && artists.length > 0" title-key="nav.myArtists">
+<!-- Header always renders so the page identity is preserved across loading
+     / empty / populated states. The hype-table column headers below carry
+     their own labels, so duplication isn't a concern. -->
+<page-header title-key="nav.myArtists">
   <page-help page="my-artists"></page-help>
 </page-header>
 

--- a/src/routes/welcome/welcome-route.css
+++ b/src/routes/welcome/welcome-route.css
@@ -18,8 +18,12 @@
 		}
 
 		/* ── Screen 1: Hero hook ──
-		   95svh when Screen 2 follows (peek effect); 100svh when alone
-		   (fallback path — no preview data, no Screen 2). */
+		   Always full-viewport. Earlier iterations used 95svh to leak a
+		   5svh peek of Screen 2's top, but that peek caught either the
+		   preview-label text or the timetable's stage headers — neither
+		   served as a clean "more below" hint. The explicit
+		   `↓ サンプルを覗く` scroll CTA covers that affordance role
+		   instead, so Screen 1 stays clean. */
 		.welcome-hero {
 			scroll-snap-align: start;
 
@@ -28,16 +32,12 @@
 			align-items: center;
 			justify-content: center;
 
-			block-size: 95svh;
+			block-size: 100svh;
 			padding-inline: var(--space-l);
 
 			text-align: center;
 
 			animation: fade-in 600ms ease-out both;
-
-			&:not(:has(~ .welcome-screen-2)) {
-				block-size: 100svh;
-			}
 		}
 
 		.welcome-hero-fallback {
@@ -52,38 +52,72 @@
 		}
 
 		.welcome-brand {
-			margin-block-end: var(--space-2xs);
+			margin-block-end: var(--space-l);
 
 			font-family: var(--font-display);
-			font-size: var(--step-0);
+			font-size: var(--step-2);
 			font-weight: 600;
 			color: var(--color-brand-accent);
+
+			/* Same festival-spotlight vocabulary as the subtitle action
+			   verbs and event-card[data-matched]. The brand sits at the
+			   top of the visual hierarchy so it earns the brightest glow. */
+			text-shadow:
+				0 0 8px oklch(from var(--color-brand-accent) l c h / 60%),
+				0 0 18px oklch(from var(--color-brand-accent) l c h / 35%);
 			text-transform: uppercase;
 			letter-spacing: 0.2em;
 		}
 
-		.welcome-descriptor {
-			max-inline-size: 28rem;
-			margin-block-end: var(--space-l);
-			font-size: var(--step--1);
-			color: var(--color-text-secondary);
-		}
-
 		.welcome-title {
-			margin-block-end: var(--space-s);
+			margin-block-end: var(--space-m);
 
 			font-family: var(--font-display);
 			font-size: var(--step-3);
 			font-weight: normal;
-			line-height: var(--leading-tight);
+			line-height: var(--leading-snug);
 			color: var(--color-text-primary);
+
+			/* Phrase-aware wrapping for CJK headlines: balance distributes
+			   line lengths evenly; auto-phrase prefers natural phrase
+			   boundaries (Chrome 119+; gracefully ignored elsewhere). */
+			text-wrap: balance;
+			word-break: auto-phrase;
 		}
 
 		.welcome-subtitle {
 			max-inline-size: 28rem;
-			margin-block-end: var(--space-l);
+			margin-block-end: var(--space-xs);
+
 			font-size: var(--step-0);
+			line-height: var(--leading-relaxed);
 			color: var(--color-text-secondary);
+
+			/* Balance line lengths + prefer phrase-level break points so
+			   neither line strands a tail like「は」or「だけ。」alone
+			   and CJK words don't split mid-character. */
+			text-wrap: balance;
+			word-break: auto-phrase;
+		}
+
+		/* The second line of the subtitle (action / role-reversal) closes
+		   the hero paragraph; it gets the larger bottom margin so the
+		   following lang switcher / scroll CTA is properly spaced. */
+		.welcome-subtitle-action {
+			margin-block-end: var(--space-xl);
+		}
+
+		/* Emphasized verbs in the role-reversal line ("追う" / "行く" /
+		   "tracks" / "go"). Reuses the festival-spotlight glow vocabulary
+		   established by event-card[data-matched] and celebration-overlay
+		   so the verbs read as "this is the brand voice speaking" rather
+		   than just bold body copy. */
+		.welcome-subtitle-action strong {
+			font-weight: 600;
+			color: var(--color-brand-accent);
+			text-shadow:
+				0 0 6px oklch(from var(--color-brand-accent) l c h / 60%),
+				0 0 14px oklch(from var(--color-brand-accent) l c h / 35%);
 		}
 
 		.welcome-scroll-cta {
@@ -157,7 +191,11 @@
 			font-weight: normal;
 			color: var(--color-brand-accent);
 			text-align: center;
+
+			/* Same wrap-balance as the hero subtitle */
+			text-wrap: balance;
 			letter-spacing: 0.05em;
+			word-break: auto-phrase;
 		}
 
 		.welcome-preview {

--- a/src/routes/welcome/welcome-route.css
+++ b/src/routes/welcome/welcome-route.css
@@ -40,13 +40,19 @@
 			}
 		}
 
-		.welcome-hero-fallback-cta-group {
-			max-inline-size: 28rem;
+		.welcome-hero-fallback {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
 			margin-block-start: var(--space-l);
 		}
 
+		.welcome-hero-fallback-cta-group {
+			max-inline-size: 28rem;
+		}
+
 		.welcome-brand {
-			margin-block-end: var(--space-l);
+			margin-block-end: var(--space-2xs);
 
 			font-family: var(--font-display);
 			font-size: var(--step-0);
@@ -54,6 +60,13 @@
 			color: var(--color-brand-accent);
 			text-transform: uppercase;
 			letter-spacing: 0.2em;
+		}
+
+		.welcome-descriptor {
+			max-inline-size: 28rem;
+			margin-block-end: var(--space-l);
+			font-size: var(--step--1);
+			color: var(--color-text-secondary);
 		}
 
 		.welcome-title {

--- a/src/routes/welcome/welcome-route.html
+++ b/src/routes/welcome/welcome-route.html
@@ -3,6 +3,7 @@
   <p class="welcome-brand">
     Liverty Music
   </p>
+  <p t="welcome.hero.descriptor" class="welcome-descriptor"></p>
   <h1 t="welcome.hero.title" class="welcome-title"></h1>
   <p t="welcome.hero.subtitle" class="welcome-subtitle"></p>
 
@@ -29,18 +30,23 @@
   ></button>
 
   <!-- Without preview data: no Screen 2 exists, so fall back to inline CTAs
-       so unauthenticated users can still start onboarding or sign in. -->
-  <div else class="[ welcome-cta-group welcome-hero-fallback-cta-group ]">
-    <button
-      click.trigger="handleGetStarted()"
-      class="welcome-btn-primary"
-      t="welcome.cta.getStarted"
-    ></button>
-    <button
-      click.trigger="handleLogin()"
-      class="welcome-btn-secondary"
-      t="welcome.cta.login"
-    ></button>
+       so unauthenticated users can still start onboarding or sign in. The
+       guest-friendly note rides above the CTA group per the landing-page spec
+       so the no-account-required message stays visible without scrolling. -->
+  <div else class="[ welcome-hero-fallback ]">
+    <p t="welcome.guestFriendly" class="welcome-guest-friendly"></p>
+    <div class="[ welcome-cta-group welcome-hero-fallback-cta-group ]">
+      <button
+        click.trigger="handleGetStarted()"
+        class="welcome-btn-primary"
+        t="welcome.cta.getStarted"
+      ></button>
+      <button
+        click.trigger="handleLogin()"
+        class="welcome-btn-secondary"
+        t="welcome.cta.login"
+      ></button>
+    </div>
   </div>
 </header>
 

--- a/src/routes/welcome/welcome-route.html
+++ b/src/routes/welcome/welcome-route.html
@@ -3,9 +3,9 @@
   <p class="welcome-brand">
     Liverty Music
   </p>
-  <p t="welcome.hero.descriptor" class="welcome-descriptor"></p>
   <h1 t="welcome.hero.title" class="welcome-title"></h1>
-  <p t="welcome.hero.subtitle" class="welcome-subtitle"></p>
+  <p t="welcome.hero.subtitlePain" class="welcome-subtitle"></p>
+  <p t="[html]welcome.hero.subtitleAction" class="welcome-subtitle welcome-subtitle-action"></p>
 
   <fieldset class="welcome-lang">
     <legend class="[ visually-hidden ]">Language</legend>


### PR DESCRIPTION
## Summary

Implements the frontend side of `refine-onboarding-copy` (spec: liverty-music/specification#434).

- **Layer A migration**: populate `entity.hype.{label,values.*}` and `entity.{concert,artist,homeArea}.label` in both locales. Asymmetric labels: JA `Stage` / EN `Hype`, JA `ライブ` / EN `Concert`.
- **Repoint consumers**: `HYPE_TIERS` in `src/adapter/view/hype-display.ts` and the My Artists table headers now read from `entity.hype.values.*`.
- **Delete legacy + dead keys**: `hype.*` top-level, `myArtists.coachMark`, `myArtists.spotlight`, `myArtists.hypeExplanation`, `myArtists.table.{watch,home,nearby,away}` (none of the dead keys were rendered by any component).
- **Terminology unification (JA)**: `ライブ` (not `コンサート`), `タイムテーブル` (not `ダッシュボード` in user copy), `フォロー` (not `登録`).
- **Welcome hero refresh**: product descriptor under brand, reward-predicting CTA labels, guest-friendly note now visible on both Screen 1 fallback and Screen 2.
- **Discovery refresh**: `Music DNA` orb label removed; `popoverGuide` rewritten to predict the next step's reward.
- **Signup gate refresh**: removed `チュートリアルお疲れ様`, restructured as value-first 3-bullet list.
- **PostSignupDialog refresh**: dropped the always-visible Hype guide row; new celebration-first title + subtitle.
- **Empty / error microcopy**: `dashboard.empty` becomes a promise; 5 retry-prompt errors split into a network-instability tone, with local-action errors keeping the brief transient tone.

Closes #348
Spec PR: liverty-music/specification#434

## Notable trade-off

Removing the post-signup Hype guide row reduces Hype-feature discoverability for first-time signed-up users — the i18n key `myArtists.coachMark.setHype` exists in the file but is not actually rendered by any component, so users now discover Hype only by exploring the My Artists page. Documented in the post-signup-dialog spec delta. A separate change can wire a coach mark if this becomes a meaningful regression.

## Test plan

- [x] `make lint` green (Biome + stylelint + typecheck + brand-vocabulary)
- [x] `make check` green — 1028 tests pass; no test changes were needed (the always-visible Hype row was a spec-only assertion with no test backing)
- [x] `npx tsx scripts/check-brand-vocabulary.ts` reports `8 entity.* keys verified across JA + EN`
- [ ] CI passes
- [ ] Manual smoke pass in `npm start` to verify rendered copy in both JA and EN before merge
