### PR TITLE
ci(deploy): add release-tag prod build path + .env.prod overlay

### DIFF
--- a/.env.prod
+++ b/.env.prod
@@ -1,0 +1,41 @@
+# Vite environment overlay for prod builds (loaded via `vite build --mode prod`).
+# Per OpenSpec change `prepare-prod-service-in` D3, this file is committed
+# to the repo because all `VITE_*` values are public by SPA convention
+# (`AuthMethodType=NONE` → OIDC client_id is unguarded; VAPID public key
+# is by definition public; preview artist IDs are non-sensitive).
+#
+# The dev `.env` is also loaded first as the base; this file overlays
+# prod-specific values on top.
+
+# Logging — prod runs at info level (no debug console noise in browser).
+VITE_LOG_LEVEL=info
+
+# Apex API + auth endpoints (per `consolidate-public-dns-on-cloudflare`
+# which made apex `liverty-music.app` a first-class hostname).
+VITE_API_BASE_URL=https://api.liverty-music.app
+VITE_ZITADEL_ISSUER=https://auth.liverty-music.app
+
+# Zitadel SPA OIDC client_id + product-org id — sourced from the prod
+# Pulumi stack state (exported via `pulumi stack output
+# webFrontendClientId/productOrgId --stack prod --show-secrets`, also
+# directly readable via `pulumi stack export --stack prod --show-secrets`
+# on the `web-frontend` ApplicationOidc resource). These values were
+# captured 2026-05-15 from the prod Pulumi state established by the
+# `refactor-unify-env-dispatch` bring-up.
+VITE_ZITADEL_CLIENT_ID=373015520582107291
+VITE_ZITADEL_ORG_ID=373015514391249051
+
+# Web Push (VAPID) — public half of the prod keypair whose private half
+# lives in GSM `vapid-private-key` (project `liverty-music-prod`).
+# Derived 2026-05-15 via P-256 point multiplication of the GSM scalar.
+# See OpenSpec change `prepare-prod-service-in` §6 + cloud-provisioning
+# PR #265 for the matching configmap update.
+VITE_VAPID_PUBLIC_KEY=BH-m9-6-0-y70MdQG7Lz-htDaz4T_NuYdmcgK5wBEElzXo22AyGs30gvHAtHbWtQBQa4XxySD6ZEaiM9Crwl6Pc
+
+# Welcome page preview: curated artist UUIDs + display names. Both lists
+# must be the same length and in the same order. Values differ per env
+# because each env has its own DB seed; the prod list below is an initial
+# carry-over from dev pending dedicated prod curation (tracked as
+# `prepare-prod-service-in` §16, low priority, follow-up PR).
+VITE_PREVIEW_ARTIST_IDS=019c8655-7a05-71ef-82b4-a4ac2494e29f,019c8655-7a05-721d-b0a8-4c11724d5c90,019c8655-7a05-71e9-9af5-e1cd4fbfd367,019c899e-baff-7ecd-8af2-e8dc819e29e4,019c8655-7a05-71f5-acd4-46157dcb0bec,019c8655-7a05-722a-bdae-a89596378f90,019c8655-7a05-72ff-8654-4e09e64043da,019c8655-7a05-723e-bef1-2d2433cd53f5,019c8655-7a05-7217-8f63-7a261ebcfceb,019c8655-7a05-72e7-a9c3-44a27d2bf07e,019c8655-7a05-71fc-bc48-92705b9ddb68
+VITE_PREVIEW_ARTIST_NAMES=Mrs. GREEN APPLE,YOASOBI,Vaundy,SUPER BEAVER,King Gnu,Official髭男dism,Creepy Nuts,Ado,back number,ONE OK ROCK,RADWIMPS

--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -33,10 +33,15 @@ concurrency:
 
 jobs:
   build-and-push:
-    # Defensive guard: only fire on the two supported events.
+    # Defensive guard: only fire on the two supported events AND require
+    # both to originate from `main`. `target_commitish` is the branch/SHA
+    # the Release was created against (set by `--target` on
+    # `gh release create`); without this check a Release published from a
+    # feature branch tag would push to prod AR. See PR #356 review thread.
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'release' && github.event.action == 'published')
+      (github.event_name == 'release' && github.event.action == 'published' &&
+       github.event.release.target_commitish == 'main')
     runs-on: ubuntu-latest
     environment:
       # release -> prod; push to main -> dev. The `prod` environment binds

--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -1,5 +1,15 @@
 name: Deploy Frontend
 
