### PR TITLE
fix(auth): unblock local OIDC sign-in against self-hosted Zitadel

### DIFF
--- a/scripts/capture-auth-state-password.ts
+++ b/scripts/capture-auth-state-password.ts
@@ -113,6 +113,34 @@ async function captureAuthStatePassword(): Promise<void> {
 		await passwordInput.fill(password)
 		await page.locator('button[type="submit"]').first().click()
 
+		// Zitadel forces a "change password on first sign-in" step when the
+		// HumanUser is created with `initialPassword` (the
+		// `@pulumiverse/zitadel.HumanUser` resource doesn't expose a
+		// `changeRequired: false` knob today — see TODO note in
+		// `cloud-provisioning/src/zitadel/components/e2e-test-user.ts`).
+		// Detect the redirect to `/ui/v2/login/password/change` and clear
+		// the prompt by re-submitting the same password as the new one.
+		// Zitadel's default password policy has no history check, so
+		// `new = current` is accepted. This step is a no-op after the
+		// first run because Zitadel marks the password as `changeRequired
+		// = false` once the user completes the prompt once.
+		await page.waitForTimeout(1500)
+		if (page.url().includes('/password/change')) {
+			console.log('[4b/5] Clearing first-sign-in password-change prompt…')
+			const changeForm = page.locator('input[type="password"]')
+			const fields = await changeForm.all()
+			if (fields.length < 2) {
+				throw new Error(
+					`Expected at least 2 password fields on /password/change, found ${fields.length}`,
+				)
+			}
+			// Current Password / New Password / Confirm Password (3 fields)
+			for (const field of fields) {
+				await field.fill(password)
+			}
+			await page.locator('button[type="submit"]').first().click()
+		}
+
 		console.log('[5/5] Waiting for OIDC callback to complete…')
 		await page.waitForFunction(
 			() => {

--- a/src/services/otel-init.ts
+++ b/src/services/otel-init.ts
@@ -29,7 +29,18 @@ export function initOtel(): WebTracerProvider {
 		instrumentations: [
 			new FetchInstrumentation({
 				propagateTraceHeaderCorsUrls: [new RegExp(escapeRegExp(API_BASE_URL))],
-				ignoreUrls: [/zitadel\.cloud/],
+				// Skip the OIDC provider entirely — Zitadel's CORS preflight
+				// rejects requests that include `traceparent` in the
+				// `Access-Control-Request-Headers` list (the preflight 204
+				// comes back WITHOUT `Access-Control-Allow-Origin`, blocking
+				// the actual `/.well-known/openid-configuration` fetch).
+				// Listing both the legacy Cloud host and the self-hosted
+				// `auth.*.liverty-music.app` hosts keeps this resilient
+				// across env (dev/staging/prod) and the never-merged rollback.
+				ignoreUrls: [
+					/zitadel\.cloud/,
+					/^https:\/\/auth\..*\.liverty-music\.app/,
+				],
 			}),
 		],
 	})


### PR DESCRIPTION
## Description

Two surgical fixes discovered while running the headless capture flow added in #352 end-to-end against the dev self-hosted Zitadel. Both are regressions from the `self-hosted-zitadel` cutover that surfaced as Playwright-only blockers; deployed user flows happen to work for different reasons.

## Type of Change

- [x] fix
- [ ] feat
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] build
- [ ] chore

## Bug #1 — `src/services/otel-init.ts` `ignoreUrls` was stale

After the 2026-04-30 self-hosted Zitadel cutover the active issuer is `https://auth.dev.liverty-music.app`, but `ignoreUrls: [/zitadel\.cloud/]` still matched only the pre-cutover Cloud host. Effect:

1. `@opentelemetry/instrumentation-fetch` (registered for all fetches not in `ignoreUrls`) adds `traceparent` to the OIDC discovery request preflight.
2. Zitadel's CORS handler returns 204 to the preflight **without** an `Access-Control-Allow-Origin` header when `Access-Control-Request-Headers` lists `traceparent` (verified with `curl -X OPTIONS …`).
3. The browser blocks the actual `/.well-known/openid-configuration` fetch.
4. `oidc-client-ts` `signinRedirect()` throws `TypeError: Failed to fetch` — clicking the welcome page Login CTA is a silent no-op.

This affects **any** developer running `npm start` and trying to sign in via the local dev server. Deployed dev (`dev.liverty-music.app`) presumably works because either the OTel SDK uses a different config there or the preflight path differs (not investigated — same-origin parent domain may relax CORS handling).

**Fix:** add a regex matching any `auth.*.liverty-music.app` host so the OIDC provider is excluded from OTel fetch instrumentation across all envs.

```diff
- ignoreUrls: [/zitadel\.cloud/],
+ ignoreUrls: [
+   /zitadel\.cloud/,
+   /^https:\/\/auth\..*\.liverty-music\.app/,
+ ],
```

## Bug #2 — `scripts/capture-auth-state-password.ts` did not handle Zitadel's "change password on first sign-in" prompt

When a `zitadel.HumanUser` is created with `initialPassword`, Zitadel sets `changeRequired = true` on the credential by default — the next sign-in is redirected to `/ui/v2/login/password/change`. The `@pulumiverse/zitadel.HumanUser` resource does not expose a `changeRequired: false` knob, so the prompt is unavoidable from the Pulumi side today.

The proper fix is a Pulumi Dynamic Resource that calls Zitadel Management API's `SetPassword(noChangeRequired=true)` after the HumanUser is created (mirroring the existing `ZitadelSmtpActivation` / `ZitadelUserIdpLink` patterns in `cloud-provisioning/src/zitadel/dynamic/`). That's tracked as a future follow-up — see the e2e-test-user component header.

In the meantime this PR makes the capture script tolerate the prompt: detect the redirect to `/password/change`, re-submit the current password as the "new" one (Zitadel's default password policy has no history check, so `new == current` is accepted), and continue. The step becomes a no-op after the first run because Zitadel updates `changeRequired` to false once the form is submitted.

## Verification

After both fixes, run end-to-end against dev:

```bash
# Tab A
npm start
# Tab B
npm run auth:capture:password
# → [1/5]…[5/5] all green, "Smoke test PASSED: http://localhost:9000/dashboard"

npx playwright test --project authenticated --project authenticated-visual
# → 6 passed (11.1s)
```

(Empirically verified on a WSL2 + WSLg host after `kubectl rollout restart deploy/zitadel-api -n zitadel` to clear a separate `self-hosted-zitadel §18.6` Login V2 in-memory state issue. The Zitadel restart is unrelated to this PR.)

## Verification (Automated)

- [x] `make lint` passed (biome + stylelint + brand vocabulary + tsc)
- [ ] `make test` — N/A (no unit-test surface)
- [ ] `make build` — N/A (script-only + config-only changes)

### Manual Verification

- [x] Local OIDC sign-in flow against dev Zitadel: completes end-to-end on WSL2
- [x] `npm run auth:capture:password`: exits 0 with smoke pass
- [x] `npx playwright test --project authenticated --project authenticated-visual`: 6/6 green
- [x] `git status` shows `.auth/storageState.json` excluded by `.auth/*` pattern

## Checklist

- [x] My code follows the style guidelines of this project (biome + stylelint pass)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (CORS root-cause note in `otel-init.ts`; Zitadel `changeRequired` note in the capture script)
- [ ] I have made corresponding changes to the documentation — N/A (both are bug fixes; `.auth/README.md` from #352 still reflects the user-facing flow)
- [x] My changes generate no new warnings

close:
