### PR TITLE
feat(auth): add headless password-flow capture for Playwright E2E

### DIFF
--- a/.auth/README.md
+++ b/.auth/README.md
@@ -1,0 +1,129 @@
+# `.auth/` — Playwright E2E authentication state
+
+This directory holds credentials and captured browser state for Playwright E2E tests against the dev self-hosted Zitadel instance (`https://auth.dev.liverty-music.app`).
+
+> **Everything in `.auth/` is gitignored except this README.** Credential files (`password.md`) and captured storage state (`storageState.json`) are generated locally by each developer and never committed.
+
+---
+
+## Two test users, two capture paths
+
+| User | UserName / email | Auth method | Capture script | Suitable host |
+|---|---|---|---|---|
+| Existing passkey user | `pepperoni9+playwright-1@gmail.com` | Passkey (WebAuthn) | `scripts/capture-auth-state.ts` (headed Chromium, manual gesture) | macOS / Linux with working display + registered authenticator device |
+| **E2E password test user** (new) | `e2e-test-password@dev.liverty-music.app` | Username + password | `scripts/capture-auth-state-password.ts` (headless Chromium, scripted) | Any host including WSL2 + WSLg |
+
+Both users are provisioned in the dev Zitadel instance and coexist. Neither replaces the other.
+
+The password user was added to unblock headless / CI / WSL2 capture — passkey credentials require a biometric/PIN gesture from the registered device and cannot be replayed by headless Playwright. See OpenSpec change [`playwright-password-test-user`](../../specification/openspec/changes/) for the full design.
+
+---
+
+## First-time setup (password flow, default)
+
+### 1. Retrieve the test user's password from ESC
+
+The password is stored as a secret in Pulumi ESC under the dev environment. Retrieve it once:
+
+```bash
+esc env get liverty-music/dev pulumiConfig.zitadel.e2eTestUser.password --show-secrets
+```
+
+Output is a single string — the test user's password.
+
+### 2. Write it to `.auth/password.md`
+
+```bash
+echo '<paste-the-password-here>' > .auth/password.md
+```
+
+The file's contents are read verbatim (whitespace trimmed). No markdown formatting required.
+
+`.auth/password.md` is gitignored — never commit it.
+
+### 3. Start the dev server
+
+The capture script navigates to the local dev server (default: `http://localhost:9000`):
+
+```bash
+npm start
+```
+
+Leave it running.
+
+### 4. Run the capture script
+
+```bash
+npm run auth:capture:password
+```
+
+Expected output:
+
+```
+[1/4] Navigating to http://localhost:9000...
+[2/4] Submitting username...
+[3/4] Submitting password...
+[4/4] Waiting for OIDC callback to complete...
+Storage state saved to .auth/storageState.json
+Smoke test: replaying storage state on a fresh context...
+Smoke test PASSED: protected route loaded (http://localhost:9000/dashboard).
+```
+
+The script writes `.auth/storageState.json` and exits 0 on success. On failure (wrong password, redirect to landing, etc.) it exits non-zero — never produces a silently-broken storage state.
+
+### 5. Run E2E
+
+```bash
+npx playwright test
+```
+
+The `authenticated` and `authenticated-visual` Playwright projects (see `playwright.config.mjs`) consume `.auth/storageState.json` automatically.
+
+---
+
+## Rotating the password
+
+If the ESC secret is rotated (or the user changes the `--secret` value), Pulumi WILL NOT replace the HumanUser automatically — the resource has `ignoreChanges: ['initialPassword']` to prevent silent token invalidation. Intentional rotation:
+
+1. Set the new ESC value: `esc env set liverty-music/dev pulumiConfig.zitadel.e2eTestUser.password <new> --secret`
+2. Trigger Pulumi up with explicit replace: `pulumi up --replace 'urn:pulumi:dev::liverty-music::...:E2eTestUser$zitadel:index/humanUser:HumanUser::e2e-test-password'`
+3. Update `.auth/password.md` with the new value
+4. Re-run `npm run auth:capture:password`
+
+---
+
+## When the storage state expires
+
+Zitadel access tokens have a finite TTL. After expiry, `npx playwright test` will start failing with 401 / redirects to landing. Just re-run the capture script:
+
+```bash
+npm run auth:capture:password
+```
+
+No need to refresh `.auth/password.md` — the password itself hasn't rotated.
+
+---
+
+## Falling back to the passkey flow (manual smoke testing)
+
+The passkey path is retained for hosts with a working display and registered authenticator. Use the existing script:
+
+```bash
+npx tsx scripts/capture-auth-state.ts
+```
+
+This opens a headed Chromium window; complete the OIDC login flow with the passkey user manually. The script waits up to 5 minutes for the `oidc.user:*` key to appear in storage, then writes `.auth/storageState.json`.
+
+**WSL2 + WSLg note**: this path is currently unreliable on WSL2 — the Chromium window opens but the page often stays at `about:blank` past the 5-minute polling timeout. Use the password flow above instead.
+
+---
+
+## File reference
+
+| File | Gitignored | Purpose |
+|---|---|---|
+| `.auth/README.md` | NO (exempted) | This document |
+| `.auth/password.md` | YES | Test user password (manual mirror of ESC) |
+| `.auth/storageState.json` | YES | Captured Playwright session (regenerate on demand) |
+| `scripts/capture-auth-state-password.ts` | NO | Password-flow headless capture script |
+| `scripts/capture-auth-state.ts` | NO | Passkey-flow headed capture script (legacy) |