+# Dual trigger per OpenSpec change `prepare-prod-service-in`:
+#  - push to main      -> dev build, dev AR (liverty-music-dev/frontend)
+#  - release published -> prod build, prod AR (liverty-music-prod/frontend)
+#
+# The `paths:` filter only applies to push events. Release events fire on
+# any published Release regardless of file diff — the deploy step is
+# always desired for a Release cut. The path list also covers `.env.prod`
+# (loaded via `--build-arg VITE_MODE=prod`) so prod-affecting changes
+# trigger dev rebuilds for sanity (the dev build itself ignores
+# `.env.prod` because Vite mode stays at the default).
 on:
   push:
     branches:
@@ -10,9 +20,12 @@ on:
       - 'package-lock.json'
       - 'vite.config.ts'
       - '.env'
+      - '.env.prod'
       - 'Dockerfile'
       - 'Caddyfile'
       - '.github/workflows/push-image.yaml'
+  release:
+    types: [published]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,9 +33,17 @@ concurrency:
 
 jobs:
   build-and-push:
+    # Defensive guard: only fire on the two supported events.
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'release' && github.event.action == 'published')
     runs-on: ubuntu-latest
     environment:
-      name: dev
+      # release -> prod; push to main -> dev. The `prod` environment binds
+      # vars.PROJECT_ID=liverty-music-prod / vars.WORKLOAD_IDENTITY_PROVIDER /
+      # vars.SERVICE_ACCOUNT scoped to the prod project (managed by Pulumi's
+      # GitHubRepositoryComponent — see cloud-provisioning/src/github/).
+      name: ${{ github.event_name == 'release' && 'prod' || 'dev' }}
     permissions:
       contents: read
       id-token: write
@@ -54,6 +75,30 @@ jobs:
       - name: Set Image URI
         run: echo "IMAGE_URI=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE }}" >> $GITHUB_ENV
 
+      # Dev tag set: :latest (consumed by ArgoCD Image Updater for dev
+      # auto-rollout) + :sha (immutable digest pointer) + :main.
+      # Prod is forbidden from using :latest per the `prod-image-pipeline`
+      # spec — release builds use :<tag> + :sha only.
+      - name: Set Image Tags (dev path)
+        if: github.event_name == 'push'
+        run: echo "IMAGE_TAGS=${{ env.IMAGE_URI }}:latest,${{ env.IMAGE_URI }}:${{ github.sha }},${{ env.IMAGE_URI }}:main" >> $GITHUB_ENV
+
+      - name: Set Image Tags (prod path)
+        if: github.event_name == 'release'
+        run: echo "IMAGE_TAGS=${{ env.IMAGE_URI }}:${{ github.event.release.tag_name }},${{ env.IMAGE_URI }}:${{ github.sha }}" >> $GITHUB_ENV
+
+      # VITE_MODE build-arg: unset for dev (Dockerfile runs `npm run build`,
+      # loading only `.env`); set to `prod` for release builds (Dockerfile
+      # runs `npm run build -- --mode prod`, loading `.env` + `.env.prod`).
+      # See OpenSpec design D2.
+      - name: Set Build Args (dev path)
+        if: github.event_name == 'push'
+        run: echo "BUILD_ARGS=" >> $GITHUB_ENV
+
+      - name: Set Build Args (prod path)
+        if: github.event_name == 'release'
+        run: echo "BUILD_ARGS=VITE_MODE=prod" >> $GITHUB_ENV
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -62,6 +107,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.IMAGE_URI }}:latest,${{ env.IMAGE_URI }}:${{ github.sha }},${{ env.IMAGE_URI }}:main
+          tags: ${{ env.IMAGE_TAGS }}
+          build-args: ${{ env.BUILD_ARGS }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -33,15 +33,16 @@ concurrency:
 
 jobs:
   build-and-push:
-    # Defensive guard: only fire on the two supported events AND require
-    # both to originate from `main`. `target_commitish` is the branch/SHA
-    # the Release was created against (set by `--target` on
-    # `gh release create`); without this check a Release published from a
-    # feature branch tag would push to prod AR. See PR #356 review thread.
+    # Defensive guard layer 1 (event filter): only fire on the two supported
+    # events. The `target_commitish == 'main'` check is intentionally
+    # absent — it's release-creation metadata, not a verified assertion
+    # about the tag's underlying commit (mirrors the analysis in backend
+    # PR #297 review threads 3248512589 / 3248513873). The authoritative
+    # check is the runtime `Verify release commit on main` step below,
+    # which compares `github.sha` against `origin/main` history.
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'release' && github.event.action == 'published' &&
-       github.event.release.target_commitish == 'main')
+      (github.event_name == 'release' && github.event.action == 'published')
     runs-on: ubuntu-latest
     environment:
       # release -> prod; push to main -> dev. The `prod` environment binds
