### PR TITLE
feat(my-artists): refine Hype vocabulary, default, and help sheets

### DIFF
--- a/scripts/check-brand-vocabulary.ts
+++ b/scripts/check-brand-vocabulary.ts
@@ -6,9 +6,12 @@
  *   2. Every second-segment stem (the entity name) appears in the curated
  *      KNOWN_ENTITY_STEMS list.
  *
- * Asymmetric values (different surface labels per locale, e.g. JA "Stage" vs
- * EN "Hype" for `entity.hype.label`) are intentionally permitted and not
- * flagged — that is normal localization, not drift.
+ * Asymmetric values (different surface labels per locale for the same key) are
+ * intentionally permitted and not flagged — that is normal localization, not
+ * drift. Note: `entity.hype.*` keys are NOT permitted at all (the `hype` stem
+ * was removed from `KNOWN_ENTITY_STEMS` when hype tier surface labels graduated
+ * to Layer B invariant brand expressions); any re-introduction will fail the
+ * unknown-stem check.
  *
  * Exits 0 on success, 1 on failure. Run via `npx tsx scripts/check-brand-vocabulary.ts`.
  */

--- a/scripts/known-entities.ts
+++ b/scripts/known-entities.ts
@@ -5,17 +5,23 @@
  * (`liverty-music/specification:proto/liverty_music/entity/v1/`). The stem is
  * derived from the entity name per the brand-vocabulary spec mirroring rule:
  *
- *   - `HypeLevel` (enum, drops the `Level` suffix) → `hype`
  *   - `Concert`   (message)                        → `concert`
  *   - `Artist`    (message)                        → `artist`
  *   - `User.HomeArea` (nested concept)             → `homeArea`