--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,13 @@ tmp/*
 !tmp/.gitkeep
 !tmp/ticket-journey-stub.js
 
-# Authenticated browser state for E2E testing
-.auth/
+# Authenticated browser state for E2E testing.
+# Directory-glob form (`.auth/*`) is required so the README negation
+# below takes effect — `.auth/` alone (directory pattern) ignores the
+# whole directory and disables in-directory negation patterns.
+.auth/*
+# README documents the setup and is safe to commit.
+!.auth/README.md
 
 # ZK circuit build artifacts (regenerated via circom compile + snarkjs setup)
 circuits/*/build/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,19 +57,30 @@ in the `aurelia2-component` skill. Read it before writing any component code.
 
 All routes require authentication by default (`AuthHook` in `src/hooks/auth-hook.ts`). Public routes explicitly set `data: { auth: false }` in route config.
 
-Test user: `pepperoni9+playwright-1@gmail.com` (password in `.auth/password.md`).
+Two dev test users exist; pick the capture path that matches your host:
 
-Before using the `playwright-auth` MCP server to test protected routes:
+| Test user | Auth | Capture command | Suitable host |
+|---|---|---|---|
+| `e2e-test-password@dev.liverty-music.app` | Username + password | `npm run auth:capture:password` | Any host including WSL2 + WSLg (default, headless) |
+| `pepperoni9+playwright-1@gmail.com` | Passkey (WebAuthn) | `npx tsx scripts/capture-auth-state.ts` | macOS / Linux with working display + registered authenticator device |
 
-```bash
-npx tsx scripts/capture-auth-state.ts
-```
+Both write to `.auth/storageState.json` — the `playwright-auth` MCP server (configured in `.claude/settings.json`) consumes whichever was captured most recently.
 
-This opens a browser for manual OIDC login and saves the session to `.auth/storageState.json`. The `playwright-auth` MCP server (configured in `.claude/settings.json`) uses this file automatically.
+**For the password flow** (preferred for WSL2 / CI / scripted automation):
 
-If navigation to a protected route redirects to `/`, the storageState has likely expired. Re-run the capture script.
+1. Retrieve the password from ESC once and mirror it locally:
+   ```bash
+   esc env get liverty-music/dev pulumiConfig.zitadel.e2eTestUser.password --show-secrets
+   # write the value into frontend/.auth/password.md (gitignored)
+   ```
+2. Start the dev server: `npm start`
+3. Run: `npm run auth:capture:password`
 
-On WSL2, the headed browser may not render via WSLg. Alternative: use Playwright MCP (headless) to navigate to `http://localhost:9000`, complete the login flow, extract localStorage, and write to `.auth/storageState.json`.
+The script is fully headless, drives the OIDC username/password flow, and self-verifies (atomic write — fails non-zero without destroying any prior working `storageState.json`). See [`frontend/.auth/README.md`](.auth/README.md) for the full setup, rotation protocol, and credential-file conventions.
+
+**For the passkey flow** (manual smoke testing on display-capable hosts), use the legacy `capture-auth-state.ts`. It opens a headed Chromium window for the operator to complete the OIDC login with the passkey gesture. On WSL2 + WSLg this path is unreliable — the Chromium window often stays at `about:blank` past the 5-minute polling timeout; use the password flow above instead.
+
+If navigation to a protected route redirects away from the requested page, the storageState has likely expired. Re-run the appropriate capture script.
 
 ## Key Technical Decisions
 

