### PR TITLE
ci(push-image): retag dev AR digest into prod AR on release (no rebuild)

### DIFF
--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -2,13 +2,17 @@ name: Deploy Frontend
 
 # Dual trigger:
 #  - push to main      -> dev build, dev AR (liverty-music-dev/frontend)
-#  - release published -> prod build, prod AR (liverty-music-prod/frontend)
+#  - release published -> retag dev AR digest into prod AR
+#                         (liverty-music-prod/frontend)
 #
-# Per OpenSpec change `adopt-runtime-config-for-frontend`, both build paths
-# run identical Dockerfile inputs (no env-specific build-args). The bundle
-# is env-agnostic — per-environment values come from /config.json served
-# by Caddy from a K8s ConfigMap at runtime. Only the image tag and target
-# AR differ between the two paths.
+# Per OpenSpec change `promote-prod-image-via-retag`, the release path
+# does NOT rebuild — it promotes the exact dev AR digest for the
+# release's commit SHA into prod AR via `gcloud artifacts docker tags
+# add`. The image deployed to prod is byte-identical to the dev AR
+# image already exercised in dev. This avoids the ~90s redundant rebuild
+# on every release and removes a class of non-determinism (dev vs prod
+# image divergence) that the env-agnostic bundle (per
+# `adopt-runtime-config-for-frontend`) made obsolete.
 #
 # The `paths:` filter only applies to push events. Release events fire on
 # any published Release regardless of file diff.
@@ -106,35 +110,40 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
+      # ====================================================================
+      # Dev push path: build env-agnostic image, push to dev AR
+      # ====================================================================
+      # `Configure Docker` and `Set up Docker Buildx` are dev-only — the
+      # release path uses `gcloud artifacts docker tags add` and never
+      # touches the Docker daemon.
+
       - name: Configure Docker
+        if: github.event_name == 'push'
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev
 
-      - name: Set Image URI
+      - name: Set Image URI (dev path)
+        if: github.event_name == 'push'
         run: echo "IMAGE_URI=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE }}" >> $GITHUB_ENV
 
       # Dev tag set: :latest (consumed by ArgoCD Image Updater for dev
       # auto-rollout) + :sha (immutable digest pointer) + :main.
-      # Prod is forbidden from using :latest per the `prod-image-pipeline`
-      # spec — release builds use :<tag> + :sha only.
       - name: Set Image Tags (dev path)
         if: github.event_name == 'push'
         run: echo "IMAGE_TAGS=${{ env.IMAGE_URI }}:latest,${{ env.IMAGE_URI }}:${{ github.sha }},${{ env.IMAGE_URI }}:main" >> $GITHUB_ENV
 
-      - name: Set Image Tags (prod path)
-        if: github.event_name == 'release'
-        run: echo "IMAGE_TAGS=${{ env.IMAGE_URI }}:${{ github.event.release.tag_name }},${{ env.IMAGE_URI }}:${{ github.sha }}" >> $GITHUB_ENV
-
       - name: Set up Docker Buildx
+        if: github.event_name == 'push'
         uses: docker/setup-buildx-action@v3
 
-      # No env-specific build-args: per OpenSpec change
-      # `adopt-runtime-config-for-frontend`, both paths build the same
-      # env-agnostic bundle. Per-env values come from /config.json at
-      # runtime (mounted from a K8s ConfigMap). The Dockerfile runs
-      # `npm run verify:build-templates` after `npm run build` as a
-      # defense-in-depth gate against template-stripping regressions
-      # (the class of bug that produced the v1.0.0 blank-screen Sev-1).
+      # No env-specific build-args: per OpenSpec archive
+      # `adopt-runtime-config-for-frontend`, the bundle is env-agnostic.
+      # Per-env values come from /config.json at runtime (mounted from a
+      # K8s ConfigMap). The Dockerfile runs `npm run verify:build-templates`
+      # after `npm run build` as a defense-in-depth gate against
+      # template-stripping regressions (the class of bug that produced
+      # the v1.0.0 blank-screen Sev-1).
       - name: Build and Push Docker Image
