### PR TITLE
refactor(onboarding): refine copy, coach mark, home selector, and event detail i18n

### DIFF
--- a/src/components/live-highway/event-card.html
+++ b/src/components/live-highway/event-card.html
@@ -23,6 +23,7 @@ class="[ event-card ]"
       if.bind="event.journeyStatus"
       data-journey-status.bind="event.journeyStatus"
       class="journey-badge" data-testid="journey-badge"
-    >${event.journeyStatus}</span>
+      t.bind="'eventDetail.journeyStatus.' + event.journeyStatus"
+    ></span>
   </article>
 </template>

--- a/src/components/live-highway/event-detail-sheet.html
+++ b/src/components/live-highway/event-detail-sheet.html
@@ -5,7 +5,7 @@
     open.bind="isOpen"
     dismissable="true"
     sheet-closed.trigger="onSheetClosed()"
-    aria-label="Event details"
+    t="[aria-label]eventDetail.ariaLabel"
   >
     <div if.bind="event" class="sheet-content" aria-labelledby="sheet-artist-name">
       <!-- Hero background image -->
@@ -37,9 +37,11 @@
           <span class="detail-icon"><svg-icon name="calendar"></svg-icon></span>
           <div>
             <time datetime.bind="event.date.toISOString()" class="detail-primary">${event.date | date:'long'}</time>
-            <p class="detail-secondary">
-              Open ${event.openTime || '—'} / Start ${event.startTime}
-            </p>
+            <p
+              class="detail-secondary"
+              t="eventDetail.openStart"
+              t-params.bind="{ open: openTimeOrFallback, start: event.startTime }"
+            ></p>
           </div>
         </div>
 
@@ -54,16 +56,15 @@
               target="_blank"
               rel="noopener noreferrer"
               class="detail-link"
-            >
-              Open in Google Maps
-            </a>
+              t="eventDetail.openInGoogleMaps"
+            ></a>
           </div>
         </div>
       </section>
 
       <!-- Ticket journey status -->
       <section if.bind="isAuthenticated" class="sheet-journey" data-testid="sheet-journey">
-        <h3 class="journey-heading">Ticket Status</h3>
+        <h3 class="journey-heading" t="eventDetail.ticketStatus"></h3>
         <div class="journey-controls">
           <button
             repeat.for="s of journeyStatuses"
@@ -73,14 +74,16 @@
             data-active.bind="event.journeyStatus === s || undefined"
             disabled.bind="journeyUpdating"
             click.trigger="setJourneyStatus(s)"
-          >${s}</button>
+            t.bind="'eventDetail.journeyStatus.' + s"
+          ></button>
         </div>
         <button
           if.bind="event.journeyStatus"
           class="journey-remove-btn" data-testid="journey-remove-btn"
           disabled.bind="journeyUpdating"
           click.trigger="removeJourney()"
-        >Stop tracking</button>
+          t="eventDetail.stopTracking"
+        ></button>
       </section>
 
       <!-- Action buttons -->
@@ -91,7 +94,8 @@
           rel="noopener noreferrer"
           class="sheet-btn-primary"
         >
-          <svg-icon name="link"></svg-icon> View Official Info
+          <svg-icon name="link"></svg-icon>
+          <span t="eventDetail.viewOfficialInfo"></span>
         </a>
         <a
           href.bind="calendarUrl"
@@ -99,7 +103,8 @@
           rel="noopener noreferrer"
           class="sheet-btn-secondary"
         >
-          <svg-icon name="calendar"></svg-icon> Add to Calendar
+          <svg-icon name="calendar"></svg-icon>
+          <span t="eventDetail.addToCalendar"></span>
         </a>
       </footer>
     </div>

--- a/src/components/live-highway/event-detail-sheet.ts
+++ b/src/components/live-highway/event-detail-sheet.ts
@@ -1,3 +1,4 @@
+import { I18N } from '@aurelia/i18n'
 import { bindable, ILogger, resolve } from 'aurelia'
 import { IHistory } from '../../adapter/browser/history'
 import { displayName } from '../../constants/iso3166'