--- a/e2e/functional/artist-image-ui.spec.ts
+++ b/e2e/functional/artist-image-ui.spec.ts
@@ -22,7 +22,7 @@ const FANART_THUMB_URL =
 	'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
 
 const OIDC_AUTHORITY = 'https://auth.dev.liverty-music.app'
-const OIDC_CLIENT_ID = '370552773634163460'
+const OIDC_CLIENT_ID = '371355407710421859'
 
 const tomorrow = new Date()
 tomorrow.setDate(tomorrow.getDate() + 1)
@@ -256,7 +256,7 @@ function seedAuthenticatedState() {
 		// Key format: {prefix}user:{authority}:{client_id} (default prefix: "oidc.")
 		// MUST match runtime config in .env (VITE_ZITADEL_ISSUER + VITE_ZITADEL_CLIENT_ID).
 		const oidcKey =
-			'oidc.user:https://auth.dev.liverty-music.app:370552773634163460'
+			'oidc.user:https://auth.dev.liverty-music.app:371355407710421859'
 		localStorage.setItem(
 			oidcKey,
 			JSON.stringify({

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
 		"test": "vitest",
 		"storybook": "storybook dev -p 6006",
 		"build-storybook": "storybook build",
-		"test:e2e": "playwright test"
+		"test:e2e": "playwright test",
+		"auth:capture:password": "npx tsx scripts/capture-auth-state-password.ts"
 	},
 	"type": "module",
 	"overrides": {

--- a/scripts/capture-auth-state-password.ts
+++ b/scripts/capture-auth-state-password.ts
@@ -73,10 +73,25 @@ async function captureAuthStatePassword(): Promise<void> {
 		const page = await context.newPage()
 		page.setDefaultTimeout(60_000)
 
-		console.log(`[1/4] Navigating to ${APP_URL}…`)
+		console.log(`[1/5] Navigating to ${APP_URL}…`)
 		await page.goto(APP_URL)
 
-		console.log('[2/4] Submitting username…')
+		console.log('[2/5] Clicking welcome page Login CTA to start OIDC sign-in…')
+		// The welcome page does NOT auto-redirect to Zitadel — OIDC sign-in
+		// is only initiated by clicking the Login button wired to
+		// `handleLogin()` in `src/routes/welcome/welcome-route.ts`. The
+		// button has class `welcome-btn-secondary` (the welcome HTML
+		// renders one of two button groups depending on `dateGroups.length`;
+		// `.first()` picks whichever is visible).
+		const loginButton = page.locator('button.welcome-btn-secondary').first()
+		await loginButton.waitFor({ state: 'visible' })
+		await loginButton.click()
+		// Wait for the cross-origin navigation to the Zitadel auth server.
+		// `waitForURL` matches against the full URL; the regex tolerates
+		// any path under the auth host.
+		await page.waitForURL(/auth\.dev\.liverty-music\.app/, { timeout: 30_000 })
+
+		console.log('[3/5] Submitting username…')
 		// Zitadel Login V2 — username input. The locator tolerates either
 		// the explicit `loginName` field name or a generic text input as a
 		// resilience hedge against upstream markup tweaks.
@@ -90,7 +105,7 @@ async function captureAuthStatePassword(): Promise<void> {
 			.first()
 			.click()
 
-		console.log('[3/4] Submitting password…')
+		console.log('[4/5] Submitting password…')
 		const passwordInput = page
 			.locator('input[type="password"], input[name="password"]')
 			.first()
@@ -98,7 +113,7 @@ async function captureAuthStatePassword(): Promise<void> {
 		await passwordInput.fill(password)
 		await page.locator('button[type="submit"]').first().click()
 
-		console.log('[4/4] Waiting for OIDC callback to complete…')
+		console.log('[5/5] Waiting for OIDC callback to complete…')
 		await page.waitForFunction(
 			() => {
 				try {

--- a/scripts/capture-auth-state-password.ts
+++ b/scripts/capture-auth-state-password.ts
@@ -118,35 +118,51 @@ async function captureAuthStatePassword(): Promise<void> {
 			{ polling: 500, timeout: 60_000 },
 		)
 
-		await context.storageState({ path: STORAGE_STATE_PATH })
-		console.log(`Storage state saved to ${STORAGE_STATE_PATH}`)
+		// Write to a temp path first; promote atomically only after the
+		// smoke test confirms the captured state actually authenticates.
+		// Without this, a failed smoke test would silently destroy the
+		// previously-working `storageState.json` (we write before we verify).
+		const tempStatePath = `${STORAGE_STATE_PATH}.tmp`
+		await context.storageState({ path: tempStatePath })
 		await context.close()
 
-		console.log('Smoke test: replaying storage state on a fresh context…')
+		console.log('Smoke test: replaying captured state on a fresh context…')
 		const smokeContext = await browser.newContext({
-			storageState: STORAGE_STATE_PATH,
+			storageState: tempStatePath,
 		})
 		const smokePage = await smokeContext.newPage()
 		smokePage.setDefaultTimeout(15_000)
 
-		// Navigate to a protected route. The frontend's AuthHook will
-		// redirect unauthenticated traffic back to `/`, so the final URL
-		// is the success/failure signal.
+		// Navigate to a protected route. Authenticated traffic lands on
+		// `/dashboard`; unauthenticated traffic gets redirected by
+		// `AuthHook` (priority 5 returns '') → root route's
+		// `redirectTo: 'welcome'` → `/welcome`. Use a POSITIVE check
+		// (must land on the requested protected route) rather than
+		// enumerating redirect targets — the check is robust even when
+		// the unauthenticated landing path changes.
 		await smokePage.goto(`${APP_URL}/dashboard`)
 		await smokePage.waitForLoadState('networkidle')
 		const finalUrl = smokePage.url()
 		await smokeContext.close()
 
-		const landingUrls = [APP_URL, `${APP_URL}/`]
-		if (landingUrls.includes(finalUrl)) {
+		if (!finalUrl.startsWith(`${APP_URL}/dashboard`)) {
 			console.error(
-				`[error] Smoke test FAILED: protected route redirected to landing (${finalUrl}).`,
+				`[error] Smoke test FAILED: protected route redirected away from /dashboard (landed at ${finalUrl}).`,
 			)
 			console.error('The captured storageState does not authenticate the user.')
 			console.error('Likely causes: wrong password, expired ESC value, or test user not provisioned.')
+			// Leave the previously-working storageState.json (if any) intact.
+			try {
+				fs.unlinkSync(tempStatePath)
+			} catch {
+				// nothing to clean up
+			}
 			process.exit(2)
 		}
 
+		// Smoke passed — atomically promote the temp file to the final path.
+		fs.renameSync(tempStatePath, STORAGE_STATE_PATH)
+		console.log(`Storage state saved to ${STORAGE_STATE_PATH}`)
 		console.log(`Smoke test PASSED: ${finalUrl}`)
 	} finally {
 		await browser.close()

--- a/scripts/capture-auth-state-password.ts
+++ b/scripts/capture-auth-state-password.ts
@@ -1,0 +1,159 @@
+/**
+ * Captures an authenticated Playwright session via the dev self-hosted
+ * Zitadel password flow.
+ *
+ * Headless. No display server required. Suitable for WSL2 + WSLg hosts
+ * where `capture-auth-state.ts` (headed Chromium) cannot render the
+ * Chromium window reliably.
+ *
+ * Usage:
+ *
+ *   npm run auth:capture:password
+ *
+ * Prerequisites:
+ *
+ *   - The frontend dev server must be running: `npm start`
+ *   - The password test user has been provisioned via Pulumi
+ *     (`cloud-provisioning` change `playwright-password-test-user`).
+ *   - The test user's password is present either at `.auth/password.md`
+ *     (preferred — mirror of the ESC secret) or in `E2E_PASSWORD`.
+ *
+ * See `.auth/README.md` for the first-time setup procedure and the
+ * ESC retrieval command.
+ *
+ * Output:
+ *
+ *   `.auth/storageState.json` (gitignored).
+ *
+ * The script exits non-zero if any step fails — it never produces a
+ * silently-broken storageState. The Playwright `authenticated` and
+ * `authenticated-visual` projects in `playwright.config.mjs` consume
+ * this file automatically.
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { chromium } from '@playwright/test'
+
+const APP_URL = process.env.APP_URL || 'http://localhost:9000'
+const OUTPUT_DIR = path.join(import.meta.dirname, '..', '.auth')
+const STORAGE_STATE_PATH = path.join(OUTPUT_DIR, 'storageState.json')
+const PASSWORD_PATH = path.join(OUTPUT_DIR, 'password.md')
+const DEFAULT_USERNAME = 'e2e-test-password@dev.liverty-music.app'
+
+function loadPassword(): string {
+	const envPassword = process.env.E2E_PASSWORD
+	if (envPassword) {
+		return envPassword
+	}
+	if (!fs.existsSync(PASSWORD_PATH)) {
+		console.error(`[error] Password file not found: ${PASSWORD_PATH}`)
+		console.error('Either set E2E_PASSWORD or create .auth/password.md.')
+		console.error('See .auth/README.md "First-time setup" for the ESC command.')
+		process.exit(1)
+	}
+	const contents = fs.readFileSync(PASSWORD_PATH, 'utf-8').trim()
+	if (contents.length === 0) {
+		console.error(`[error] Password file is empty: ${PASSWORD_PATH}`)
+		process.exit(1)
+	}
+	return contents
+}
+
+async function captureAuthStatePassword(): Promise<void> {
+	fs.mkdirSync(OUTPUT_DIR, { recursive: true })
+
+	const username = process.env.E2E_USERNAME || DEFAULT_USERNAME
+	const password = loadPassword()
+
+	const browser = await chromium.launch({ headless: true })
+
+	try {
+		const context = await browser.newContext()
+		const page = await context.newPage()
+		page.setDefaultTimeout(60_000)
+
+		console.log(`[1/4] Navigating to ${APP_URL}…`)
+		await page.goto(APP_URL)
+
+		console.log('[2/4] Submitting username…')
+		// Zitadel Login V2 — username input. The locator tolerates either
+		// the explicit `loginName` field name or a generic text input as a
+		// resilience hedge against upstream markup tweaks.
+		const usernameInput = page
+			.locator('input[name="loginName"], input[autocomplete="username"], input[type="text"]')
+			.first()
+		await usernameInput.waitFor({ state: 'visible' })
+		await usernameInput.fill(username)
+		await page
+			.locator('button[type="submit"]')
+			.first()
+			.click()
+
+		console.log('[3/4] Submitting password…')
+		const passwordInput = page
+			.locator('input[type="password"], input[name="password"]')
+			.first()
+		await passwordInput.waitFor({ state: 'visible' })
+		await passwordInput.fill(password)
+		await page.locator('button[type="submit"]').first().click()
+
+		console.log('[4/4] Waiting for OIDC callback to complete…')
+		await page.waitForFunction(
+			() => {
+				try {
+					const localKeys = Object.keys(localStorage)
+					const sessionKeys = Object.keys(sessionStorage)
+					return Boolean(
+						localKeys.find((key) => key.startsWith('oidc.user:')) ||
+							sessionKeys.find((key) => key.startsWith('oidc.user:')),
+					)
+				} catch {
+					// Some intermediate pages (Zitadel Login V2, about:blank during
+					// redirects) throw SecurityError when reading storage. Treat as
+					// "not yet authenticated" and keep polling.
+					return false
+				}
+			},
+			{ polling: 500, timeout: 60_000 },
+		)
+
+		await context.storageState({ path: STORAGE_STATE_PATH })
+		console.log(`Storage state saved to ${STORAGE_STATE_PATH}`)
+		await context.close()
+
+		console.log('Smoke test: replaying storage state on a fresh context…')
+		const smokeContext = await browser.newContext({
+			storageState: STORAGE_STATE_PATH,
+		})
+		const smokePage = await smokeContext.newPage()
+		smokePage.setDefaultTimeout(15_000)
+
+		// Navigate to a protected route. The frontend's AuthHook will
+		// redirect unauthenticated traffic back to `/`, so the final URL
+		// is the success/failure signal.
+		await smokePage.goto(`${APP_URL}/dashboard`)
+		await smokePage.waitForLoadState('networkidle')
+		const finalUrl = smokePage.url()
+		await smokeContext.close()
+
+		const landingUrls = [APP_URL, `${APP_URL}/`]
+		if (landingUrls.includes(finalUrl)) {
+			console.error(
+				`[error] Smoke test FAILED: protected route redirected to landing (${finalUrl}).`,
+			)
+			console.error('The captured storageState does not authenticate the user.')
+			console.error('Likely causes: wrong password, expired ESC value, or test user not provisioned.')
+			process.exit(2)
+		}
+
+		console.log(`Smoke test PASSED: ${finalUrl}`)
+	} finally {
+		await browser.close()
+	}
+}
+
+captureAuthStatePassword().catch((err) => {
+	console.error('Failed to capture auth state:', err)
+	process.exit(1)
+})


### PR DESCRIPTION
## Description

Add a headless Playwright capture path for the dev E2E password test user (provisioned by liverty-music/cloud-provisioning#254). Companion to liverty-music/specification#456 (`playwright-password-test-user`).

The existing `scripts/capture-auth-state.ts` (headed Chromium + manual passkey gesture) is unusable on WSL2 + WSLg (Chromium opens but stays at `about:blank` past the 5-minute polling timeout) and incompatible with headless automation in general. The new path runs entirely headless, drives the OIDC username/password flow against `https://auth.dev.liverty-music.app`, and self-verifies the captured storage state before exiting.

**Tasks covered (from `playwright-password-test-user/tasks.md`):**

- §2.2 `.gitignore` — switched `.auth/` → `.auth/*` so `!.auth/README.md` negation takes effect (git's directory-glob semantics). `password.md` and `storageState.json` remain ignored.
- §2.3 `frontend/.auth/README.md` (new, committed) — documents both test users, ESC retrieval procedure, rotation protocol, WSL2 caveat.
- §3.1 Capture-tool decision — Playwright Node API in headless mode (the documented fallback per Design D2 — chosen over Playwright MCP integration to keep the change CI-portable and dependency-free at the project level).
- §3.2 New `scripts/capture-auth-state-password.ts` — launches headless Chromium → fills username + password → waits for `oidc.user:*` in storage → writes `.auth/storageState.json`.
- §3.3 `npm run auth:capture:password` script in `package.json`.
- §3.4 Smoke step inside the script — after writing storageState, replays it on a fresh `BrowserContext` and asserts `/dashboard` does not redirect to landing; exits non-zero on failure (no silently-broken storage state).
- §5.1 The existing `scripts/capture-auth-state.ts` (passkey path) is intentionally untouched.
- §5.2 `.auth/README.md` cross-links both scripts with their suitable-host matrix.

**Tasks NOT in this PR (operator/live ops):**

- §2.1 — copy the password from ESC into `.auth/password.md` locally
- §3.5 — run the new capture script on the developer's WSL2 host and verify end-to-end
- §4.1–§4.3 — `npx playwright test` + storage-state regenerate

**Dependency on the cloud-provisioning PR:** the test user (`e2e-test-password@dev.liverty-music.app`) doesn't exist yet — liverty-music/cloud-provisioning#254 provisions it. This frontend PR can land before or after that one, but the capture script will only succeed after the test user is live in dev Zitadel.

## Type of Change

- [x] feat: A new feature
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] build
- [ ] chore

## Verification

### Automated Tests

- [x] `npm run lint` passed (biome + stylelint + brand vocabulary + tsc — all clean)
- [ ] `npm run test` — N/A for this PR (no unit tests; the change is a build-time script + docs)
- [ ] `npm run build` — N/A (script lives outside the Vite build graph)

### Manual Verification

Deferred to operator post-merge (after the cloud-provisioning side lands and the ESC secret is seeded):

1. `esc env get liverty-music/dev pulumiConfig.zitadel.e2eTestUser.password --show-secrets` → write to `.auth/password.md`
2. `npm start` (dev server)
3. `npm run auth:capture:password` → confirm exit 0 and "Smoke test PASSED"
4. `npx playwright test` against the `authenticated` and `authenticated-visual` projects → confirm tests run

## Checklist

- [x] My code follows the style guidelines of this project (biome + stylelint pass)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (Zitadel Login V2 selector locator chains; storage-state polling)
- [x] I have made corresponding changes to the documentation (`.auth/README.md`)
- [x] My changes generate no new warnings

close: liverty-music/frontend#345