+        if: github.event_name == 'push'
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -142,6 +151,75 @@ jobs:
           tags: ${{ env.IMAGE_TAGS }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # ====================================================================
+      # Release path: retag the dev AR digest into prod AR — no rebuild
+      # ====================================================================
+      # Per OpenSpec archive `promote-prod-image-via-retag`, every release
+      # promotes the exact dev AR digest for the release's commit SHA into
+      # prod AR. The prod CI service account has scoped reader on
+      # `liverty-music-dev/frontend` (granted by
+      # `cloud-provisioning#282`, declared in `src/gcp/index.ts` as
+      # `prod-ci-frontend-ar-reader`).
+      #
+      # Source FQDN is hardcoded to `liverty-music-dev/frontend/web-app`
+      # because the dev project ID is the constant source of every prod
+      # promotion. Destination FQDN uses `vars.PROJECT_ID`
+      # (= `liverty-music-prod` per the `prod` environment binding) to
+      # match the prod-AR convention enforced by `prod-image-pipeline`.
+
+      - name: Resolve dev AR digest for github.sha
+        if: github.event_name == 'release'
+        id: resolve_digest
+        env:
+          DEV_AR_IMAGE: ${{ env.REGION }}-docker.pkg.dev/liverty-music-dev/${{ env.REPOSITORY }}/${{ env.IMAGE }}
+        run: |
+          # 6 total attempts (initial + 5 retries) × 60s wait between =
+          # ~5-minute total budget. Absorbs the race window where a
+          # release is cut seconds after merge-to-main and the dev push
+          # is still in-flight. Per the spec, this is a SHALL retry, not
+          # a MAY — silent failure on the digest-resolve step is exactly
+          # what the retry contract prevents.
+          for attempt in $(seq 1 6); do
+            digest=$(gcloud artifacts docker images describe \
+              "${DEV_AR_IMAGE}:${GITHUB_SHA}" \
+              --format='value(image_summary.digest)' \
+              2>/dev/null || echo "")
+            if [ -n "$digest" ]; then
+              echo "Resolved digest on attempt ${attempt}/6: $digest"
+              echo "digest=$digest" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if [ "$attempt" -lt 6 ]; then
+              echo "Attempt ${attempt}/6: dev AR :sha not yet available; waiting 60s..."
+              sleep 60
+            fi
+          done
+          echo "::error::dev AR tag :${GITHUB_SHA} not found after 6 attempts (~5 min total wait). Either the dev build for this commit failed, or the release was cut on a non-main commit. See docs/runbooks/prod-image-tag-pinning.md#retag-failure-recovery in cloud-provisioning."
+          exit 1
+
+      - name: Promote dev AR digest to prod AR (semver tag)
+        if: github.event_name == 'release'
+        env:
+          DEV_AR_IMAGE: ${{ env.REGION }}-docker.pkg.dev/liverty-music-dev/${{ env.REPOSITORY }}/${{ env.IMAGE }}
+          PROD_AR_IMAGE: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE }}
+          DIGEST: ${{ steps.resolve_digest.outputs.digest }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          gcloud artifacts docker tags add \
+            "${DEV_AR_IMAGE}@${DIGEST}" \
+            "${PROD_AR_IMAGE}:${RELEASE_TAG}"
+
+      - name: Promote dev AR digest to prod AR (commit SHA tag)
+        if: github.event_name == 'release'
+        env:
+          DEV_AR_IMAGE: ${{ env.REGION }}-docker.pkg.dev/liverty-music-dev/${{ env.REPOSITORY }}/${{ env.IMAGE }}
+          PROD_AR_IMAGE: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE }}
+          DIGEST: ${{ steps.resolve_digest.outputs.digest }}
+        run: |
+          gcloud artifacts docker tags add \
+            "${DEV_AR_IMAGE}@${DIGEST}" \
+            "${PROD_AR_IMAGE}:${GITHUB_SHA}"
 
   # Post-deploy smoke: hits the live URL and asserts the SPA renders
   # plus /config.json reports the expected environment. Closes the


### PR DESCRIPTION
## Summary

