### PR TITLE
refactor(workflows): use reusable Claude review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,43 +3,21 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+
+# Permissions are inherited by the reusable workflow's job and intersected
+# with its own workflow-level declarations. Set them here in the caller so
+# the called job has everything it needs (sticky/inline comment, Claude
+# action OIDC, Check Run publish).
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+  id-token: write
+  checks: write
 
 jobs:
-  claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: read
-      id-token: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code Review
-        id: claude-review
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
-          claude_args: '--allowedTools "Bash(gh pr *),Bash(gh api *),Bash(git *),Write"'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-
+  review:
+    uses: liverty-music/.github/.github/workflows/claude-review.yml@main
+    secrets: inherit
+    with:
+      additional_focus: "Aurelia 2 patterns, CUBE CSS methodology, INP optimization, semantic HTML"


### PR DESCRIPTION
## Summary

Replace the inline Claude code-review workflow with a thin caller of the shared reusable workflow at [`liverty-music/.github/.github/workflows/claude-review.yml@main`](https://github.com/liverty-music/.github/blob/main/.github/workflows/claude-review.yml).

### Before vs After

Same Claude Code plugin (`code-review@claude-code-plugins`), same auth (`CLAUDE_CODE_OAUTH_TOKEN`), but:
- Workflow drops from 45 lines to 16 lines.
- Verdict surfaces as a **`Claude review` GitHub Check Run** (`pass → success` ✅ / `fail → failure` ❌ / missing → `neutral` ⚪), in addition to the existing sticky PR comment.
- `additional_focus` input pinned to `"Aurelia 2 patterns, CUBE CSS methodology, INP optimization, semantic HTML"`.

### Auth

`CLAUDE_CODE_OAUTH_TOKEN` is now provisioned as an **org-level `ActionsOrganizationSecret`** (Pulumi-managed since [liverty-music/cloud-provisioning#269](https://github.com/liverty-music/cloud-provisioning/pull/269), live in prod state since 2026-05-16). No per-repo secret needed.

### Status check

This PR does **not** yet make `Claude review` a Required Status Check for `liverty-music/frontend`. That follows in a separate Pulumi PR (Section 5 step 3 of OpenSpec change `claude-review-check-run`) once we've observed the workflow running cleanly on this repo for ~1 week. Until then the verdict is **informational** — failing it does not block merge.

### Test plan

- [ ] On this PR (and the next few unrelated PRs), the `Claude review` Check Run should appear with `conclusion: success` (no high-signal issues expected for an infra/CI-only change).
- [ ] Sticky comment behavior unchanged.

### Related

- OpenSpec proposal: [liverty-music/specification#475](https://github.com/liverty-music/specification/pull/475) (merged)
- Pilot (specification caller): [liverty-music/specification#477](https://github.com/liverty-music/specification/pull/477) (merged 2026-05-15)
- Pilot verification (broken PR test): [liverty-music/specification#479](https://github.com/liverty-music/specification/pull/479) (closed, verified `failure` + `BLOCKED`)
- Org-level OAuth secret: [liverty-music/cloud-provisioning#269](https://github.com/liverty-music/cloud-provisioning/pull/269) (merged + applied to prod)
- Tracking issue: [liverty-music/specification#474](https://github.com/liverty-music/specification/issues/474)

Refs: liverty-music/specification#474
