### PR TITLE
fix(ci): use `crane copy` (not gcrane) + share Configure Docker

### DIFF
--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -7,9 +7,9 @@ name: Deploy Frontend
 #
 # Per OpenSpec change `promote-prod-image-via-retag`, the release path
 # does NOT rebuild — it promotes the exact dev AR digest for the
-# release's commit SHA into prod AR via `gcloud artifacts docker tags
-# add`. The image deployed to prod is byte-identical to the dev AR
-# image already exercised in dev. This avoids the ~90s redundant rebuild
+# release's commit SHA into prod AR via `crane copy`. The image
+# deployed to prod is byte-identical to the dev AR image already
+# exercised in dev. This avoids the ~90s redundant rebuild
 # on every release and removes a class of non-determinism (dev vs prod
 # image divergence) that the env-agnostic bundle (per
 # `adopt-runtime-config-for-frontend`) made obsolete.
@@ -113,12 +113,14 @@ jobs:
       # ====================================================================
       # Dev push path: build env-agnostic image, push to dev AR
       # ====================================================================
-      # `Configure Docker` and `Set up Docker Buildx` are dev-only — the
-      # release path uses `gcloud artifacts docker tags add` and never
-      # touches the Docker daemon.
+      # `Configure Docker` is shared by both paths: the dev push uses
+      # buildx's pusher, and the release path uses `crane copy`, which
+      # reads its auth from Docker's config.json credential helpers (the
+      # gcloud helper for *.pkg.dev). Without this step crane falls
+      # back to anonymous and fails with 403 on the prod AR write.
+      # `Set up Docker Buildx` remains dev-only.
 
       - name: Configure Docker
-        if: github.event_name == 'push'
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev
 
       - name: Set Image URI (dev path)
@@ -168,18 +170,24 @@ jobs:
       # (= `liverty-music-prod` per the `prod` environment binding) to
       # match the prod-AR convention enforced by `prod-image-pipeline`.
 
-      # Install `gcrane` (Google's go-containerregistry CLI) for the
+      # Install `crane` (go-containerregistry's registry CLI) for the
       # cross-repository / cross-project digest copy. `gcloud artifacts
       # docker tags add` is intentionally NOT used here: despite its
       # name, it only renames tags within a single repository — passing
       # a source from `liverty-music-dev/frontend/web-app` and a
       # destination in `liverty-music-prod/frontend/web-app` fails with
-      # `Image ... does not match image ...`. `gcrane copy` is the
+      # `Image ... does not match image ...`. `crane copy` is the
       # registry-to-registry primitive; within the same AR region it
       # uses cross-repo blob mounting so no image bytes actually
-      # transfer (manifest re-push only). Auth flows through ADC that
-      # `google-github-actions/auth@v2` already exported.
-      - name: Install gcrane
+      # transfer (manifest re-push only).
+      #
+      # Note: the action's name is `setup-crane`, and it installs the
+      # `crane` binary — NOT the `gcrane` wrapper (a GCR-specific
+      # convenience build from the same go-containerregistry repo that
+      # the action does not ship). `crane` works identically for AR.
+      # Auth: `crane` reads `~/.docker/config.json` populated by the
+      # `Configure Docker` step above.
+      - name: Install crane
         if: github.event_name == 'release'
         uses: imjasonh/setup-crane@v0.4
 
@@ -221,7 +229,7 @@ jobs:
           DIGEST: ${{ steps.resolve_digest.outputs.digest }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          gcrane copy \
+          crane copy \
             "${DEV_AR_IMAGE}@${DIGEST}" \
             "${PROD_AR_IMAGE}:${RELEASE_TAG}"
 
@@ -232,7 +240,7 @@ jobs:
           PROD_AR_IMAGE: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE }}
           DIGEST: ${{ steps.resolve_digest.outputs.digest }}
         run: |
-          gcrane copy \
+          crane copy \
             "${DEV_AR_IMAGE}@${DIGEST}" \
             "${PROD_AR_IMAGE}:${GITHUB_SHA}"
 


### PR DESCRIPTION
## Summary

Fixes two bugs in the release-event retag path that combined to cause both v1.0.2 runs to fail before any prod-AR tag was written.

## What was wrong

### 1. `gcrane: command not found` — run #26025721319

PR #362 added `imjasonh/setup-crane@v0.4` to install `gcrane` for the cross-AR digest copy. But that action installs the **`crane`** binary — NOT `gcrane`. The two are siblings from the same `google/go-containerregistry` repo, but `gcrane` is a GCR-specific convenience wrapper that the action does not ship. So when the release path ran `gcrane copy …`, the shell errored out:

```
/home/runner/work/_temp/...sh: line 1: gcrane: command not found
##[error]Process completed with exit code 127.
```

For Artifact Registry, `crane copy` is functionally equivalent — AR speaks the OCI registry protocol that `crane` was written against. Within the same AR region this still uses cross-repo blob mounting (manifest re-push only, no image-byte transfer).

### 2. Latent auth bug: `Configure Docker` was gated to `push` only

`crane` authenticates by reading `~/.docker/config.json` credential helpers, NOT via `GOOGLE_APPLICATION_CREDENTIALS` directly. The previous workflow had:

```yaml
- name: Configure Docker
  if: github.event_name == 'push'
  run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev
```

So on the release path, Docker's config was empty and `crane` would have fallen back to anonymous, failing with 403 on the prod-AR write — even after fixing bug 1. The `setup-crane` action does not configure auth on its own.

## Changes

- Replace both `gcrane copy` → `crane copy` invocations.
- Drop the `if: github.event_name == 'push'` gate on `Configure Docker` so the gcloud credential helper lands in `~/.docker/config.json` for both paths. `Set up Docker Buildx` remains dev-only.
- Inline comment block now documents both traps explicitly so the next reader sees them.

## v1.0.2 release status

GH release tag exists; both prior workflow runs failed before any tag was written to prod AR. Per `prod-image-tag-immutability` spec, this is recoverable — nothing in prod AR to conflict with. After this PR merges, deleting the GH release and re-cutting v1.0.2 on the new HEAD will re-trigger the release event against the fixed workflow.

## Deferred

Spec / runbook updates that still reference `gcloud artifacts docker tags add` (three scenarios in `prod-image-pipeline/spec.md` + the cloud-provisioning runbook) remain deferred to a follow-up spec PR — landing here only after the new tool validates end-to-end.

## Testing

- N/A locally — this exercises a GitHub-hosted workflow against Artifact Registry. The actual validation is the next v1.0.2 retag attempt against this branch's HEAD after merge.

Refs: liverty-music/specification#494