Implements §3 of OpenSpec archive [`promote-prod-image-via-retag`](https://github.com/liverty-music/specification/tree/main/openspec/changes/archive). The frontend release path no longer rebuilds — it promotes the dev AR digest into prod AR via `gcloud artifacts docker tags add`. The image deployed to prod is byte-identical to the dev AR image already tested in dev.

## Predecessors (already merged)

- [specification#495](https://github.com/liverty-music/specification/pull/495) — spec contract
- [cloud-provisioning#282](https://github.com/liverty-music/cloud-provisioning/pull/282) — `prod-ci-frontend-ar-reader` IAM grant on dev `frontend` AR repo

**Verified live** (this session):
```
$ gcloud artifacts repositories get-iam-policy frontend \
    --project=liverty-music-dev --location=asia-northeast2 --format=json \
    | jq '.bindings[] | select(.members[]? | contains("github-actions@liverty-music-prod"))'

{ "role": "roles/artifactregistry.reader",
  "members": [ ..., "serviceAccount:github-actions@liverty-music-prod.iam.gserviceaccount.com", ... ] }
```

No writer, no admin, no project-level grant on dev. Exactly the scope the spec carves out.

## Workflow changes

Single file: `.github/workflows/push-image.yaml`, `build-and-push` job.

**Shared steps** (both paths) — unchanged:
- Checkout
- Authenticate to Google Cloud
- Set up Cloud SDK

**Push path only** (`if: github.event_name == 'push'`) — same logic, just gated:
- Configure Docker
- Set Image URI (dev path)
- Set Image Tags (dev path)
- Set up Docker Buildx
- Build and Push Docker Image

**Release path only** (`if: github.event_name == 'release'`):
- *Verify release commit is on main* — already release-gated
- **NEW**: Resolve dev AR digest for `github.sha` — `gcloud artifacts docker images describe` with 6 attempts × 60s wait per the spec's `SHALL` retry contract. Absorbs in-flight-dev-push races. Failure message points at `docs/runbooks/prod-image-tag-pinning.md#retag-failure-recovery` (in cloud-provisioning).
- **NEW**: Promote dev AR digest to prod AR (semver tag) — `gcloud artifacts docker tags add <dev>@<digest> <prod>:vX.Y.Z`
- **NEW**: Promote dev AR digest to prod AR (commit SHA tag) — same digest, different prod-side tag

## CI runtime impact

| Event | Before | After |
|---|---|---|
| push to main | ~90s (build + push) | ~90s (unchanged) |
| release published | ~90s (build + push) | **~30s** (auth + resolve + 2× tag-add) |

## What was removed from the release path

- `Set Image Tags (prod path)` — folded into the new tag-add steps' env blocks
- `Set up Docker Buildx` — no longer needed
- `Build and Push Docker Image` — replaced by retag
- The shared `Set Image URI` is now `Set Image URI (dev path)` — release path builds URIs inline because it needs both dev (source) and prod (destination) FQDNs

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` parses cleanly
- [x] `make lint` passes (biome + tsc clean)
- [x] Workflow conditional matrix verified step-by-step (no shared step accidentally rebuilds; no release-only step accidentally fires on push)
- [x] cloud-provisioning IAM grant verified live via `gcloud`
- [ ] After merge: a `push` to main triggers the dev build path identically to before — `post-deploy-smoke` job confirms dev still works
- [ ] After merge: cut a release tag (`v1.0.2` or higher) and watch the release-event run. Expected: ~30s end-to-end. Confirm `gcloud artifacts docker images describe asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app:vX.Y.Z` returns the same digest as `liverty-music-dev/frontend/web-app:<sha-of-the-release-commit>`.
- [ ] After release tag: bump `cloud-provisioning/k8s/namespaces/frontend/overlays/prod/kustomization.yaml`'s `newTag:` + `app.kubernetes.io/version` label to the new release. Merge that PR. ArgoCD syncs prod. Trigger smoke against prod: `gh workflow run "Deploy Frontend" --repo liverty-music/frontend -f smoke_url=https://liverty-music.app`.

Refs: liverty-music/specification#494