@@ -63,6 +64,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      # Defensive guard layer 2 (runtime verification): for release events,
+      # confirm the checked-out commit (`github.sha`, == the tag's commit)
+      # is actually reachable from `origin/main`. Closes the gap where:
+      #   * a tag points at a non-main commit, AND
+      #   * the release was created with `--target main` (so a literal
+      #     `target_commitish == 'main'` event-level check would falsely
+      #     pass), OR
+      #   * the release was created with `--target <sha>` (where the SHA
+      #     happens to be main HEAD but the literal `target_commitish`
+      #     string is the SHA, not `"main"`).
+      # See backend PR #297 review threads 3248512589 (false-negative)
+      # and 3248513873 (false-positive) for the analysis.
+      - name: Verify release commit is on main
+        if: github.event_name == 'release'
+        run: |
+          git fetch origin main --depth=100
+          if ! git merge-base --is-ancestor HEAD origin/main; then
+            echo "::error::Release tag at $(git rev-parse HEAD) is not reachable from origin/main ($(git rev-parse origin/main)). Refusing to push prod images. Cut releases on main HEAD only."
+            exit 1
+          fi
 
       - name: Authenticate to Google Cloud
         id: auth

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,19 @@ RUN npm ci
 # Copy source code (including .env files)
 COPY . .
 
-# Build the application
-RUN npm run build
+# Vite mode selector — controls which `.env.<mode>` overlay file is loaded
+# on top of the base `.env` at build time. Defaults to empty (Vite's
+# built-in `production` mode, which loads only `.env`). The prod CI path
+# passes `--build-arg VITE_MODE=prod` to load `.env.prod` overlay (apex
+# API URL, prod OIDC issuer + client_id + org_id, prod VAPID public key,
+# `info` log level). See OpenSpec change `prepare-prod-service-in` D2.
+ARG VITE_MODE=""
+
+# Build the application. When VITE_MODE is unset (= dev path), this is
+# `npm run build` (Vite defaults to mode=production but no `.env.production`
+# file exists so only `.env` is loaded). When VITE_MODE=prod, this becomes
+# `npm run build -- --mode prod`, loading `.env` + `.env.prod`.
+RUN if [ -n "$VITE_MODE" ]; then npm run build -- --mode "$VITE_MODE"; else npm run build; fi
 
 #----------------------------
 


### PR DESCRIPTION
## Summary

Implements OpenSpec change `prepare-prod-service-in` **§7** — frontend release-tag-triggered prod build path + `.env.prod` Vite overlay with prod identifiers.

After this PR merges, publishing a GitHub Release on `main` (e.g., `v1.0.0`, post `§8` operator action) triggers a prod-AR push to `liverty-music-prod/frontend/web-app:<tag>,:<sha>`, baked with prod URLs / OIDC client / VAPID public via `vite build --mode prod` loading `.env.prod`. Push-to-main keeps building dev images unchanged.

## Changes

