### PR TITLE
fix(ci): use `gcrane copy` for cross-AR promotion (gcloud tags-add doesn't)

### DIFF
--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -168,6 +168,21 @@ jobs:
       # (= `liverty-music-prod` per the `prod` environment binding) to
       # match the prod-AR convention enforced by `prod-image-pipeline`.
 
+      # Install `gcrane` (Google's go-containerregistry CLI) for the
+      # cross-repository / cross-project digest copy. `gcloud artifacts
+      # docker tags add` is intentionally NOT used here: despite its
+      # name, it only renames tags within a single repository — passing
+      # a source from `liverty-music-dev/frontend/web-app` and a
+      # destination in `liverty-music-prod/frontend/web-app` fails with
+      # `Image ... does not match image ...`. `gcrane copy` is the
+      # registry-to-registry primitive; within the same AR region it
+      # uses cross-repo blob mounting so no image bytes actually
+      # transfer (manifest re-push only). Auth flows through ADC that
+      # `google-github-actions/auth@v2` already exported.
+      - name: Install gcrane
+        if: github.event_name == 'release'
+        uses: imjasonh/setup-crane@v0.4
+
       - name: Resolve dev AR digest for github.sha
         if: github.event_name == 'release'
         id: resolve_digest
@@ -206,7 +221,7 @@ jobs:
           DIGEST: ${{ steps.resolve_digest.outputs.digest }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          gcloud artifacts docker tags add \
+          gcrane copy \
             "${DEV_AR_IMAGE}@${DIGEST}" \
             "${PROD_AR_IMAGE}:${RELEASE_TAG}"
 
@@ -217,7 +232,7 @@ jobs:
           PROD_AR_IMAGE: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE }}
           DIGEST: ${{ steps.resolve_digest.outputs.digest }}
         run: |
-          gcloud artifacts docker tags add \
+          gcrane copy \
             "${DEV_AR_IMAGE}@${DIGEST}" \
             "${PROD_AR_IMAGE}:${GITHUB_SHA}"
 


### PR DESCRIPTION
## Diagnosis

The v1.0.2 release run ([26025105562](https://github.com/liverty-music/frontend/actions/runs/26025105562)) failed at the promote step:

```
ERROR: (gcloud.artifacts.docker.tags.add) Image asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
does not match image asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app
```

`gcloud artifacts docker tags add` only renames tags **within a single repository**. The source and destination image paths must match. It cannot copy a digest across repos (or across projects).

The IAM grant works fine — the digest-resolve step ran cleanly (`sha256:3efd27e2b9...` resolved in <5s). The cross-project READ was OK; what failed was using the wrong tool for cross-repository write.

The `promote-prod-image-via-retag` design D1 had explicitly considered and rejected `gcrane` on incorrect grounds ("gcloud-tags-add suffices, no new tooling deps"). That premise was wrong.

## Fix

`gcrane copy` (Google's purpose-built CLI from `go-containerregistry`) is the registry-to-registry primitive. Within the same AR region, it uses cross-repo blob mounting — server-side, no bytes transfer, just manifest re-push.

Changes (release path only):
- Add `imjasonh/setup-crane@v0.4` action to install gcrane
- Replace both `gcloud artifacts docker tags add` invocations with `gcrane copy SRC@DIGEST DST:TAG`
- Auth flows through ADC already exported by `google-github-actions/auth@v2` — no separate Docker creds helper needed
- Inline comment documents WHY gcloud-tags-add was rejected so future readers see the trap

## v1.0.2 release tag state

- GH release tag exists, points at `4755811b` (frontend@main when cut)
- **No prod AR image was created** — the workflow failed before any tag was written
- Per `prod-image-tag-immutability` spec this is fully recoverable: nothing in prod AR to conflict with

## After merge

1. Delete the v1.0.2 GH release (`gh release delete v1.0.2 --cleanup-tag`)
2. Re-cut v1.0.2 on the new main HEAD (the fix commit)
3. Watch the release-event run exercise the fixed retag flow end-to-end
4. Verify `gcloud artifacts docker images describe asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app:v1.0.2` returns the same digest as `liverty-music-dev/frontend/web-app:<sha>`

## Follow-up (separate spec PR)

The spec at `openspec/specs/prod-image-pipeline/spec.md` and the runbook at `cloud-provisioning/docs/runbooks/prod-image-tag-pinning.md` still reference `gcloud artifacts docker tags add` in 3 scenarios. Once this workflow change validates the new tool end-to-end, I'll open a small specification PR updating those references to match reality. Tracking that under the existing #494 issue.

## Test plan

- [x] YAML parses
- [x] `make lint` passes
- [x] Inline comment explains the trap
- [ ] After merge: re-cut v1.0.2 → release-event CI succeeds → prod AR has byte-identical digest

Refs: liverty-music/specification#494