### PR TITLE
fix(auth): rotate Zitadel client_id and org_id post re-bootstrap

### DIFF
--- a/.env
+++ b/.env
@@ -8,8 +8,15 @@ VITE_API_BASE_URL=https://api.dev.liverty-music.app
 
 # Zitadel Authentication
 VITE_ZITADEL_ISSUER=https://auth.dev.liverty-music.app
-VITE_ZITADEL_CLIENT_ID=370552773634163460
-VITE_ZITADEL_ORG_ID=369968599999251129
+# client_id and org_id changed when the dev Zitadel instance was wiped and
+# re-bootstrapped per OpenSpec change `add-zitadel-console-admin-via-google-idp`
+# (cloud-provisioning PRs #224-#229). Both values are bound to the
+# Pulumi-managed `liverty-music` product org and `web-frontend`
+# ApplicationOidc resource. To regenerate after a future Pulumi recreate of
+# either resource, see the lookup procedure in
+# cloud-provisioning/docs/runbooks/zitadel-oauth-client-recreate.md.
+VITE_ZITADEL_CLIENT_ID=371355407710421859
+VITE_ZITADEL_ORG_ID=371348346264093539
 
 # Web Push (VAPID)
 VITE_VAPID_PUBLIC_KEY=BNg-zJP4IiX11Cz1dghWll0mwBnMV6oeOSSVsYyOK2l8NFAqN9xHFSTS_W3_oXO4k3BlMyYLjkMUE-uA7LABGHo


### PR DESCRIPTION
## Summary

The dev Zitadel instance was wiped and re-bootstrapped per OpenSpec change `add-zitadel-console-admin-via-google-idp` (cloud-provisioning PRs #224–#229). The instance now hosts two orgs:

- `admin` — role org, IAM_OWNER + Google SSO via OAuth
- `liverty-music` — product org, end-user passkey-only

Both `VITE_ZITADEL_CLIENT_ID` and `VITE_ZITADEL_ORG_ID` are bound to the new `liverty-music` product org and the new `web-frontend` `ApplicationOidc` declared in Pulumi.

## Changes

| Variable | Before | After |
|---|---|---|
| `VITE_ZITADEL_CLIENT_ID` | `370552773634163460` (deleted in DB wipe) | `371355407710421859` (current Pulumi `web-frontend`) |
| `VITE_ZITADEL_ORG_ID` | `369968599999251129` (the old `ZITADEL` bootstrap org) | `371348346264093539` (the new `liverty-music` org) |

The new `web-frontend` ApplicationOidc keeps the same redirect URIs (`https://dev.liverty-music.app/auth/callback` + `http://localhost:9000/auth/callback`) and OIDC settings, so no other code changes are needed.

A comment on the env block explains why these values are committed plain (public client identifiers, not secrets — the OAuth flow uses PKCE) and points at [`cloud-provisioning/docs/runbooks/zitadel-oauth-client-recreate.md`](https://github.com/liverty-music/cloud-provisioning/blob/main/docs/runbooks/zitadel-oauth-client-recreate.md) for the re-derivation procedure.

## Why this is needed

Without the rotation, the SPA's OIDC AuthN fails with `unauthorized_client` because the old client_id no longer exists in Zitadel — the wipe destroyed the old `ApplicationOidc` along with everything else. Frontend production users currently can't sign in to dev.

## Test plan

- [x] `make check` (lint + 1028 unit tests) passes locally
- [ ] CI passes (`Deploy Frontend` workflow builds the image with the new env)
- [ ] After merge: image pushed to `asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app:latest`
- [ ] Force a Deployment rollout so the new image is pulled (`imagePullPolicy: Always` is set, but existing pods don't redeploy on tag-only changes):
  ```bash
  kubectl -n frontend rollout restart deployment/web-app
  ```
- [ ] Browser smoke test at `https://dev.liverty-music.app`:
  - SPA loads without OIDC error
  - Sign-in completes via passkey
  - Authenticated routes (artist discovery, dashboard) load with data

Closes the W2.7.x outstanding tasks in OpenSpec change `add-zitadel-console-admin-via-google-idp`.

Refs: liverty-music/cloud-provisioning#224 liverty-music/cloud-provisioning#225 liverty-music/cloud-provisioning#226 liverty-music/cloud-provisioning#228 liverty-music/cloud-provisioning#229
Refs: liverty-music/specification#438