@@ -16,6 +17,7 @@ export class EventDetailSheet {
 	private readonly journeyService = resolve(ITicketJourneyService)
 	private readonly authService = resolve(IAuthService)
 	private readonly history = resolve(IHistory)
+	private readonly i18n = resolve(I18N)
 
 	// Arrow function to allow `removeEventListener` with the same reference
 	private readonly onPopstate = (): void => {
@@ -93,6 +95,10 @@ export class EventDetailSheet {
 
 	public get journeyStatuses(): JourneyStatus[] {
 		return ['tracking', 'applied', 'lost', 'unpaid', 'paid']
+	}
+
+	public get openTimeOrFallback(): string {
+		return this.event?.openTime || this.i18n.tr('eventDetail.openStartFallback')
 	}
 
 	public async setJourneyStatus(status: JourneyStatus): Promise<void> {

--- a/src/components/live-highway/event-detail-sheet.ts
+++ b/src/components/live-highway/event-detail-sheet.ts
@@ -1,4 +1,3 @@
-import { I18N } from '@aurelia/i18n'
 import { bindable, ILogger, resolve } from 'aurelia'
 import { IHistory } from '../../adapter/browser/history'
 import { displayName } from '../../constants/iso3166'
@@ -17,7 +16,6 @@ export class EventDetailSheet {
 	private readonly journeyService = resolve(ITicketJourneyService)
 	private readonly authService = resolve(IAuthService)
 	private readonly history = resolve(IHistory)
-	private readonly i18n = resolve(I18N)
 
 	// Arrow function to allow `removeEventListener` with the same reference
 	private readonly onPopstate = (): void => {
@@ -98,7 +96,7 @@ export class EventDetailSheet {
 	}
 
 	public get openTimeOrFallback(): string {
-		return this.event?.openTime || this.i18n.tr('eventDetail.openStartFallback')
+		return this.event?.openTime ?? '—'
 	}
 
 	public async setJourneyStatus(status: JourneyStatus): Promise<void> {

--- a/src/components/user-home-selector/user-home-selector.css
+++ b/src/components/user-home-selector/user-home-selector.css
@@ -79,13 +79,20 @@
 		}
 
 		.selector-back-btn {
-			display: flex;
+			display: inline-flex;
+			gap: var(--space-3xs);
 			align-items: center;
 			justify-content: center;
 
-			inline-size: 2rem;
+			inline-size: auto;
 			block-size: 2rem;
-			border-radius: var(--radius-full);
+			padding-inline: var(--space-2xs);
+			border-radius: var(--radius-button);
+
+			font-family: var(--font-display);
+			font-size: var(--step--1);
+			font-weight: 600;
+			color: var(--color-text-primary);
 
 			background: var(--color-surface-overlay);
 
@@ -98,7 +105,7 @@
 			& svg {
 				inline-size: 1rem;
 				block-size: 1rem;
-				color: var(--color-text-secondary);
+				color: var(--color-text-primary);
 			}
 		}
 	}

--- a/src/components/user-home-selector/user-home-selector.html
+++ b/src/components/user-home-selector/user-home-selector.html
@@ -47,9 +47,10 @@
           t="[aria-label]userHome.back"
           class="selector-back-btn"
         >
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <path d="M15 18l-6-6 6-6"></path>
           </svg>
+          <span t="userHome.backToRegions"></span>
         </button>
         <h2 class="selector-title">
           <span t.bind="'userHome.regions.' + selectedRegion.key"></span>

--- a/src/components/user-home-selector/user-home-selector.html
+++ b/src/components/user-home-selector/user-home-selector.html
@@ -44,7 +44,6 @@
       <div class="selector-header-row">
         <button
           click.trigger="backToRegions()"
-          t="[aria-label]userHome.back"
           class="selector-back-btn"
         >
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -56,7 +56,6 @@
 		"quickSelect": "Quick Select",
 		"selectByRegion": "Select by Region",
 		"selectPrefecture": "Select your prefecture.",
-		"back": "Back",
 		"backToRegions": "Regions",
 		"cities": {
 			"tokyo": "Tokyo",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -52,11 +52,12 @@
 	},
 	"userHome": {
 		"title": "Select Your Home Area",
-		"description": "The HOME STAGE shows lives in your home area. Where do you live?",
+		"description": "HOME STAGE shows lives in the area you select. Where do you live?",
 		"quickSelect": "Quick Select",
 		"selectByRegion": "Select by Region",
 		"selectPrefecture": "Select your prefecture.",
 		"back": "Back",
+		"backToRegions": "Regions",
 		"cities": {
 			"tokyo": "Tokyo",
 			"osaka": "Osaka",
@@ -123,6 +124,23 @@
 			"chugoku": "Chugoku",
 			"shikoku": "Shikoku",
 			"kyushu": "Kyushu"
+		}
+	},
+	"eventDetail": {
+		"ariaLabel": "Event details",
+		"openStart": "Open {{open}} / Start {{start}}",
+		"openStartFallback": "—",
+		"openInGoogleMaps": "Open in Google Maps",
+		"ticketStatus": "Ticket Status",
+		"stopTracking": "Stop tracking",
+		"viewOfficialInfo": "View Official Info",
+		"addToCalendar": "Add to Calendar",
+		"journeyStatus": {
+			"tracking": "Tracking",
+			"applied": "Applied",
+			"lost": "Lost",
+			"unpaid": "Unpaid",
+			"paid": "Paid"
 		}
 	},
 	"dashboard": {
@@ -210,7 +228,7 @@
 		"loadFailed": "Failed to load artists. Tap retry to try again.",
 		"retryFailed": "Still unable to load artists. Please try again later.",
 		"followFailed": "Couldn't save your follow of {{name}} — your connection may be unstable. Wait a moment and try again.",
-		"hasUpcomingEvents": "{{name}} has upcoming live events!",
+		"hasUpcomingEvents": "Found upcoming live events for {{name}}!",
 		"similarArtistsUnavailable": "No more similar artists available for {{name}}",
 		"similarArtistsError": "Couldn't find similar artists for {{name}}",
 		"srStatus": "Artist discovery: {{available}} artists available, {{followed}} followed.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -128,7 +128,6 @@
 	"eventDetail": {
 		"ariaLabel": "Event details",
 		"openStart": "Open {{open}} / Start {{start}}",
-		"openStartFallback": "—",
 		"openInGoogleMaps": "Open in Google Maps",
 		"ticketStatus": "Ticket Status",
 		"stopTracking": "Stop tracking",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -31,13 +31,13 @@
 			"seePreview": "サンプルを覗く"
 		},
 		"cta": {
-			"getStarted": "推しを選んでみる",
+			"getStarted": "アーティストをフォローする",
 			"login": "ログイン",
 			"loginHint": "アカウントをお持ちの方はログイン"
 		},
 		"guestFriendly": "アカウント不要・30秒で体験",
 		"preview": {
-			"label": "↓ 推しを選ぶと、あなただけのタイムテーブルに！"
+			"label": "↓ アーティストをフォローすると、あなただけのタイムテーブルに！"
 		},
 		"error": {
 			"navigation": "画面遷移に失敗しました。もう一度お試しください。",
@@ -45,18 +45,19 @@
 		}
 	},
 	"signup": {
-		"title": "あと一歩で、推しのライブを逃さなくなる",
+		"title": "あと一歩で、好きなアーティストのライブを逃さなくなる",
 		"description": "アカウントを作ると：<br>🔔 新ライブが見つかったらすぐに通知<br>📱 どの端末からでもタイムテーブルを開ける<br>🎟 これから追加されるチケット情報も保存",
 		"button": "Passkeyでアカウント作成（30秒）",
 		"error": "アカウント作成を完了できませんでした。ネットワークが不安定なようです。少し時間を置いてもう一度お試しください。"
 	},
 	"userHome": {
 		"title": "ホームエリアを選択",
-		"description": "HOME STAGEにはあなたの地元のライブが並びます。居住エリアはどこですか？",
+		"description": "HOME STAGEには選択したエリアのライブが並びます。あなたの居住エリアはどこですか？",
 		"quickSelect": "主要都市",
 		"selectByRegion": "地方から選ぶ",
 		"selectPrefecture": "都道府県を選んでください。",
 		"back": "戻る",
+		"backToRegions": "地方一覧",
 		"cities": {
 			"tokyo": "東京",
 			"osaka": "大阪",
@@ -125,6 +126,23 @@
 			"kyushu": "九州"
 		}
 	},
+	"eventDetail": {
+		"ariaLabel": "ライブ詳細",
+		"openStart": "開場 {{open}} / 開演 {{start}}",
+		"openStartFallback": "—",
+		"openInGoogleMaps": "Google Maps で開く",
+		"ticketStatus": "チケット状況",
+		"stopTracking": "追跡を停止",
+		"viewOfficialInfo": "公式情報を見る",
+		"addToCalendar": "カレンダーに追加",
+		"journeyStatus": {
+			"tracking": "検討中",
+			"applied": "申込済み",
+			"lost": "落選",
+			"unpaid": "当選・未入金",
+			"paid": "入金済み"
+		}
+	},
 	"dashboard": {
 		"lane": {
 			"home": "HOME STAGE",
@@ -141,7 +159,7 @@
 		"loading": "イベントを読み込み中…",
 		"empty": {
 			"title": "新しいライブが見つかり次第、ここに並びます",
-			"subtitle": "もっと推しを増やすと、タイムテーブルが充実します。",
+			"subtitle": "もっとアーティストをフォローすると、タイムテーブルが充実します。",
 			"discoverLink": "アーティストを探す"
 		},
 		"error": {
@@ -204,13 +222,13 @@
 		"coachMark": {
 			"viewTimetable": "タイムテーブルを見てみよう！"
 		},
-		"popoverGuide": "気になるアーティストをタップ — 選んだ推しのライブが、次のステップでタイムテーブルになります",
+		"popoverGuide": "気になるアーティストをタップ — フォローしたアーティストのライブが、次のステップでタイムテーブルになります",
 		"generateDashboard": "👉 タイムテーブルを生成する",
 		"viewSchedule": "ライブスケジュールを見る（{{count}}アーティスト）",
 		"loadFailed": "アーティストの読み込みに失敗しました。リトライしてください。",
 		"retryFailed": "読み込みに失敗しました。後ほど再度お試しください。",
 		"followFailed": "{{name}}のフォローを保存できませんでした。ネットワークが不安定なようです。少し時間を置いてもう一度お試しください。",
-		"hasUpcomingEvents": "{{name}}のライブが近日開催予定です！",
+		"hasUpcomingEvents": "{{name}}の開催予定のライブが見つかりました！",
 		"similarArtistsUnavailable": "{{name}}の類似アーティストはこれ以上ありません",
 		"similarArtistsError": "{{name}}の類似アーティストが見つかりませんでした",
 		"srStatus": "アーティスト探索: {{available}}アーティスト表示中、{{followed}}フォロー済み",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -128,7 +128,6 @@
 	"eventDetail": {
 		"ariaLabel": "ライブ詳細",
 		"openStart": "開場 {{open}} / 開演 {{start}}",
-		"openStartFallback": "—",
 		"openInGoogleMaps": "Google Maps で開く",
 		"ticketStatus": "チケット状況",
 		"stopTracking": "追跡を停止",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -56,7 +56,6 @@
 		"quickSelect": "主要都市",
 		"selectByRegion": "地方から選ぶ",
 		"selectPrefecture": "都道府県を選んでください。",
-		"back": "戻る",
 		"backToRegions": "地方一覧",
 		"cities": {
 			"tokyo": "東京",
@@ -136,7 +135,7 @@
 		"viewOfficialInfo": "公式情報を見る",
 		"addToCalendar": "カレンダーに追加",
 		"journeyStatus": {
-			"tracking": "検討中",
+			"tracking": "追跡中",
 			"applied": "申込済み",
 			"lost": "落選",
 			"unpaid": "当選・未入金",

--- a/src/routes/discovery/discovery-route.ts
+++ b/src/routes/discovery/discovery-route.ts
@@ -19,8 +19,6 @@ import { BubbleManager } from './bubble-manager'
 import { GenreFilterController } from './genre-filter-controller'
 import { SearchController } from './search-controller'
 
-const COACH_MARK_FADE_MS = 2000
-
 export class DiscoveryRoute {
 	private readonly artistClient = resolve(IArtistServiceClient)
 	private readonly followService = resolve(IFollowServiceClient)
@@ -36,7 +34,6 @@ export class DiscoveryRoute {
 
 	private abortController = new AbortController()
 	private dashboardCoachMarkShown = false
-	private coachMarkFadeTimer: ReturnType<typeof setTimeout> | null = null
 
 	// Controllers
 	public readonly bubbles = new BubbleManager(
@@ -125,10 +122,6 @@ export class DiscoveryRoute {
 				() => this.onCoachMarkTap(),
 				'50%',
 			)
-			this.coachMarkFadeTimer = setTimeout(() => {
-				this.coachMarkFadeTimer = null
-				this.onboarding.deactivateSpotlight()
-			}, COACH_MARK_FADE_MS)
 		}
 	}
 
@@ -175,10 +168,7 @@ export class DiscoveryRoute {
 		this.abortController.abort()
 		document.removeEventListener('visibilitychange', this.onVisibilityChange)
 		this.search.dispose()
-		if (this.coachMarkFadeTimer) {
-			clearTimeout(this.coachMarkFadeTimer)
-			this.coachMarkFadeTimer = null
-		}
+		this.onboarding.deactivateSpotlight()
 		this.onboarding.setDiscoveryCounts(0, 0)
 	}
 


### PR DESCRIPTION
## Summary

Polish a set of small but visible UI roughness across the onboarding and dashboard surfaces — implementing the spec proposal in liverty-music/specification#502.

- **Retire 「推し」** from JA user-facing copy in favor of "アーティスト" + "フォローする". Touches welcome CTA, welcome preview hint, signup title, discovery popover guide, and dashboard onboarding subtitle.
- **Rewrite the Discovery snack** "{{name}}のライブが近日開催予定です！" → "{{name}}の開催予定のライブが見つかりました！" (the system cannot verify imminence — only that concerts were found). EN value mirrored to "Found upcoming live events for {{name}}!".
- **Remove the 2-second auto-dismiss timer** on the Discovery → Dashboard coach mark. The spotlight now persists until the user taps the highlighted Dashboard icon. `detaching()` now calls `deactivateSpotlight()` so navigating away by other means (browser back, direct nav-tab tap) still cleans up.
- **Fix `userHome.description`** to accurately describe the flow: "HOME STAGEには選択したエリアのライブが並びます。あなたの居住エリアはどこですか？" — the previous copy assumed residence rather than asking for it.
- **Add a visible text label** ("地方一覧" / "Regions") to the prefecture-step back button in the home selector, alongside the existing chevron. Users were perceiving the icon-only circular button as a decorative dot, not a back affordance. Button now pill-shaped with `inline-size: auto`, chevron color bumped from `--color-text-secondary` to `--color-text-primary`.
- **Localize the concert detail sheet** (and the journey-status badge on event cards) into a new `eventDetail.*` i18n namespace, including JA/EN translations for every `JourneyStatus` value (`tracking` / `applied` / `lost` / `unpaid` / `paid`). Removes the hardcoded English that was leaking through an otherwise-Japanese UI.

## Files

| File | Concern |
|---|---|
| `src/locales/ja/translation.json` | All JA copy refinements + new `eventDetail.*` + `userHome.backToRegions` |
| `src/locales/en/translation.json` | Snack rewording + new `eventDetail.*` + `userHome.backToRegions` |
| `src/routes/discovery/discovery-route.ts` | Drop timer; explicit `deactivateSpotlight()` in `detaching()` |
| `src/components/user-home-selector/user-home-selector.html` | Back button: icon + `<span t="userHome.backToRegions">` |
| `src/components/user-home-selector/user-home-selector.css` | Pill-shaped back button; chevron contrast bump |
| `src/components/live-highway/event-detail-sheet.html` | Wire every literal string to `eventDetail.*` keys |
| `src/components/live-highway/event-detail-sheet.ts` | DI `I18N`; expose `openTimeOrFallback` getter for `t-params` |
| `src/components/live-highway/event-card.html` | Journey badge label sourced from `eventDetail.journeyStatus.*` |

## Spec

Proposal in liverty-music/specification#502 (OpenSpec change `refine-onboarding-copy`). Modified capabilities: `brand-vocabulary`, `onboarding-tutorial`, `user-home`, `concert-detail`.

No proto, backend, or infra changes. No new dependencies.

closes #348

## Test plan
- [x] `make lint` — biome + stylelint + tsc + brand-vocabulary parity all clean
- [x] `make test` — vitest 99 test files pass; no assertions on changed copy
- [ ] Smoke: onboarding flow in JA — confirm CTA reads "アーティストをフォローする", coach mark stays put until tap, home selector back button shows "地方一覧" pill, concert detail shows fully Japanese copy including journey-status badges
- [ ] CI green on `frontend-pr-checks.yml`