### `.github/workflows/push-image.yaml`
- Dual trigger: `push: branches:[main]` (dev) + `release: types:[published]` (prod). `paths:` filter applies only to push events; release events fire on any published Release.
- Path list extended to include `.env.prod` so prod-affecting edits also rebuild dev (sanity; dev's Vite mode ignores `.env.prod` content).
- Job-level `environment:` selector: `release` → `prod`, push → `dev`. Picks up Pulumi-managed Environment vars (`vars.PROJECT_ID=liverty-music-prod`, etc.).
- Defensive `if:` guard at job level — only fires on the two supported event combinations.
- Image tags are event-conditional via two mutually-exclusive `Set Image Tags` steps:
  - dev: `:latest,:<sha>,:main` (preserved — ArgoCD Image Updater for dev consumes `:latest`).
  - prod: `:<release-tag>,:<sha>` (no `:latest` per the `prod-image-pipeline` spec).
- `BUILD_ARGS` is conditional too: empty on dev path (default `npm run build`); `VITE_MODE=prod` on release path (`npm run build -- --mode prod`).

### `Dockerfile`
- Added `ARG VITE_MODE=""` build-arg.
- Build step is now conditional:
  ```dockerfile
  RUN if [ -n "$VITE_MODE" ]; then \
        npm run build -- --mode "$VITE_MODE"; \
      else \
        npm run build; \
      fi
  ```
- Dev path (no arg) preserves current behavior — Vite defaults to mode=production, loads only `.env`.
- Prod path (`VITE_MODE=prod`) loads `.env` + `.env.prod` overlay.

### `.env.prod` (new)
Per OpenSpec design D3, `.env.prod` is committed to the repo (all `VITE_*` values are public by SPA convention).

| Key | Value | Source |
|---|---|---|
| `VITE_LOG_LEVEL` | `info` | spec §7.1 |
| `VITE_API_BASE_URL` | `https://api.liverty-music.app` | apex DNS established by `consolidate-public-dns-on-cloudflare` |
| `VITE_ZITADEL_ISSUER` | `https://auth.liverty-music.app` | same |
| `VITE_ZITADEL_CLIENT_ID` | `373015520582107291` | prod Pulumi stack state — `pulumi stack export --stack prod --show-secrets` on the `web-frontend` ApplicationOidc URN. Captured 2026-05-15. cloud-provisioning PR #264 exposes this via `pulumi stack output webFrontendClientId` once the next prod up runs. |
| `VITE_ZITADEL_ORG_ID` | `373015514391249051` | same state export, prod `liverty-music` product org. |
| `VITE_VAPID_PUBLIC_KEY` | `BH-m9-6-0-...Crwl6Pc` | P-256 point derived from the GSM `vapid-private-key` scalar in `liverty-music-prod` (Phase 6 audit, 2026-05-15). Matches the configmap update in cloud-provisioning PR #265. |
| `VITE_PREVIEW_ARTIST_IDS` / `_NAMES` | (carry-over from dev) | initial seed pending dedicated prod curation per spec §16. |

## Verification

- [x] `make lint` passes — biome + tsc + stylelint + brand-vocabulary, 0 issues. No Aurelia component changes.
- [x] `npm run build -- --mode prod` succeeds locally. Spot check on `dist/`:
  - No occurrences of `dev.liverty-music.app` anywhere.
  - `api.liverty-music.app` and `auth.liverty-music.app` present.
  - `VITE_ZITADEL_CLIENT_ID: "373015520582107291"` embedded in welcome-route + index chunks.
  - `MODE: "prod"` in the bundled env config.
- [x] `npm run build` (dev path, no `--mode prod`) regression check — bundle still embeds `api.dev.liverty-music.app`, dev client_id `371355407710421859`. No regression.

## Sequencing

Per the specification's design D7 migration plan, this PR opens at item E (frontend `.env.prod` + workflow). Operator follow-ups after merge:

1. **§3** (`pulumi up --stack prod` via Pulumi Cloud console): apply the new `webFrontendClientId` / `productOrgId` stack outputs declared in cloud-provisioning PR #264. The underlying resources already exist (created during `refactor-unify-env-dispatch` prod bring-up); only the exports are new. Verify post-up that `pulumi stack output webFrontendClientId --stack prod --show-secrets` returns `373015520582107291`.
2. **§8** cut a frontend Release tag (e.g., `v1.0.0`) on `main`. The release-triggered Deploy Frontend run is then expected to push `liverty-music-prod/frontend/web-app:v1.0.0,:<sha>`. Phase 3 needs to land first because the env tag pattern (cloud-provisioning PR #266) is the gate that allows `v*` tags to enter the prod env.

## Companion PRs

- liverty-music/cloud-provisioning#264 (parent change — `webFrontendClientId` / `productOrgId` stack outputs + Atlas overlay scaffolding, merged 2026-05-15)
- liverty-music/cloud-provisioning#265 (VAPID configmap fix, in flight)
- liverty-music/cloud-provisioning#266 (prod env tag-pattern policy fix — REQUIRED before §8 release cut works; v1.0.0 release attempt failed against the pre-fix policy)
- liverty-music/backend#296 (backend deploy.yml + Atlas overlay, merged 2026-05-15)

## Test plan

- [ ] CI green (Lint workflow)
- [ ] claude-review feedback addressed
- [ ] Reviewer sign-off

## Out of scope

- Cutting the actual `v1.0.0` Release tag — operator-attended (§8), AND blocked on cloud-provisioning PR #266 landing first.
- The prod kustomize overlay image pinning (`prepare-prod-service-in` §9) — separate cloud-provisioning PR, gated on §5 + §8 release SHAs.

## Related

- Spec PR: liverty-music/specification#473 (merged 2026-05-15)
