### PR TITLE
ci(smoke): wire post-deploy smoke + add unit test for verify-build-templates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
               - 'src/**'
               - 'test/**'
               - 'e2e/**'
+              - 'scripts/**'
               - 'index.html'
               - 'public/**'
               - 'package.json'
@@ -36,10 +37,12 @@ jobs:
               - 'tsconfig*.json'
               - 'vite.config.ts'
               - 'vitest.config.ts'
+              - 'vitest.scripts.config.ts'
               - 'biome.json'
               - '.stylelintrc.json'
               - 'Makefile'
               - 'playwright.config.mjs'
+              - 'playwright.smoke.config.mjs'
               - '.github/workflows/**'
 
   lint:

--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -28,6 +28,13 @@ on:
       - '.github/workflows/push-image.yaml'
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      smoke_url:
+        description: 'Run post-deploy smoke against this URL only (no build/push). Use after a prod pin-bump merges in cloud-provisioning.'
+        required: true
+        type: string
+        default: 'https://liverty-music.app'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -42,6 +49,7 @@ jobs:
     # PR #297 review threads 3248512589 / 3248513873). The authoritative
     # check is the runtime `Verify release commit on main` step below,
     # which compares `github.sha` against `origin/main` history.
+    # workflow_dispatch is excluded — that path only runs the smoke job.
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'release' && github.event.action == 'published')
@@ -134,3 +142,101 @@ jobs:
           tags: ${{ env.IMAGE_TAGS }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # Post-deploy smoke: hits the live URL and asserts the SPA renders
+  # plus /config.json reports the expected environment. Closes the
+  # gap left by section 5.5 of OpenSpec archive
+  # `2026-05-16-adopt-runtime-config-for-frontend`: the smoke spec
+  # existed but ran only on demand.
+  #
+  # Path matrix:
+  #   - push to main      -> wait for ArgoCD Image Updater to pick up
+  #                          dev AR :latest, then smoke dev URL
+  #   - release published -> SKIP (prod does not auto-deploy; the
+  #                          pin-bump PR in cloud-provisioning is the
+  #                          gate. Re-run this workflow via
+  #                          workflow_dispatch after that PR merges to
+  #                          smoke prod)
+  #   - workflow_dispatch -> smoke whatever `smoke_url` is provided
+  #                          (no build, no wait)
+  post-deploy-smoke:
+    needs: build-and-push
+    # Skip if the upstream build failed/was skipped (e.g., release path
+    # wants prod smoke deferred to the manual pin-bump).
+    if: |
+      always() &&
+      ((github.event_name == 'push' && needs.build-and-push.result == 'success') ||
+       github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Pick smoke target URL
+        id: target
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "url=${{ inputs.smoke_url }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "url=https://dev.liverty-music.app" >> "$GITHUB_OUTPUT"
+          fi
+
+      # For the push-to-main path, the deploy is gated by ArgoCD Image
+      # Updater scanning the AR `:latest` tag (typical poll interval
+      # 60-180s). Build locally to learn the new bundle hash, then poll
+      # the live URL until that hash surfaces. Confirms the deployed
+      # image actually carries this PR's code (not the previous one).
+      # workflow_dispatch skips this — the operator chose when to run.
+      - name: Build to learn expected bundle hash
+        if: github.event_name == 'push'
+        run: npm run build
+
+      - name: Wait for new bundle to surface at dev URL
+        if: github.event_name == 'push'
+        timeout-minutes: 8
+        run: |
+          expected_bundle=$(grep -oE 'assets/index-[A-Za-z0-9_-]+\.js' dist/index.html | head -1)
+          if [ -z "$expected_bundle" ]; then
+            echo "::error::Could not parse expected bundle hash from local dist/index.html"
+            exit 1
+          fi
+          echo "Expected bundle: $expected_bundle"
+          for attempt in $(seq 1 24); do
+            live_bundle=$(curl -sS "${{ steps.target.outputs.url }}/" | grep -oE 'assets/index-[A-Za-z0-9_-]+\.js' | head -1)
+            if [ "$live_bundle" = "$expected_bundle" ]; then
+              echo "ArgoCD rollout complete after $((attempt * 20))s"
+              exit 0
+            fi
+            echo "Attempt $attempt/24: live bundle is '$live_bundle', waiting..."
+            sleep 20
+          done
+          echo "::error::Timed out waiting for $expected_bundle to surface at ${{ steps.target.outputs.url }}"
+          exit 1
+
+      - name: Run smoke against deployed URL
+        env:
+          SMOKE_BASE_URL: ${{ steps.target.outputs.url }}
+        run: npm run test:smoke
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-playwright-report
+          path: |
+            playwright-report/
+            test-results/smoke/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -184,14 +184,36 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
+      # Pick the target URL up-front and validate that it points at a
+      # known production-tier hostname. The workflow_dispatch input
+      # MUST NOT be interpolated directly into a `run:` shell — instead
+      # we route it through the env block (single env var, no shell
+      # parsing of the value) and then through a regex allowlist.
       - name: Pick smoke target URL
         id: target
+        env:
+          SMOKE_URL_INPUT: ${{ inputs.smoke_url }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "url=${{ inputs.smoke_url }}" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            candidate="$SMOKE_URL_INPUT"
           else
-            echo "url=https://dev.liverty-music.app" >> "$GITHUB_OUTPUT"
+            candidate="https://dev.liverty-music.app"
           fi
+          # Allowlist: only the three known liverty-music hostnames.
+          # Same map the SPA's KNOWN_HOSTS enforces at bootstrap.
+          case "$candidate" in
+            https://liverty-music.app|https://liverty-music.app/) ;;
+            https://dev.liverty-music.app|https://dev.liverty-music.app/) ;;
+            https://staging.liverty-music.app|https://staging.liverty-music.app/) ;;
+            *)
+              echo "::error::smoke_url not in allowlist: '$candidate'"
+              exit 1
+              ;;
+          esac
+          # Strip trailing slash for a canonical form.
+          candidate="${candidate%/}"
+          echo "url=$candidate" >> "$GITHUB_OUTPUT"
 
       # For the push-to-main path, the deploy is gated by ArgoCD Image
       # Updater scanning the AR `:latest` tag (typical poll interval
@@ -206,6 +228,8 @@ jobs:
       - name: Wait for new bundle to surface at dev URL
         if: github.event_name == 'push'
         timeout-minutes: 8
+        env:
+          TARGET_URL: ${{ steps.target.outputs.url }}
         run: |
           expected_bundle=$(grep -oE 'assets/index-[A-Za-z0-9_-]+\.js' dist/index.html | head -1)
           if [ -z "$expected_bundle" ]; then
@@ -214,7 +238,7 @@ jobs:
           fi
           echo "Expected bundle: $expected_bundle"
           for attempt in $(seq 1 24); do
-            live_bundle=$(curl -sS "${{ steps.target.outputs.url }}/" | grep -oE 'assets/index-[A-Za-z0-9_-]+\.js' | head -1)
+            live_bundle=$(curl -sS "$TARGET_URL/" | grep -oE 'assets/index-[A-Za-z0-9_-]+\.js' | head -1)
             if [ "$live_bundle" = "$expected_bundle" ]; then
               echo "ArgoCD rollout complete after $((attempt * 20))s"
               exit 0
@@ -222,7 +246,7 @@ jobs:
             echo "Attempt $attempt/24: live bundle is '$live_bundle', waiting..."
             sleep 20
           done
-          echo "::error::Timed out waiting for $expected_bundle to surface at ${{ steps.target.outputs.url }}"
+          echo "::error::Timed out waiting for $expected_bundle to surface at $TARGET_URL"
           exit 1
 
       - name: Run smoke against deployed URL

--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -238,7 +238,15 @@ jobs:
           fi
           echo "Expected bundle: $expected_bundle"
           for attempt in $(seq 1 24); do
-            live_bundle=$(curl -sS "$TARGET_URL/" | grep -oE 'assets/index-[A-Za-z0-9_-]+\.js' | head -1)
+            # -f: fail on HTTP errors (503 during rollout, etc.) so we
+            # log the actual problem instead of treating empty output
+            # as "bundle not yet updated" for the full 8-minute window.
+            http_body=$(curl -sSf "$TARGET_URL/" 2>&1) || {
+              echo "Attempt $attempt/24: curl failed (${http_body:0:200}); retrying..."
+              sleep 20
+              continue
+            }
+            live_bundle=$(echo "$http_body" | grep -oE 'assets/index-[A-Za-z0-9_-]+\.js' | head -1)
             if [ "$live_bundle" = "$expected_bundle" ]; then
               echo "ArgoCD rollout complete after $((attempt * 20))s"
               exit 0

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,10 @@ lint-brand-vocabulary:
 fix:
 	npx biome check --write src test
 
-## test: unit tests with coverage
+## test: unit tests with coverage + scripts tests (separate vitest config)
 test:
 	npx vitest run --coverage
+	npx vitest run --config vitest.scripts.config.ts
 
 ## lint-no-style: ban style attributes in templates (CSS owns presentation)
 lint-no-style:

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
 		"build": "vite build",
 		"verify:build-templates": "npx tsx scripts/verify-build-templates.ts",
 		"test": "vitest",
+		"test:scripts": "vitest run --config vitest.scripts.config.ts",
 		"storybook": "storybook dev -p 6006",
 		"build-storybook": "storybook build",
 		"test:e2e": "playwright test",

--- a/scripts/capture-auth-state-password.ts
+++ b/scripts/capture-auth-state-password.ts
@@ -96,14 +96,13 @@ async function captureAuthStatePassword(): Promise<void> {
 		// the explicit `loginName` field name or a generic text input as a
 		// resilience hedge against upstream markup tweaks.
 		const usernameInput = page
-			.locator('input[name="loginName"], input[autocomplete="username"], input[type="text"]')
+			.locator(
+				'input[name="loginName"], input[autocomplete="username"], input[type="text"]',
+			)
 			.first()
 		await usernameInput.waitFor({ state: 'visible' })
 		await usernameInput.fill(username)
-		await page
-			.locator('button[type="submit"]')
-			.first()
-			.click()
+		await page.locator('button[type="submit"]').first().click()
 
 		console.log('[4/4] Submitting password and waiting for OIDC callback…')
 		const passwordInput = page
@@ -164,7 +163,9 @@ async function captureAuthStatePassword(): Promise<void> {
 				`[error] Smoke test FAILED: protected route redirected away from /dashboard (landed at ${finalUrl}).`,
 			)
 			console.error('The captured storageState does not authenticate the user.')
-			console.error('Likely causes: wrong password, expired ESC value, or test user not provisioned.')
+			console.error(
+				'Likely causes: wrong password, expired ESC value, or test user not provisioned.',
+			)
 			// Leave the previously-working storageState.json (if any) intact.
 			try {
 				fs.unlinkSync(tempStatePath)

--- a/scripts/verify-build-templates.lib.ts
+++ b/scripts/verify-build-templates.lib.ts
@@ -1,0 +1,81 @@
+/**
+ * Pure library used by `verify-build-templates.ts`. Exposes the route →
+ * marker contract and a `checkBuildTemplates(distDir)` function that
+ * returns a structured result (success / failures) instead of calling
+ * `process.exit()`. Splitting this out makes the assertion logic
+ * unit-testable against a synthetic `dist/` directory without spawning
+ * subprocesses.
+ *
+ * Adding a route: register it in `ROUTE_MARKERS` with a stable class
+ * name or other template-derived literal from its `.html` file. The
+ * literal must NOT appear in the corresponding `.ts` file (so we know
+ * it survived only via template compilation).
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+export interface RouteMarker {
+	readonly route: string
+	readonly marker: string
+}
+
+export const ROUTE_MARKERS: readonly RouteMarker[] = [
+	{ route: 'welcome', marker: 'welcome-brand' },
+	{ route: 'about', marker: 'about-title' },
+	{ route: 'auth-callback', marker: 'callback-loading' },
+	{ route: 'dashboard', marker: 'loading-text' },
+	{ route: 'discovery', marker: 'search-bar' },
+	{ route: 'import-ticket-email', marker: 'import-wizard' },
+	{ route: 'my-artists', marker: 'artists-fieldset' },
+	{ route: 'not-found', marker: 'not-found-code' },
+	{ route: 'settings', marker: 'settings-section-title' },
+	{ route: 'tickets', marker: 'ticket-row' },
+]
+
+export type CheckResult =
+	| { kind: 'ok'; checked: number }
+	| { kind: 'missing-assets'; assetsDir: string }
+	| { kind: 'failed'; failures: readonly string[] }
+
+function findChunk(assetsDir: string, route: string): string | null {
+	const prefix = `${route}-route-`
+	const entries = readdirSync(assetsDir).filter(
+		(f) => f.startsWith(prefix) && f.endsWith('.js'),
+	)
+	if (entries.length === 0) return null
+	return join(assetsDir, entries[0])
+}
+
+/**
+ * Inspects the built `dist/assets/` directory and returns a structured
+ * result indicating whether every known route chunk contains its
+ * template-derived marker.
+ *
+ * Pure (no process.exit, no console writes) — call sites are
+ * responsible for surfacing the result.
+ */
+export function checkBuildTemplates(distDir: string): CheckResult {
+	const assetsDir = join(distDir, 'assets')
+	if (!existsSync(assetsDir)) {
+		return { kind: 'missing-assets', assetsDir }
+	}
+
+	const failures: string[] = []
+	for (const { route, marker } of ROUTE_MARKERS) {
+		const chunkPath = findChunk(assetsDir, route)
+		if (!chunkPath) {
+			failures.push(`route '${route}': no chunk found in ${assetsDir}`)
+			continue
+		}
+		const content = readFileSync(chunkPath, 'utf-8')
+		if (!content.includes(marker)) {
+			failures.push(
+				`route '${route}': chunk ${chunkPath} does not contain marker '${marker}'. Template stripping suspected — see OpenSpec archive \`2026-05-16-adopt-runtime-config-for-frontend\` design D10.`,
+			)
+		}
+	}
+
+	if (failures.length > 0) return { kind: 'failed', failures }
+	return { kind: 'ok', checked: ROUTE_MARKERS.length }
+}

--- a/scripts/verify-build-templates.lib.ts
+++ b/scripts/verify-build-templates.lib.ts
@@ -38,13 +38,19 @@ export type CheckResult =
 	| { kind: 'missing-assets'; assetsDir: string }
 	| { kind: 'failed'; failures: readonly string[] }
 
-function findChunk(assetsDir: string, route: string): string | null {
+type ChunkLookup =
+	| { kind: 'found'; path: string }
+	| { kind: 'not-found' }
+	| { kind: 'ambiguous'; entries: readonly string[] }
+
+function findChunk(assetsDir: string, route: string): ChunkLookup {
 	const prefix = `${route}-route-`
 	const entries = readdirSync(assetsDir).filter(
 		(f) => f.startsWith(prefix) && f.endsWith('.js'),
 	)
-	if (entries.length === 0) return null
-	return join(assetsDir, entries[0])
+	if (entries.length === 0) return { kind: 'not-found' }
+	if (entries.length > 1) return { kind: 'ambiguous', entries }
+	return { kind: 'found', path: join(assetsDir, entries[0]) }
 }
 
 /**
@@ -63,15 +69,26 @@ export function checkBuildTemplates(distDir: string): CheckResult {
 
 	const failures: string[] = []
 	for (const { route, marker } of ROUTE_MARKERS) {
-		const chunkPath = findChunk(assetsDir, route)
-		if (!chunkPath) {
+		const lookup = findChunk(assetsDir, route)
+		if (lookup.kind === 'not-found') {
 			failures.push(`route '${route}': no chunk found in ${assetsDir}`)
 			continue
 		}
-		const content = readFileSync(chunkPath, 'utf-8')
+		if (lookup.kind === 'ambiguous') {
+			// A genuine build anomaly worth surfacing as a failure (rather
+			// than a silent first-match) — duplicate chunk emission
+			// usually means a tree-shaking regression or two competing
+			// route definitions. The CLI prints all entries so the
+			// operator can diagnose.
+			failures.push(
+				`route '${route}': multiple chunks emitted in ${assetsDir} (${lookup.entries.join(', ')}). Expected exactly one '<route>-route-*.js'.`,
+			)
+			continue
+		}
+		const content = readFileSync(lookup.path, 'utf-8')
 		if (!content.includes(marker)) {
 			failures.push(
-				`route '${route}': chunk ${chunkPath} does not contain marker '${marker}'. Template stripping suspected — see OpenSpec archive \`2026-05-16-adopt-runtime-config-for-frontend\` design D10.`,
+				`route '${route}': chunk ${lookup.path} does not contain marker '${marker}'. Template stripping suspected — see OpenSpec archive \`2026-05-16-adopt-runtime-config-for-frontend\` design D10.`,
 			)
 		}
 	}

--- a/scripts/verify-build-templates.spec.ts
+++ b/scripts/verify-build-templates.spec.ts
@@ -1,0 +1,105 @@
+// @vitest-environment node
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+	checkBuildTemplates,
+	ROUTE_MARKERS,
+} from './verify-build-templates.lib'
+
+/**
+ * Populates a synthetic dist/assets directory with one chunk per route.
+ * Each chunk's contents are caller-supplied (defaults to a string that
+ * includes the route's expected marker, so the default scaffold is a
+ * "valid" build).
+ */
+function scaffoldDist(
+	distDir: string,
+	overrides: Partial<Record<string, string>> = {},
+): void {
+	const assetsDir = join(distDir, 'assets')
+	mkdirSync(assetsDir, { recursive: true })
+	for (const { route, marker } of ROUTE_MARKERS) {
+		const content = overrides[route] ?? `// marker:${marker}`
+		writeFileSync(join(assetsDir, `${route}-route-XXXX.js`), content)
+	}
+}
+
+describe('checkBuildTemplates', () => {
+	let workDir: string
+
+	beforeEach(() => {
+		workDir = mkdtempSync(join(tmpdir(), 'verify-build-templates-'))
+	})
+
+	afterEach(() => {
+		rmSync(workDir, { recursive: true, force: true })
+	})
+
+	it('returns missing-assets when dist/assets is absent', () => {
+		const result = checkBuildTemplates(workDir)
+		expect(result.kind).toBe('missing-assets')
+		if (result.kind === 'missing-assets') {
+			expect(result.assetsDir).toBe(join(workDir, 'assets'))
+		}
+	})
+
+	it('returns ok when every route chunk contains its marker', () => {
+		scaffoldDist(workDir)
+		const result = checkBuildTemplates(workDir)
+		expect(result.kind).toBe('ok')
+		if (result.kind === 'ok') {
+			expect(result.checked).toBe(ROUTE_MARKERS.length)
+		}
+	})
+
+	it('returns failed when a chunk is missing for a route', () => {
+		scaffoldDist(workDir)
+		// Remove the welcome chunk so it has no entry in dist/assets.
+		rmSync(join(workDir, 'assets', `welcome-route-XXXX.js`))
+		const result = checkBuildTemplates(workDir)
+		expect(result.kind).toBe('failed')
+		if (result.kind === 'failed') {
+			expect(result.failures).toHaveLength(1)
+			expect(result.failures[0]).toMatch(/welcome.*no chunk found/)
+		}
+	})
+
+	it('returns failed when a chunk is present but missing its marker', () => {
+		scaffoldDist(workDir, { welcome: '// nothing meaningful here' })
+		const result = checkBuildTemplates(workDir)
+		expect(result.kind).toBe('failed')
+		if (result.kind === 'failed') {
+			expect(result.failures).toHaveLength(1)
+			expect(result.failures[0]).toMatch(
+				/welcome.*does not contain marker 'welcome-brand'/,
+			)
+		}
+	})
+
+	it('reports every failing route in a single pass', () => {
+		scaffoldDist(workDir, {
+			welcome: '// blank',
+			dashboard: '// blank too',
+		})
+		const result = checkBuildTemplates(workDir)
+		expect(result.kind).toBe('failed')
+		if (result.kind === 'failed') {
+			expect(result.failures).toHaveLength(2)
+			expect(result.failures.some((f) => f.includes('welcome'))).toBe(true)
+			expect(result.failures.some((f) => f.includes('dashboard'))).toBe(true)
+		}
+	})
+
+	it('contract: ROUTE_MARKERS lists every route in src/app-shell.ts', () => {
+		// Spot-check: every entry has a unique route and a non-empty marker.
+		const routes = new Set<string>()
+		for (const { route, marker } of ROUTE_MARKERS) {
+			expect(route).toMatch(/^[a-z][a-z-]+$/)
+			expect(marker.length).toBeGreaterThan(0)
+			expect(routes.has(route)).toBe(false)
+			routes.add(route)
+		}
+	})
+})

--- a/scripts/verify-build-templates.spec.ts
+++ b/scripts/verify-build-templates.spec.ts
@@ -92,8 +92,15 @@ describe('checkBuildTemplates', () => {
 		}
 	})
 
-	it('contract: ROUTE_MARKERS lists every route in src/app-shell.ts', () => {
-		// Spot-check: every entry has a unique route and a non-empty marker.
+	it('shape: ROUTE_MARKERS entries are well-formed and unique', () => {
+		// Local consistency only: each entry has a kebab-case route slug,
+		// a non-empty marker, and the route slug does not duplicate
+		// another entry. This does NOT verify alignment with
+		// `src/app-shell.ts` — adding a new route to app-shell.ts
+		// without updating ROUTE_MARKERS will silently skip that
+		// route in the post-build assertion. Keeping the two in sync is
+		// a contributor checklist item (see `frontend/docs/runtime-config.md`
+		// once that follow-up lands; tracked in liverty-music/specification#491).
 		const routes = new Set<string>()
 		for (const { route, marker } of ROUTE_MARKERS) {
 			expect(route).toMatch(/^[a-z][a-z-]+$/)

--- a/scripts/verify-build-templates.spec.ts
+++ b/scripts/verify-build-templates.spec.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { strict as assert } from 'node:assert'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -39,19 +40,19 @@ describe('checkBuildTemplates', () => {
 
 	it('returns missing-assets when dist/assets is absent', () => {
 		const result = checkBuildTemplates(workDir)
-		expect(result.kind).toBe('missing-assets')
-		if (result.kind === 'missing-assets') {
-			expect(result.assetsDir).toBe(join(workDir, 'assets'))
-		}
+		// node:assert narrows the type AND fails loudly — vitest's
+		// `expect(result.kind).toBe(...)` followed by an `if`-guard would
+		// silently skip inner assertions when the outer expectation fails.
+		assert.equal(result.kind, 'missing-assets')
+		assert(result.kind === 'missing-assets')
+		expect(result.assetsDir).toBe(join(workDir, 'assets'))
 	})
 
 	it('returns ok when every route chunk contains its marker', () => {
 		scaffoldDist(workDir)
 		const result = checkBuildTemplates(workDir)
-		expect(result.kind).toBe('ok')
-		if (result.kind === 'ok') {
-			expect(result.checked).toBe(ROUTE_MARKERS.length)
-		}
+		assert(result.kind === 'ok')
+		expect(result.checked).toBe(ROUTE_MARKERS.length)
 	})
 
 	it('returns failed when a chunk is missing for a route', () => {
@@ -59,23 +60,36 @@ describe('checkBuildTemplates', () => {
 		// Remove the welcome chunk so it has no entry in dist/assets.
 		rmSync(join(workDir, 'assets', `welcome-route-XXXX.js`))
 		const result = checkBuildTemplates(workDir)
-		expect(result.kind).toBe('failed')
-		if (result.kind === 'failed') {
-			expect(result.failures).toHaveLength(1)
-			expect(result.failures[0]).toMatch(/welcome.*no chunk found/)
-		}
+		assert(result.kind === 'failed')
+		expect(result.failures).toHaveLength(1)
+		expect(result.failures[0]).toMatch(/welcome.*no chunk found/)
 	})
 
 	it('returns failed when a chunk is present but missing its marker', () => {
 		scaffoldDist(workDir, { welcome: '// nothing meaningful here' })
 		const result = checkBuildTemplates(workDir)
-		expect(result.kind).toBe('failed')
-		if (result.kind === 'failed') {
-			expect(result.failures).toHaveLength(1)
-			expect(result.failures[0]).toMatch(
-				/welcome.*does not contain marker 'welcome-brand'/,
-			)
-		}
+		assert(result.kind === 'failed')
+		expect(result.failures).toHaveLength(1)
+		expect(result.failures[0]).toMatch(
+			/welcome.*does not contain marker 'welcome-brand'/,
+		)
+	})
+
+	it('returns failed when multiple chunks are emitted for a single route', () => {
+		// Build anomaly — tree-shaking regression or duplicate route
+		// definitions could emit two chunks. The lib used to silently
+		// pick the first match; it now flags the ambiguity loudly.
+		scaffoldDist(workDir)
+		writeFileSync(
+			join(workDir, 'assets', 'welcome-route-YYYY.js'),
+			'// duplicate chunk',
+		)
+		const result = checkBuildTemplates(workDir)
+		assert(result.kind === 'failed')
+		expect(result.failures).toHaveLength(1)
+		expect(result.failures[0]).toMatch(/welcome.*multiple chunks/)
+		expect(result.failures[0]).toMatch(/welcome-route-XXXX\.js/)
+		expect(result.failures[0]).toMatch(/welcome-route-YYYY\.js/)
 	})
 
 	it('reports every failing route in a single pass', () => {
@@ -84,29 +98,35 @@ describe('checkBuildTemplates', () => {
 			dashboard: '// blank too',
 		})
 		const result = checkBuildTemplates(workDir)
-		expect(result.kind).toBe('failed')
-		if (result.kind === 'failed') {
-			expect(result.failures).toHaveLength(2)
-			expect(result.failures.some((f) => f.includes('welcome'))).toBe(true)
-			expect(result.failures.some((f) => f.includes('dashboard'))).toBe(true)
-		}
+		assert(result.kind === 'failed')
+		expect(result.failures).toHaveLength(2)
+		expect(result.failures.some((f) => f.includes('welcome'))).toBe(true)
+		expect(result.failures.some((f) => f.includes('dashboard'))).toBe(true)
 	})
 
-	it('shape: ROUTE_MARKERS entries are well-formed and unique', () => {
+	it('shape: ROUTE_MARKERS entries are well-formed, with unique routes and unique markers', () => {
 		// Local consistency only: each entry has a kebab-case route slug,
-		// a non-empty marker, and the route slug does not duplicate
-		// another entry. This does NOT verify alignment with
-		// `src/app-shell.ts` — adding a new route to app-shell.ts
-		// without updating ROUTE_MARKERS will silently skip that
-		// route in the post-build assertion. Keeping the two in sync is
-		// a contributor checklist item (see `frontend/docs/runtime-config.md`
-		// once that follow-up lands; tracked in liverty-music/specification#491).
+		// a non-empty marker, the route slug does not duplicate another
+		// entry, and the marker does not duplicate another entry. Marker
+		// uniqueness matters because two routes sharing a marker would
+		// each pass their individual checks even if their templates were
+		// swapped or one was stripped.
+		//
+		// This does NOT verify alignment with `src/app-shell.ts` — adding
+		// a new route there without updating ROUTE_MARKERS will silently
+		// skip that route in the post-build assertion. Keeping the two
+		// in sync is a contributor checklist item (see
+		// `frontend/docs/runtime-config.md` once that follow-up lands;
+		// tracked in liverty-music/specification#491).
 		const routes = new Set<string>()
+		const markers = new Set<string>()
 		for (const { route, marker } of ROUTE_MARKERS) {
 			expect(route).toMatch(/^[a-z][a-z-]+$/)
 			expect(marker.length).toBeGreaterThan(0)
 			expect(routes.has(route)).toBe(false)
+			expect(markers.has(marker)).toBe(false)
 			routes.add(route)
+			markers.add(marker)
 		}
 	})
 })

--- a/scripts/verify-build-templates.ts
+++ b/scripts/verify-build-templates.ts
@@ -1,89 +1,33 @@
 /**
- * Post-build assertion: every lazy route chunk MUST contain a known
- * template-derived marker string. Guards against the v1.0.0 regression
- * class in which a build-time misconfiguration silently strips compiled
- * HTML templates from chunks, producing a bundle that loads but cannot
- * resolve any route.
+ * Post-build assertion entry. Delegates the work to
+ * `verify-build-templates.lib.ts` (which is pure and testable) and maps
+ * the returned result to console output + exit code.
  *
- * Adding a route: register it here with a stable class name or other
- * template-derived literal from its `.html` file. The literal must NOT
- * appear in the corresponding `.ts` file (so we know it survived only
- * via template compilation).
- *
- * Run via `npm run verify:build-templates` (wired into CI).
+ * Run via `npm run verify:build-templates` (wired into the Dockerfile
+ * + the post-deploy CI workflow).
  */
 
-import { existsSync, readdirSync, readFileSync } from 'node:fs'
-import { join } from 'node:path'
 import { argv, exit } from 'node:process'
+import { checkBuildTemplates } from './verify-build-templates.lib'
 
-interface RouteMarker {
-	route: string
-	marker: string
-}
+const distDir = argv[2] ?? 'dist'
+const result = checkBuildTemplates(distDir)
 
-const ROUTE_MARKERS: readonly RouteMarker[] = [
-	{ route: 'welcome', marker: 'welcome-brand' },
-	{ route: 'about', marker: 'about-title' },
-	{ route: 'auth-callback', marker: 'callback-loading' },
-	{ route: 'dashboard', marker: 'loading-text' },
-	{ route: 'discovery', marker: 'search-bar' },
-	{ route: 'import-ticket-email', marker: 'import-wizard' },
-	{ route: 'my-artists', marker: 'artists-fieldset' },
-	{ route: 'not-found', marker: 'not-found-code' },
-	{ route: 'settings', marker: 'settings-section-title' },
-	{ route: 'tickets', marker: 'ticket-row' },
-]
-
-function findChunk(assetsDir: string, route: string): string | null {
-	const prefix = `${route}-route-`
-	const entries = readdirSync(assetsDir).filter(
-		(f) => f.startsWith(prefix) && f.endsWith('.js'),
-	)
-	if (entries.length === 0) return null
-	if (entries.length > 1) {
-		console.warn(
-			`[verify-build-templates] multiple chunks for ${route}: ${entries.join(', ')}; using first`,
-		)
-	}
-	return join(assetsDir, entries[0])
-}
-
-function main(): void {
-	const distDir = argv[2] ?? 'dist'
-	const assetsDir = join(distDir, 'assets')
-
-	if (!existsSync(assetsDir)) {
+switch (result.kind) {
+	case 'missing-assets':
 		console.error(
-			`[verify-build-templates] assets directory not found: ${assetsDir}. Did you run \`npm run build\` first?`,
+			`[verify-build-templates] assets directory not found: ${result.assetsDir}. Did you run \`npm run build\` first?`,
 		)
 		exit(2)
-	}
-
-	const failures: string[] = []
-	for (const { route, marker } of ROUTE_MARKERS) {
-		const chunkPath = findChunk(assetsDir, route)
-		if (!chunkPath) {
-			failures.push(`route '${route}': no chunk found in ${assetsDir}`)
-			continue
-		}
-		const content = readFileSync(chunkPath, 'utf-8')
-		if (!content.includes(marker)) {
-			failures.push(
-				`route '${route}': chunk ${chunkPath} does not contain marker '${marker}'. Template stripping suspected — see OpenSpec change \`adopt-runtime-config-for-frontend\` design D10.`,
-			)
-		}
-	}
-
-	if (failures.length > 0) {
+		break
+	case 'failed':
 		console.error('[verify-build-templates] FAILED:')
-		for (const f of failures) console.error(`  - ${f}`)
+		for (const f of result.failures) console.error(`  - ${f}`)
 		exit(1)
-	}
-
-	console.log(
-		`[verify-build-templates] OK: all ${ROUTE_MARKERS.length} route chunks contain expected template markers`,
-	)
+		break
+	case 'ok':
+		console.log(
+			`[verify-build-templates] OK: all ${result.checked} route chunks contain expected template markers`,
+		)
+		break
 }
-
-main()

--- a/scripts/verify-build-templates.ts
+++ b/scripts/verify-build-templates.ts
@@ -4,30 +4,30 @@
  * the returned result to console output + exit code.
  *
  * Run via `npm run verify:build-templates` (wired into the Dockerfile
- * + the post-deploy CI workflow).
+ * RUN that follows `npm run build`, and the post-deploy CI workflow).
  */
 
 import { argv, exit } from 'node:process'
 import { checkBuildTemplates } from './verify-build-templates.lib'
 
-const distDir = argv[2] ?? 'dist'
-const result = checkBuildTemplates(distDir)
-
-switch (result.kind) {
-	case 'missing-assets':
-		console.error(
-			`[verify-build-templates] assets directory not found: ${result.assetsDir}. Did you run \`npm run build\` first?`,
-		)
-		exit(2)
-		break
-	case 'failed':
-		console.error('[verify-build-templates] FAILED:')
-		for (const f of result.failures) console.error(`  - ${f}`)
-		exit(1)
-		break
-	case 'ok':
-		console.log(
-			`[verify-build-templates] OK: all ${result.checked} route chunks contain expected template markers`,
-		)
-		break
+function run(distDir: string): never {
+	const result = checkBuildTemplates(distDir)
+	switch (result.kind) {
+		case 'missing-assets':
+			console.error(
+				`[verify-build-templates] assets directory not found: ${result.assetsDir}. Did you run \`npm run build\` first?`,
+			)
+			exit(2)
+		case 'failed':
+			console.error('[verify-build-templates] FAILED:')
+			for (const f of result.failures) console.error(`  - ${f}`)
+			exit(1)
+		case 'ok':
+			console.log(
+				`[verify-build-templates] OK: all ${result.checked} route chunks contain expected template markers`,
+			)
+			exit(0)
+	}
 }
+
+run(argv[2] ?? 'dist')

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,7 +17,10 @@ export default mergeConfig(
         },
       },
       watch: false,
-      exclude: [...configDefaults.exclude, "e2e/**"],
+      // scripts/ tests run via a dedicated `vitest.scripts.config.ts`
+      // because they import `node:fs` / `node:os` directly and need to
+      // bypass the SPA build's `nodePolyfills` plugin.
+      exclude: [...configDefaults.exclude, "e2e/**", "scripts/**"],
       root: fileURLToPath(new URL("./", import.meta.url)),
       setupFiles: ["./test/setup.ts"],
       coverage: {

--- a/vitest.scripts.config.ts
+++ b/vitest.scripts.config.ts
@@ -1,0 +1,24 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+/**
+ * Dedicated vitest config for `scripts/` tests.
+ *
+ * The main `vitest.config.ts` inherits the SPA's vite config, which
+ * includes `vite-plugin-node-polyfills` to support snarkjs and other
+ * browser-bundled deps. That polyfill rewrites `node:fs` / `node:os` /
+ * `node:path` to browser-stdlib shims, which makes Node-native APIs
+ * (`mkdtempSync`, `rmSync`, etc.) inaccessible to scripts tests.
+ *
+ * This config explicitly does NOT extend `vite.config.ts` — it ships
+ * the bare-minimum vitest setup so `node:*` imports resolve to the
+ * real Node modules. Run via `npm run test:scripts`.
+ */
+export default defineConfig({
+	test: {
+		environment: 'node',
+		include: ['scripts/**/*.spec.ts'],
+		watch: false,
+		root: fileURLToPath(new URL('./', import.meta.url)),
+	},
+})


### PR DESCRIPTION
## Summary

Closes the two warnings from `/opsx:verify` on the archived OpenSpec change [`2026-05-16-adopt-runtime-config-for-frontend`](https://github.com/liverty-music/specification/tree/main/openspec/changes/archive/2026-05-16-adopt-runtime-config-for-frontend).

### W1 — Wire post-deploy smoke into CI

Adds a `post-deploy-smoke` job in `.github/workflows/push-image.yaml`:

- **push-to-main path**: builds locally to derive the expected bundle hash from `dist/index.html`, polls `https://dev.liverty-music.app/` until that hash surfaces (≤8 min, 20s intervals — ArgoCD Image Updater's typical lag), then runs `npm run test:smoke`. Uploads Playwright report on failure.
- **release path**: deliberately NOT smoked — release-publish only puts the image in prod AR; actual prod rollout happens when the `cloud-provisioning` pin-bump PR merges. Running smoke against prod here would test the *previous* image.
- **workflow_dispatch path (new)**: takes a `smoke_url` input (default `https://liverty-music.app`) and runs smoke against it without any build. Use after the pin-bump PR merges:
  ```
  gh workflow run "Deploy Frontend" --repo liverty-music/frontend \
    -f smoke_url=https://liverty-music.app
  ```

This matches the spirit of task 5.5 in the archived tasks.md, and closes the regression gap surfaced by `/opsx:verify`.

### W2 — Unit test for verify-build-templates

Task 4.4 was marked done in the archived tasks.md without a test landing because the prior attempt hit a `vite-plugin-node-polyfills` conflict with `node:child_process` imports.

This PR refactors the script into:

- **`scripts/verify-build-templates.lib.ts`** — pure `checkBuildTemplates(distDir)` returning a discriminated-union result (no `process.exit`, no console writes). Easily testable.
- **`scripts/verify-build-templates.ts`** — thin CLI entry that maps the result to exit codes (external behavior unchanged).
- **`scripts/verify-build-templates.spec.ts`** — 6 test cases: missing-assets, ok, missing-chunk, missing-marker, multi-failure aggregation, ROUTE_MARKERS contract check.

The new spec runs under a dedicated `vitest.scripts.config.ts` that does NOT inherit `vite.config.ts`, so `node:fs` / `node:os` / `node:path` imports resolve to real Node modules. The main `vitest.config.ts` excludes `scripts/**`. New npm script: `test:scripts`.

## Test plan

- [x] `npm run test:scripts` → 6/6 pass
- [x] `npm test` (main vitest suite) → 1047/1047 pass (unchanged)
- [x] `npx tsc --noEmit` → clean
- [x] `make lint` → clean
- [x] `npm run build && npm run verify:build-templates` → OK (the CLI still works)
- [x] YAML syntax of `push-image.yaml` parses cleanly
- [ ] After merge: a dummy push to main triggers `post-deploy-smoke` and it polls dev → runs smoke → passes
- [ ] After merge: `gh workflow run "Deploy Frontend" -f smoke_url=https://dev.liverty-music.app` runs smoke standalone

## Notes

- `scripts/capture-auth-state-password.ts` has minor biome auto-format reflows (line collapses) picked up during the lint pass; no behavior change.

Refs: liverty-music/specification#489