+ *
+ * Note: `HypeType` (proto enum) does NOT appear here. The four hype tier surface
+ * forms (`Watch / Home / Nearby / Away`) and the `Hype` concept label itself
+ * are Layer B brand expressions per `openspec/specs/brand-vocabulary/spec.md`;
+ * they are rendered invariantly in English and are not sourced from i18n.
+ * Adding `hype` back to this set will cause `entity.hype.*` keys to pass the
+ * known-entity check, which would silently re-introduce locale-translated
+ * tier labels — exactly the drift the Layer B graduation eliminated.
  *
  * When a new protobuf entity needs a UI label, add its stem here in the same
  * change that introduces the label. The brand-vocabulary lint script exits
  * non-zero if an `entity.<unknown>` key appears.
  */
 export const KNOWN_ENTITY_STEMS: ReadonlySet<string> = new Set([
-	'hype',
 	'concert',
 	'artist',
 	'homeArea',

--- a/src/adapter/view/hype-display.spec.ts
+++ b/src/adapter/view/hype-display.spec.ts
@@ -11,9 +11,18 @@ describe('HYPE_TIERS', () => {
 		expect(Object.keys(HYPE_TIERS).sort()).toEqual([...ALL_HYPES].sort())
 	})
 
-	it.each(ALL_HYPES)('%s has non-empty labelKey and icon', (hype) => {
+	it.each(ALL_HYPES)('%s has non-empty label and icon', (hype) => {
 		const tier = HYPE_TIERS[hype]
-		expect(tier.labelKey).toBeTruthy()
+		expect(tier.label).toBeTruthy()
 		expect(tier.icon).toBeTruthy()
+	})
+
+	it.each([
+		['watch', 'Watch'],
+		['home', 'Home'],
+		['nearby', 'Nearby'],
+		['away', 'Away'],
+	] as const)('%s renders the invariant English label %s', (hype, label) => {
+		expect(HYPE_TIERS[hype].label).toBe(label)
 	})
 })

--- a/src/adapter/view/hype-display.ts
+++ b/src/adapter/view/hype-display.ts
@@ -2,13 +2,13 @@ import type { Hype } from '../../entities/follow'
 
 /**
  * Display metadata for each hype tier.
- * Maps hype values to their UI label key and icon. Labels live in the
- * canonical `entity.hype.values.*` i18n namespace per the brand-vocabulary
- * capability mirror rule.
+ * Maps hype values to their invariant brand label and emoji icon. Labels are
+ * Layer B brand expressions (per the brand-vocabulary spec) rendered in the
+ * same English form across every locale; they are not sourced from i18n.
  */
-export const HYPE_TIERS: Record<Hype, { labelKey: string; icon: string }> = {
-	watch: { labelKey: 'entity.hype.values.watch', icon: '👀' },
-	home: { labelKey: 'entity.hype.values.home', icon: '🔥' },
-	nearby: { labelKey: 'entity.hype.values.nearby', icon: '🔥🔥' },
-	away: { labelKey: 'entity.hype.values.away', icon: '🔥🔥🔥' },
+export const HYPE_TIERS: Record<Hype, { label: string; icon: string }> = {
+	watch: { label: 'Watch', icon: '👀' },
+	home: { label: 'Home', icon: '🔥' },
+	nearby: { label: 'Nearby', icon: '🔥🔥' },
+	away: { label: 'Away', icon: '🔥🔥🔥' },
 }

--- a/src/components/page-help/page-help.css
+++ b/src/components/page-help/page-help.css
@@ -189,8 +189,10 @@
 		   description (1fr). Auto-sized columns 1 and 2 expand to fit the
 		   widest cell in each column, so label-column and description-column
 		   left edges align across all four tiers regardless of icon width.
-		   Semantic markup is <dl> with two <dt>s per <dd>: icon + label both
-		   define the term; description is the definition. */
+		   Markup is <ul> + <li display:contents>: the <li> participates as a
+		   single grid row container while its children become direct grid
+		   items. The decorative emoji is a plain <span aria-hidden="true">
+		   inside the row so it is NOT promoted to a list term. */
 		.help-hype-grid {
 			display: grid;
 			grid-template-columns: auto auto 1fr;
@@ -200,7 +202,13 @@
 			padding: var(--space-s);
 			border-radius: var(--radius-card);
 
+			list-style: none;
+
 			background: oklch(from var(--color-surface-overlay) calc(l + 0.04) c h);
+		}
+
+		.help-hype-row {
+			display: contents;
 		}
 
 		.help-hype-icon {

--- a/src/components/page-help/page-help.css
+++ b/src/components/page-help/page-help.css
@@ -46,11 +46,21 @@
 			background: oklch(from var(--color-brand-accent) l c h / 18%);
 		}
 
+		/* Each sub-section is a <section class="page-help-content"> block. A
+		   sheet may contain multiple sub-sections rendered in document order;
+		   they share visual treatment via the .page-help-header + .help-section-title
+		   pair below. */
 		.page-help-content {
 			padding: var(--space-m) var(--space-s) var(--space-l);
 		}
 
-		/* ── Header (icon + title with subtle divider) ──────────────────── */
+		/* Sub-sections after the first reduce top padding so the divider
+		   from the previous section's content doesn't double up visually. */
+		.page-help-content + .page-help-content {
+			padding-block-start: var(--space-2xs);
+		}
+
+		/* ── Sub-section header (icon + title with subtle divider) ──────── */
 		.page-help-header {
 			display: flex;
 			gap: var(--space-2xs);
@@ -67,7 +77,7 @@
 			color: var(--color-brand-accent);
 		}
 
-		.page-help-title {
+		.help-section-title {
 			margin: 0;
 			font-family: var(--font-display);
 			font-size: var(--step-1);
@@ -173,25 +183,45 @@
 			color: var(--color-stage-away);
 		}
 
-		/* ── Hype table (My Artists) ────────────────────────────────────── */
-		.page-help-hype-table {
-			border-collapse: collapse;
-			inline-size: 100%;
+		/* ── Hype tier grid (My Artists) ────────────────────────────────── */
+
+		/* 3-column grid: icon (auto) · invariant English label (auto) · scope
+		   description (1fr). Auto-sized columns 1 and 2 expand to fit the
+		   widest cell in each column, so label-column and description-column
+		   left edges align across all four tiers regardless of icon width.
+		   Semantic markup is <dl> with two <dt>s per <dd>: icon + label both
+		   define the term; description is the definition. */
+		.help-hype-grid {
+			display: grid;
+			grid-template-columns: auto auto 1fr;
+			gap: var(--space-xs) var(--space-s);
+
 			margin-block: var(--space-s);
+			padding: var(--space-s);
+			border-radius: var(--radius-card);
+
+			background: oklch(from var(--color-surface-overlay) calc(l + 0.04) c h);
 		}
 
-		.page-help-hype-table :is(td, th) {
-			padding: var(--space-2xs);
-			vertical-align: top;
-		}
-
-		.page-help-hype-table :is(td, th):first-child {
-			inline-size: 7rem;
+		.help-hype-icon {
+			align-self: center;
+			font-size: var(--step-0);
+			line-height: var(--leading-none);
+			text-align: center;
 			white-space: nowrap;
 		}
 
-		.page-help-hype-table tr + tr :is(td, th) {
-			border-block-start: 1px solid var(--color-border-subtle);
+		.help-hype-label {
+			align-self: center;
+			font-family: var(--font-display);
+			font-weight: 700;
+			white-space: nowrap;
+		}
+
+		.help-hype-desc {
+			align-self: center;
+			margin: 0;
+			color: var(--color-text-secondary);
 		}
 
 		/* ── Note (footnote / caption) ──────────────────────────────────── */

--- a/src/components/page-help/page-help.html
+++ b/src/components/page-help/page-help.html
@@ -8,76 +8,117 @@
   type="button"
 >?</button>
 
-<bottom-sheet open.bind="isOpen" sheet-closed.trigger="onSheetClosed()" aria-label="ページのヘルプ">
+<!-- Each per-page <template case="…"> contains one or more <section> sub-blocks.
+     Each sub-section carries its own .help-section-title heading; there is no
+     sheet-level <h2>, because the bottom-sheet itself provides the accessible
+     name via its aria-label. See onboarding-page-help capability spec. -->
+<bottom-sheet open.bind="isOpen" sheet-closed.trigger="onSheetClosed()" aria-label.bind="i18n.tr('pageHelp.sheetAriaLabel')">
 
   <template switch.bind="page">
 
-    <section case="discovery" class="page-help-content" aria-labelledby="help-discovery-title">
-      <header class="page-help-header">
-        <svg-icon name="info" class="page-help-icon" data-size="sm"></svg-icon>
-        <h2 id="help-discovery-title" class="page-help-title" t="pageHelp.discovery.title"></h2>
-      </header>
-      <p class="page-help-desc" t="pageHelp.discovery.description"></p>
+    <template case="discovery">
+      <!-- Discovery: 2 sub-sections — Finding Artists + Unfollowing. -->
+      <section class="page-help-content">
+        <header class="page-help-header">
+          <svg-icon name="info" class="page-help-icon" data-size="sm"></svg-icon>
+          <h3 class="help-section-title" t="pageHelp.discovery.findingSectionTitle"></h3>
+        </header>
+        <p class="page-help-desc" t="pageHelp.discovery.description"></p>
 
-      <!-- Inline demo of the actual genre chips so the tip is shown, not just told. -->
-      <div class="page-help-chip-demo" aria-hidden="true">
-        <span class="page-help-chip">Rock</span>
-        <span class="page-help-chip" data-active>Pop</span>
-        <span class="page-help-chip">Jazz</span>
-      </div>
+        <!-- Inline demo of the actual genre chips so the tip is shown, not just told. -->
+        <div class="page-help-chip-demo" aria-hidden="true">
+          <span class="page-help-chip">Rock</span>
+          <span class="page-help-chip" data-active>Pop</span>
+          <span class="page-help-chip">Jazz</span>
+        </div>
 
-      <ul class="page-help-tips">
-        <li t="pageHelp.discovery.genreTip"></li>
-        <li t="pageHelp.discovery.searchTip"></li>
-      </ul>
-    </section>
+        <ul class="page-help-tips">
+          <li t="pageHelp.discovery.genreTip"></li>
+          <li t="pageHelp.discovery.searchTip"></li>
+        </ul>
+      </section>
 
-    <section case="dashboard" class="page-help-content" aria-labelledby="help-dashboard-title">
-      <header class="page-help-header">
-        <svg-icon name="info" class="page-help-icon" data-size="sm"></svg-icon>
-        <h2 id="help-dashboard-title" class="page-help-title" t="pageHelp.dashboard.title"></h2>
-      </header>
-      <p class="page-help-desc" t="pageHelp.dashboard.description"></p>
-      <dl class="page-help-lanes">
-        <dt class="stage-home" t="pageHelp.dashboard.homeLabel"></dt>
-        <dd t="pageHelp.dashboard.homeDesc"></dd>
-        <dt class="stage-near" t="pageHelp.dashboard.nearLabel"></dt>
-        <dd t="pageHelp.dashboard.nearDesc"></dd>
-        <dt class="stage-away" t="pageHelp.dashboard.awayLabel"></dt>
-        <dd t="pageHelp.dashboard.awayDesc"></dd>
-      </dl>
-      <p class="page-help-note" t="pageHelp.dashboard.cardTip"></p>
-    </section>
+      <section class="page-help-content">
+        <header class="page-help-header">
+          <svg-icon name="info" class="page-help-icon" data-size="sm"></svg-icon>
+          <h3 class="help-section-title" t="pageHelp.discovery.unfollowSectionTitle"></h3>
+        </header>
+        <p class="page-help-desc" t="pageHelp.discovery.unfollowDesc"></p>
+      </section>
+    </template>
 
-    <section case="my-artists" class="page-help-content" aria-labelledby="help-my-artists-title">
-      <header class="page-help-header">
-        <svg-icon name="info" class="page-help-icon" data-size="sm"></svg-icon>
-        <h2 id="help-my-artists-title" class="page-help-title" t="pageHelp.myArtists.title"></h2>
-      </header>
-      <p class="page-help-desc" t="pageHelp.myArtists.description"></p>
-      <table class="page-help-hype-table">
-        <tbody>
-          <tr>
-            <th scope="row"><span aria-hidden="true">👀</span> Watch</th>
-            <td t="pageHelp.myArtists.watchDesc"></td>
-          </tr>
-          <tr>
-            <th scope="row"><span aria-hidden="true">🔥</span> Home</th>
-            <td t="pageHelp.myArtists.homeDesc"></td>
-          </tr>
-          <tr>
-            <th scope="row"><span aria-hidden="true">🔥🔥</span> Nearby</th>
-            <td t="pageHelp.myArtists.nearbyDesc"></td>
-          </tr>
-          <tr>
-            <th scope="row"><span aria-hidden="true">🔥🔥🔥</span> Away</th>
-            <td t="pageHelp.myArtists.awayDesc"></td>
-          </tr>
-        </tbody>
-      </table>
-      <p class="page-help-note" t="pageHelp.myArtists.tip"></p>
-      <p if.bind="isPointerCoarse" class="page-help-note" t="pageHelp.myArtists.longPressTip"></p>
-    </section>
+    <template case="dashboard">
+      <!-- Dashboard: 2 sub-sections — Reading the Stage Lanes + Viewing Concert Details. -->
+      <section class="page-help-content">
+        <header class="page-help-header">
+          <svg-icon name="info" class="page-help-icon" data-size="sm"></svg-icon>
+          <h3 class="help-section-title" t="pageHelp.dashboard.lanesSectionTitle"></h3>
+        </header>
+        <p class="page-help-desc" t="pageHelp.dashboard.description"></p>
+        <dl class="page-help-lanes">
+          <dt class="stage-home" t="pageHelp.dashboard.homeLabel"></dt>
+          <dd t="pageHelp.dashboard.homeDesc"></dd>
+          <dt class="stage-near" t="pageHelp.dashboard.nearLabel"></dt>
+          <dd t="pageHelp.dashboard.nearDesc"></dd>
+          <dt class="stage-away" t="pageHelp.dashboard.awayLabel"></dt>
+          <dd t="pageHelp.dashboard.awayDesc"></dd>
+        </dl>
+      </section>
+
+      <section class="page-help-content">
+        <header class="page-help-header">
+          <svg-icon name="info" class="page-help-icon" data-size="sm"></svg-icon>
+          <h3 class="help-section-title" t="pageHelp.dashboard.detailsSectionTitle"></h3>
+        </header>
+        <p class="page-help-desc" t="pageHelp.dashboard.cardTip"></p>
+      </section>
+    </template>
+
+    <template case="my-artists">
+      <!-- My Artists: Hype sub-section (always rendered) +
+           Unfollow sub-section (only on touch devices, per existing isPointerCoarse gate). -->
+      <section class="page-help-content">
+        <header class="page-help-header">
+          <svg-icon name="info" class="page-help-icon" data-size="sm"></svg-icon>
+          <h3 class="help-section-title" t="pageHelp.myArtists.hypeSectionTitle"></h3>
+        </header>
+        <p class="page-help-desc" t="pageHelp.myArtists.description"></p>
+
+        <!-- 3-column grid via <dl> with two <dt>s per <dd>: icon (col 1), invariant
+             English label (col 2), notification scope description (col 3). The
+             column edges align across all four tiers because the grid auto-sizes
+             columns 1 and 2 to the widest cell. See onboarding-page-help spec:
+             "Hype tier table is a 3-column grid". Hype tier labels are Layer B
+             brand expressions (invariant English) per brand-vocabulary spec. -->
+        <dl class="help-hype-grid">
+          <dt class="help-hype-icon" aria-hidden="true">👀</dt>
+          <dt class="help-hype-label">Watch</dt>
+          <dd class="help-hype-desc" t="pageHelp.myArtists.watchDesc"></dd>
+
+          <dt class="help-hype-icon" aria-hidden="true">🔥</dt>
+          <dt class="help-hype-label">Home</dt>
+          <dd class="help-hype-desc" t="pageHelp.myArtists.homeDesc"></dd>
+
+          <dt class="help-hype-icon" aria-hidden="true">🔥🔥</dt>
+          <dt class="help-hype-label">Nearby</dt>
+          <dd class="help-hype-desc" t="pageHelp.myArtists.nearbyDesc"></dd>
+
+          <dt class="help-hype-icon" aria-hidden="true">🔥🔥🔥</dt>
+          <dt class="help-hype-label">Away</dt>
+          <dd class="help-hype-desc" t="pageHelp.myArtists.awayDesc"></dd>
+        </dl>
+
+        <p class="page-help-note" t="pageHelp.myArtists.tip"></p>
+      </section>
+
+      <section if.bind="isPointerCoarse" class="page-help-content">
+        <header class="page-help-header">
+          <svg-icon name="info" class="page-help-icon" data-size="sm"></svg-icon>
+          <h3 class="help-section-title" t="pageHelp.myArtists.unfollowSectionTitle"></h3>
+        </header>
+        <p class="page-help-desc" t="pageHelp.myArtists.longPressTip"></p>
+      </section>
+    </template>
 
   </template>
 

--- a/src/components/page-help/page-help.html
+++ b/src/components/page-help/page-help.html
@@ -2,8 +2,7 @@
 
 <button
   class="page-help-trigger"
-  aria-label.bind="ariaLabel"
-  title.bind="ariaLabel"
+  t="[aria-label]pageHelp.triggerAriaLabel;[title]pageHelp.triggerAriaLabel"
   click.trigger="onHelpTap()"
   type="button"
 >?</button>
@@ -12,7 +11,7 @@
      Each sub-section carries its own .help-section-title heading; there is no
      sheet-level <h2>, because the bottom-sheet itself provides the accessible
      name via its aria-label. See onboarding-page-help capability spec. -->
-<bottom-sheet open.bind="isOpen" sheet-closed.trigger="onSheetClosed()" aria-label.bind="i18n.tr('pageHelp.sheetAriaLabel')">
+<bottom-sheet open.bind="isOpen" sheet-closed.trigger="onSheetClosed()" t="[aria-label]pageHelp.sheetAriaLabel">
 
   <template switch.bind="page">
 
@@ -84,29 +83,39 @@
         </header>
         <p class="page-help-desc" t="pageHelp.myArtists.description"></p>
 
-        <!-- 3-column grid via <dl> with two <dt>s per <dd>: icon (col 1), invariant
-             English label (col 2), notification scope description (col 3). The
-             column edges align across all four tiers because the grid auto-sizes
-             columns 1 and 2 to the widest cell. See onboarding-page-help spec:
+        <!-- 3-column grid: icon (col 1), invariant English label (col 2),
+             notification scope description (col 3). Auto-sized columns 1 and 2
+             expand to fit the widest cell so label-column and description-column
+             edges align across all four tier rows. See onboarding-page-help spec:
              "Hype tier table is a 3-column grid". Hype tier labels are Layer B
-             brand expressions (invariant English) per brand-vocabulary spec. -->
-        <dl class="help-hype-grid">
-          <dt class="help-hype-icon" aria-hidden="true">👀</dt>
-          <dt class="help-hype-label">Watch</dt>
-          <dd class="help-hype-desc" t="pageHelp.myArtists.watchDesc"></dd>
+             brand expressions (invariant English) per brand-vocabulary spec.
 
-          <dt class="help-hype-icon" aria-hidden="true">🔥</dt>
-          <dt class="help-hype-label">Home</dt>
-          <dd class="help-hype-desc" t="pageHelp.myArtists.homeDesc"></dd>
-
-          <dt class="help-hype-icon" aria-hidden="true">🔥🔥</dt>
-          <dt class="help-hype-label">Nearby</dt>
-          <dd class="help-hype-desc" t="pageHelp.myArtists.nearbyDesc"></dd>
-
-          <dt class="help-hype-icon" aria-hidden="true">🔥🔥🔥</dt>
-          <dt class="help-hype-label">Away</dt>
-          <dd class="help-hype-desc" t="pageHelp.myArtists.awayDesc"></dd>
-        </dl>
+             Markup uses <ul> + <li display:contents> rather than <dl> so the
+             decorative emoji icon is not promoted to a <dt> "description term".
+             Each <li> participates in the parent grid via display: contents,
+             keeping a single grid context for column auto-sizing. -->
+        <ul class="help-hype-grid">
+          <li class="help-hype-row">
+            <span class="help-hype-icon" aria-hidden="true">👀</span>
+            <span class="help-hype-label">Watch</span>
+            <span class="help-hype-desc" t="pageHelp.myArtists.watchDesc"></span>
+          </li>
+          <li class="help-hype-row">
+            <span class="help-hype-icon" aria-hidden="true">🔥</span>
+            <span class="help-hype-label">Home</span>
+            <span class="help-hype-desc" t="pageHelp.myArtists.homeDesc"></span>
+          </li>
+          <li class="help-hype-row">
+            <span class="help-hype-icon" aria-hidden="true">🔥🔥</span>
+            <span class="help-hype-label">Nearby</span>
+            <span class="help-hype-desc" t="pageHelp.myArtists.nearbyDesc"></span>
+          </li>
+          <li class="help-hype-row">
+            <span class="help-hype-icon" aria-hidden="true">🔥🔥🔥</span>
+            <span class="help-hype-label">Away</span>
+            <span class="help-hype-desc" t="pageHelp.myArtists.awayDesc"></span>
+          </li>
+        </ul>
 
         <p class="page-help-note" t="pageHelp.myArtists.tip"></p>
       </section>

--- a/src/components/page-help/page-help.spec.ts
+++ b/src/components/page-help/page-help.spec.ts
@@ -10,24 +10,11 @@ const fakeOnboarding = {
 	isOnboarding: true,
 }
 
-const fakeI18N = {
-	tr: (key: string) => key,
-}
-
 vi.mock('aurelia', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('aurelia')>()
-	// Track resolve() calls in component-construction order:
-	//   1st call: IOnboardingService (from `private readonly onboarding = resolve(...)`)
-	//   2nd call: I18N (from `public readonly i18n = resolve(I18N)`)
-	// Resets per `new PageHelp()` instantiation via the modulo on call count.
-	const resolveCallCount = { count: 0 }
 	return {
 		...actual,
-		resolve: vi.fn(() => {
-			const slot = resolveCallCount.count % 2
-			resolveCallCount.count += 1
-			return slot === 0 ? fakeOnboarding : fakeI18N
-		}),
+		resolve: vi.fn(() => fakeOnboarding),
 		bindable: actual.bindable,
 	}
 })

--- a/src/components/page-help/page-help.spec.ts
+++ b/src/components/page-help/page-help.spec.ts
@@ -6,11 +6,28 @@ vi.mock('../../adapter/storage/onboarding-storage', () => ({
 	clearAllHelpSeen: vi.fn(),
 }))
 
+const fakeOnboarding = {
+	isOnboarding: true,
+}
+
+const fakeI18N = {
+	tr: (key: string) => key,
+}
+
 vi.mock('aurelia', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('aurelia')>()
+	// Track resolve() calls in component-construction order:
+	//   1st call: IOnboardingService (from `private readonly onboarding = resolve(...)`)
+	//   2nd call: I18N (from `public readonly i18n = resolve(I18N)`)
+	// Resets per `new PageHelp()` instantiation via the modulo on call count.
+	const resolveCallCount = { count: 0 }
 	return {
 		...actual,
-		resolve: vi.fn(() => fakeOnboarding),
+		resolve: vi.fn(() => {
+			const slot = resolveCallCount.count % 2
+			resolveCallCount.count += 1
+			return slot === 0 ? fakeOnboarding : fakeI18N
+		}),
 		bindable: actual.bindable,
 	}
 })
@@ -20,10 +37,6 @@ import {
 	saveHelpSeen,
 } from '../../adapter/storage/onboarding-storage'
 import { PageHelp, type PageHelpPage } from './page-help'
-
-const fakeOnboarding = {
-	isOnboarding: true,
-}
 
 describe('PageHelp', () => {
 	let sut: PageHelp

--- a/src/components/page-help/page-help.ts
+++ b/src/components/page-help/page-help.ts
@@ -1,3 +1,4 @@
+import { I18N } from '@aurelia/i18n'
 import { bindable, resolve } from 'aurelia'
 import {
 	clearAllHelpSeen,
@@ -21,6 +22,7 @@ export class PageHelp {
 	public isPointerCoarse = false
 
 	private readonly onboarding = resolve(IOnboardingService)
+	public readonly i18n = resolve(I18N)
 
 	public attached(): void {
 		this.isPointerCoarse =
@@ -49,7 +51,7 @@ export class PageHelp {
 	}
 
 	public get ariaLabel(): string {
-		return 'ヘルプを表示'
+		return this.i18n.tr('pageHelp.triggerAriaLabel')
 	}
 
 	public static clearHelpSeen(): void {

--- a/src/components/page-help/page-help.ts
+++ b/src/components/page-help/page-help.ts
@@ -1,4 +1,3 @@
-import { I18N } from '@aurelia/i18n'
 import { bindable, resolve } from 'aurelia'
 import {
 	clearAllHelpSeen,
@@ -22,7 +21,6 @@ export class PageHelp {
 	public isPointerCoarse = false
 
 	private readonly onboarding = resolve(IOnboardingService)
-	public readonly i18n = resolve(I18N)
 
 	public attached(): void {
 		this.isPointerCoarse =
@@ -48,10 +46,6 @@ export class PageHelp {
 
 	public onSheetClosed(): void {
 		this.isOpen = false
-	}
-
-	public get ariaLabel(): string {
-		return this.i18n.tr('pageHelp.triggerAriaLabel')
 	}
 
 	public static clearHelpSeen(): void {

--- a/src/components/signup-prompt-banner/signup-prompt-banner.css
+++ b/src/components/signup-prompt-banner/signup-prompt-banner.css
@@ -29,41 +29,9 @@
 			backdrop-filter: blur(12px);
 		}
 
-		.signup-banner-header {
-			display: flex;
-			gap: var(--space-xs);
-			align-items: flex-start;
-			justify-content: space-between;
-		}
-
 		.signup-banner-message {
 			font-size: var(--step-0);
 			color: var(--color-text-secondary);
-		}
-
-		.signup-banner-dismiss {
-			display: flex;
-			flex-shrink: 0;
-			align-items: center;
-			justify-content: center;
-
-			inline-size: 1.5rem;
-			block-size: 1.5rem;
-			border-radius: var(--radius-full);
-
-			color: var(--color-text-muted);
-
-			transition: color 150ms ease-out;
-
-			& svg-icon {
-				inline-size: 0.875rem;
-				block-size: 0.875rem;
-			}
-
-			&:hover,
-			&:focus-visible {
-				color: var(--color-text-secondary);
-			}
 		}
 
 		.signup-banner-btn {

--- a/src/components/signup-prompt-banner/signup-prompt-banner.html
+++ b/src/components/signup-prompt-banner/signup-prompt-banner.html
@@ -1,11 +1,10 @@
 <import from="./signup-prompt-banner.css"></import>
 
+<!-- Persistent for guest users until they complete signup. Per the
+     signup-prompt-banner capability spec ("No dismiss control" scenario), the
+     banner offers no UI affordance to dismiss — visibility is controlled
+     entirely by the host page via the `visible` bindable. -->
 <aside if.bind="visible" aria-label="Signup prompt" class="[ signup-banner ]">
-  <div class="signup-banner-header">
-    <span class="signup-banner-message">${message}</span>
-    <button type="button" class="signup-banner-dismiss" t="[aria-label]common.dismiss" click.trigger="onDismiss()">
-      <svg-icon name="x" aria-hidden="true"></svg-icon>
-    </button>
-  </div>
+  <span class="signup-banner-message">${message}</span>
   <button class="signup-banner-btn" click.trigger="onSignup()" t="common.createAccount"></button>
 </aside>

--- a/src/components/signup-prompt-banner/signup-prompt-banner.ts
+++ b/src/components/signup-prompt-banner/signup-prompt-banner.ts
@@ -11,10 +11,4 @@ export class SignupPromptBanner {
 			new CustomEvent('signup-requested', { bubbles: true }),
 		)
 	}
-
-	public onDismiss(): void {
-		this.element.dispatchEvent(
-			new CustomEvent('banner-dismissed', { bubbles: true }),
-		)
-	}
 }

--- a/src/entities/follow.ts
+++ b/src/entities/follow.ts
@@ -3,8 +3,16 @@ import type { Artist } from './artist'
 /** Hype level indicating how far the user will travel for an artist. */
 export type Hype = 'watch' | 'home' | 'nearby' | 'away'
 
-/** Default hype level assigned to new follows and used as fallback. */
-export const DEFAULT_HYPE: Hype = 'watch'
+/**
+ * Default hype level assigned to new follows and used as fallback.
+ *
+ * Set to `'nearby'` so a fresh follow immediately implies "notify me about
+ * concerts within reach of my home area." The non-dismissable signup banner
+ * (see `signup-prompt-banner` capability) makes the signup prerequisite for
+ * actually receiving these notifications visible from the moment a guest
+ * lands on the My Artists page.
+ */
+export const DEFAULT_HYPE: Hype = 'nearby'
 
 /**
  * A followed artist combining the proto Artist entity

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -4,15 +4,6 @@
 		"createAccount": "Create Account"
 	},
 	"entity": {
-		"hype": {
-			"label": "Hype",
-			"values": {
-				"watch": "Watching",
-				"home": "Home",
-				"nearby": "Near",
-				"away": "Away"
-			}
-		},
 		"concert": {
 			"label": "Concert"
 		},
@@ -300,14 +291,18 @@
 		"close": "Close"
 	},
 	"pageHelp": {
+		"sheetAriaLabel": "Page help",
+		"triggerAriaLabel": "Show help",
 		"discovery": {
-			"title": "Follow Artists",
-			"description": "Tap a bubble to follow an artist. Unfollow from the My Artists page.",
+			"findingSectionTitle": "Finding Artists",
+			"description": "Tap a bubble to follow an artist.",
 			"genreTip": "Filter by genre using the tabs",
-			"searchTip": "Search by name using the search bar"
+			"searchTip": "Search by name using the search bar",
+			"unfollowSectionTitle": "Unfollowing",
+			"unfollowDesc": "You can unfollow from the My Artists page."
 		},
 		"dashboard": {
-			"title": "Reading the Timetable",
+			"lanesSectionTitle": "Reading the Stage Lanes",
 			"description": "Your followed artists' lives are shown by distance.",
 			"homeLabel": "HOME",
 			"homeDesc": "Lives in your home area",
@@ -315,16 +310,18 @@
 			"nearDesc": "Lives within reach",
 			"awayLabel": "AWAY",
 			"awayDesc": "Lives anywhere",
+			"detailsSectionTitle": "Viewing Concert Details",
 			"cardTip": "Tap a card to see concert details"
 		},
 		"myArtists": {
-			"title": "About Hype Levels",
-			"description": "Hype level controls how far away you get notified. Tap a dot to change it.",
+			"hypeSectionTitle": "About Hype",
+			"description": "Hype controls how far away you get notified. Tap the slider to change it.",
 			"watchDesc": "No notifications",
-			"homeDesc": "Notify for home area lives",
-			"nearbyDesc": "Notify for nearby lives too",
-			"awayDesc": "Notify for all lives nationwide",
-			"tip": "Start by setting artists you're curious about to Home — you'll get notified when they play nearby.",
+			"homeDesc": "Notify for home-area concerts",
+			"nearbyDesc": "Notify for nearby concerts too",
+			"awayDesc": "Notify for every concert",
+			"tip": "Set artists you'd travel for to Away to never miss them!",
+			"unfollowSectionTitle": "Unfollowing",
 			"longPressTip": "Long-press an artist row to see the unfollow confirmation."
 		}
 	}

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -4,15 +4,6 @@
 		"createAccount": "アカウント作成"
 	},
 	"entity": {
-		"hype": {
-			"label": "Stage",
-			"values": {
-				"watch": "観測",
-				"home": "地元",
-				"nearby": "近郊",
-				"away": "全国"
-			}
-		},
 		"concert": {
 			"label": "ライブ"
 		},
@@ -209,7 +200,7 @@
 		"unfollow": "フォロー解除",
 		"unfollowArtist": "{{name}}のフォローを解除",
 		"failedUnfollow": "{{name}}のフォロー解除に失敗しました",
-		"failedHype": "Stageの更新に失敗しました",
+		"failedHype": "Hypeの更新に失敗しました",
 		"unfollowSheet": {
 			"confirm": "フォロー解除",
 			"cancel": "キャンセル",
@@ -300,14 +291,18 @@
 		"close": "閉じる"
 	},
 	"pageHelp": {
+		"sheetAriaLabel": "ページのヘルプ",
+		"triggerAriaLabel": "ヘルプを表示",
 		"discovery": {
-			"title": "アーティストをフォローしよう",
-			"description": "バブルをタップしてフォロー。フォロー解除は My Artists ページから。",
+			"findingSectionTitle": "アーティストの探し方",
+			"description": "バブルをタップしてフォローしましょう。",
 			"genreTip": "ジャンルタブで絞り込めます",
-			"searchTip": "検索バーで名前からも探せます"
+			"searchTip": "検索バーで名前からも探せます",
+			"unfollowSectionTitle": "フォロー解除",
+			"unfollowDesc": "フォロー解除は My Artists ページから行えます。"
 		},
 		"dashboard": {
-			"title": "タイムテーブルの見方",
+			"lanesSectionTitle": "ステージレーンの読み方",
 			"description": "フォローしたアーティストのライブが距離ごとに表示されます。",
 			"homeLabel": "HOME",
 			"homeDesc": "居住エリアのライブ",
@@ -315,16 +310,18 @@
 			"nearDesc": "少し足を伸ばせば行けるライブ",
 			"awayLabel": "AWAY",
 			"awayDesc": "遠征ライブ",
+			"detailsSectionTitle": "ライブ詳細を見る",
 			"cardTip": "カードをタップすると詳細が見られます"
 		},
 		"myArtists": {
-			"title": "Stage について",
-			"description": "Stage で通知の範囲が変わります。ドットをタップして切り替えられます。",
+			"hypeSectionTitle": "Hype（熱量） について",
+			"description": "Hype（熱量） で通知の範囲が変わります。スライダーをタップして切り替えられます。",
 			"watchDesc": "通知なし",
 			"homeDesc": "居住エリアのライブを通知",
 			"nearbyDesc": "近くのライブも通知",
-			"awayDesc": "全国のライブを通知",
-			"tip": "まずは気になるアーティストを Home に設定してみましょう。近くでライブがあればお知らせします。",
+			"awayDesc": "全てのライブを通知",
+			"tip": "遠征してでも見たいアーティストは Away に設定してみましょう！",
+			"unfollowSectionTitle": "フォロー解除",
 			"longPressTip": "アーティスト行を長押しするとフォロー解除の確認が表示されます。"
 		}
 	}

--- a/src/routes/dashboard/dashboard-route.html
+++ b/src/routes/dashboard/dashboard-route.html
@@ -36,12 +36,11 @@
 <!-- Bottom sheet for event details (top-layer dialog) -->
 <event-detail-sheet component.ref="detailSheet"></event-detail-sheet>
 
-<!-- Signup prompt banner for unauthenticated users -->
+<!-- Signup prompt banner for unauthenticated users (non-dismissable) -->
 <signup-prompt-banner
   visible.bind="showSignupBanner && !isAuthenticated"
   message.bind="i18n.tr('myArtists.signupBanner.message')"
-  signup-requested.trigger="onSignupRequested()"
-  banner-dismissed.trigger="onBannerDismissed()">
+  signup-requested.trigger="onSignupRequested()">
 </signup-prompt-banner>
 
 <!-- Home area selector bottom sheet -->

--- a/src/routes/dashboard/dashboard-route.ts
+++ b/src/routes/dashboard/dashboard-route.ts
@@ -215,10 +215,6 @@ export class DashboardRoute {
 		this.authService.signUp()
 	}
 
-	public onBannerDismissed(): void {
-		this.showSignupBanner = false
-	}
-
 	public detaching(): void {
 		this.abortController?.abort()
 		this.abortController = null

--- a/src/routes/my-artists/my-artists-route.html
+++ b/src/routes/my-artists/my-artists-route.html
@@ -34,10 +34,12 @@
       <thead>
         <tr class="artists-thead-row">
           <th scope="col" class="[ visually-hidden ]" t="myArtists.table.artistCol"></th>
-          <th scope="col" class="hype-col-header">👀<small t="entity.hype.values.watch"></small></th>
-          <th scope="col" class="hype-col-header">🔥<small t="entity.hype.values.home"></small></th>
-          <th scope="col" class="hype-col-header">🔥🔥<small t="entity.hype.values.nearby"></small></th>
-          <th scope="col" class="hype-col-header">🔥🔥🔥<small t="entity.hype.values.away"></small></th>
+          <!-- Hype tier labels are Layer B brand expressions (per brand-vocabulary spec):
+               rendered invariantly in English in every locale, not via i18n. -->
+          <th scope="col" class="hype-col-header">👀<small>Watch</small></th>
+          <th scope="col" class="hype-col-header">🔥<small>Home</small></th>
+          <th scope="col" class="hype-col-header">🔥🔥<small>Nearby</small></th>
+          <th scope="col" class="hype-col-header">🔥🔥🔥<small>Away</small></th>
           <th scope="col" class="[ visually-hidden ]" t="myArtists.table.unfollowCol"></th>
         </tr>
       </thead>
@@ -96,10 +98,11 @@
   ></artist-unfollow-sheet>
 </main>
 
-<!-- Signup prompt banner -->
+<!-- Signup prompt banner — non-dismissable; visible whenever the user is a guest.
+     Per signup-prompt-banner capability spec, the dismiss button is removed
+     entirely and visibility is host-controlled by `showSignupBanner`. -->
 <signup-prompt-banner
   visible.bind="showSignupBanner && !isAuthenticated"
   message.bind="i18n.tr('myArtists.signupBanner.message')"
-  signup-requested.trigger="onSignupRequested()"
-  banner-dismissed.trigger="onBannerDismissed()">
+  signup-requested.trigger="onSignupRequested()">
 </signup-prompt-banner>

--- a/src/routes/my-artists/my-artists-route.ts
+++ b/src/routes/my-artists/my-artists-route.ts
@@ -95,7 +95,10 @@ export class MyArtistsRoute {
 			this.isLoading = false
 		}
 
-		if (!this.isAuthenticated && this.onboarding.isCompleted) {
+		// Signup banner visible for any guest user on this page (during AND after
+		// onboarding) — per signup-prompt-banner capability "Banner appears for
+		// guest user during onboarding" / "after onboarding" scenarios.
+		if (!this.isAuthenticated) {
 			this.showSignupBanner = true
 		}
 	}
@@ -254,10 +257,10 @@ export class MyArtistsRoute {
 			this.prevHypes.set(artistId, hype)
 			this.onboarding.deactivateSpotlight()
 			this.onboarding.setStep(OnboardingStep.COMPLETED)
-			// Persist for guest users — merged on signup
+			// Persist for guest users — merged on signup. The signup banner is
+			// already visible (set in loading() for any guest); no toggle here.
 			if (!this.isAuthenticated) {
 				this.guest.setHype(artistId, hype)
-				this.showSignupBanner = true
 			}
 			return
 		}
@@ -268,11 +271,11 @@ export class MyArtistsRoute {
 			return
 		}
 
-		// Unauthenticated outside onboarding: persist to guest storage, show signup banner
+		// Unauthenticated outside onboarding: persist to guest storage. The signup
+		// banner is already visible from loading(); no host-side toggle needed.
 		if (!this.isAuthenticated) {
 			this.prevHypes.set(artistId, hype)
 			this.guest.setHype(artistId, hype)
-			this.showSignupBanner = true
 			return
 		}
 
@@ -310,10 +313,6 @@ export class MyArtistsRoute {
 
 	public onSignupRequested(): void {
 		this.authService.signUp()
-	}
-
-	public onBannerDismissed(): void {
-		this.showSignupBanner = false
 	}
 
 	public hypeIcon(artist: MyArtist): string {

--- a/src/routes/welcome/welcome-route.ts
+++ b/src/routes/welcome/welcome-route.ts
@@ -67,7 +67,13 @@ export class WelcomeRoute implements IRouteViewModel {
 				this.abortController.signal,
 			)
 
-			// Build artist map from configured names (preview has no followed artists)
+			// Build artist map from configured names (preview has no followed artists).
+			// Preview-only synthetic hype. Intentionally NOT DEFAULT_HYPE — `watch`
+			// makes preview concerts render as "unmatched" (faded-poster treatment)
+			// per the passion-level hype-lane match rule, which keeps the welcome
+			// page softer than a real fan's dashboard. Changing this to DEFAULT_HYPE
+			// would shift the visual treatment to "matched" (festival-stage) and
+			// alter the welcome page's intended aesthetic.
 			const artistMap = new Map<string, { artist: Artist; hype: Hype }>()
 			for (const [id, name] of getPreviewArtistNameMap()) {
 				artistMap.set(id, {

--- a/src/services/follow-service-client.spec.ts
+++ b/src/services/follow-service-client.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Artist } from '../entities/artist'
-import type { FollowedArtist } from '../entities/follow'
+import { DEFAULT_HYPE, type FollowedArtist } from '../entities/follow'
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
@@ -45,7 +45,7 @@ function makeArtist(id: string, name: string): Artist {
 }
 
 function makeFollowedArtist(id: string, name: string): FollowedArtist {
-	return { artist: makeArtist(id, name), hype: 'watch' as const }
+	return { artist: makeArtist(id, name), hype: DEFAULT_HYPE }
 }
 
 describe('FollowServiceClient', () => {

--- a/test/components/signup-prompt-banner.spec.ts
+++ b/test/components/signup-prompt-banner.spec.ts
@@ -62,4 +62,22 @@ describe('SignupPromptBanner', () => {
 			expect(event.bubbles).toBe(true)
 		})
 	})
+
+	// Per signup-prompt-banner capability "No dismiss control" scenario, the
+	// banner offers no user affordance to dismiss. The dismiss API has been
+	// removed from the component contract.
+	describe('no dismiss API', () => {
+		it('should not expose an onDismiss handler', () => {
+			expect(
+				(sut as unknown as { onDismiss?: () => void }).onDismiss,
+			).toBeUndefined()
+		})
+
+		it('should never emit banner-dismissed events', () => {
+			const handler = vi.fn()
+			hostElement.addEventListener('banner-dismissed', handler)
+			sut.onSignup()
+			expect(handler).not.toHaveBeenCalled()
+		})
+	})
 })


### PR DESCRIPTION
## Summary

Frontend half of the cross-repo change tracked in liverty-music/specification#505. Pairs with the already-merged backend migration (liverty-music/backend#302).

- **Default Hype = Nearby.** `DEFAULT_HYPE = 'nearby'` in `entities/follow.ts` — now consistent with the backend column DEFAULT deployed in #302.
- **Brand-vocabulary graduation.** Hype concept label + 4 tier values (`Watch / Home / Nearby / Away`) move from Layer A (entity-grounded, locale-translatable) to Layer B (invariant English brand expressions). Remove the `entity.hype.*` subtree from both locales; drop `hype` from the brand-vocabulary lint script's curated stems.
- **Help-sheet multi-section restructure.** All three sheets (Discovery / Dashboard / My Artists) become multi-section with `<h3 class="help-section-title">` per sub-section; drop the per-sheet `<h2 class="page-help-title">`. The bottom-sheet's `aria-label` (now locale-driven) carries the sheet's accessible name.
- **3-col hype tier grid.** Replace the my-artists help-sheet table with a `<dl class="help-hype-grid">` using `grid-template-columns: auto auto 1fr`. Icon, invariant English label, and notification-scope description align across all four rows.
- **Signup banner persistence.** Remove the dismiss `X` button entirely. Banner shows for any guest on My Artists (during AND after onboarding). Drop `banner-dismissed` event from the component and the corresponding `onBannerDismissed` handlers in `my-artists-route.ts` + `dashboard-route.ts`.
- **EN copy de-Japanism.** `pageHelp.myArtists.{homeDesc, nearbyDesc}`: "lives" → "concerts", matching the already-corrected `awayDesc` (literal translation of ライブ flagged in spec review).
- **My Artists table column headers.** Replace `<small t="entity.hype.values.*">` with literal `<small>Watch|Home|Nearby|Away</small>`.

## Why

See the design discussion in liverty-music/specification#505. Three smaller issues addressed in one bundle:

1. **Notification opt-in friction.** The previous `watch` default made push notifications a discovery puzzle — guests could finish onboarding without ever encountering the value proposition. Flipping to `nearby` makes following an artist an immediate notification commitment. The non-dismissable signup banner makes the signup prerequisite visible without being deceptive.
2. **Vocabulary drift.** "Stage" appeared nowhere else in the UI; the tier labels were translated to JA-only forms (`観測 / 地元 / 近郊 / 全国`) in some surfaces and rendered as English in others (timetable lanes, the help sheet itself). Graduating to invariant English Layer B brand expressions eliminates the drift.
3. **Help-sheet ergonomics.** Title + description + 2-col tier table + tip + long-press tip were all in one visual lane on My Artists, mixing two unrelated topics. The restructure separates hype mechanics from unfollow gestures and improves column alignment.

## Cross-repo coordination

Third and final PR of the bundle:

1. ✅ liverty-music/backend#302 — merged at 87fdd23. Atlas migration `ALTER COLUMN hype SET DEFAULT 'nearby'` deployed; `entity.DefaultHype = HypeNearby` const introduced; `follow_repo.go` INSERT passes `entity.DefaultHype` explicitly so the Go domain is the source-of-truth on the write path. Deploy Backend workflow on main succeeded.
2. ✅ liverty-music/specification#506 — merged at 41ae0ac. OpenSpec change `refine-hype-and-help-sheets` proposal + design + 5 spec deltas (brand-vocabulary, my-artists, onboarding-page-help, signup-prompt-banner, passion-level) all on main.
3. 👉 This PR (frontend) — opens after backend deploys to dev. CI runs against the new backend defaults; merge once green + reviewed.
4. (Follow-up) Specification archive PR — moves the change directory to `openspec/changes/archive/` and syncs delta → main specs via `openspec-sync-specs`.

## Test plan

- [x] `make check` passes: 100 test files, 1068 tests, 7 script tests, brand-vocabulary lint OK
- [x] `npm run build` succeeds: 89 modules transformed, PWA service worker generated, no missing-translation warnings
- [ ] Smoke test on dev (Phase 7 in spec tasks.md):
  - Guest signup flow → arrive at My Artists during onboarding step 3
  - Help sheet auto-opens, "Hype（熱量） について" as first section title, 3-col grid renders with aligned columns
  - Signup banner visible with NO X button
  - Tap a hype dot → banner persists (no dismiss)
  - Newly-followed artist shows Nearby (3rd dot active) — verifies backend deploy
  - Open Dashboard help sheet via `?` → 2 sub-sections render with `help-section-title` headings
  - Open Discovery help sheet via `?` → 2 sub-sections render
  - Switch language to EN → help sheets still show invariant `Hype / Watch / Home / Nearby / Away`
- [ ] CI / Playwright passes

## Rollback

Each commit is independently revertable. The behavior-affecting changes (`DEFAULT_HYPE = 'nearby'`, signup-banner persistence) are isolated to specific files; reverting just those without rolling the backend back would temporarily leave the frontend asking for `watch` while the backend writes `nearby` — benign on the data side (existing rows preserved per migration design).

Refs liverty-music/specification#505