### PR TITLE
feat!: consume Series-hierarchy Concert proto from v0.41.0 BSR

### DIFF
--- a/e2e/functional/artist-filter-bar.spec.ts
+++ b/e2e/functional/artist-filter-bar.spec.ts
@@ -55,7 +55,7 @@ async function mockRpcRoutes(page: Page): Promise<void> {
 									series: {
 										id: { value: 's-1' },
 										title: { value: 'Zepp Live' },
-										},
+									},
 									localDate: {
 										value: {
 											year: tomorrow.getFullYear(),

--- a/e2e/functional/artist-filter-bar.spec.ts
+++ b/e2e/functional/artist-filter-bar.spec.ts
@@ -45,8 +45,17 @@ async function mockRpcRoutes(page: Page): Promise<void> {
 							home: [
 								{
 									id: { value: 'c-1' },
-									artistId: { value: 'artist-1' },
-									title: { value: 'Zepp Live' },
+									performers: [
+										{
+											id: { value: 'artist-1' },
+											name: { value: 'YOASOBI' },
+											mbid: { value: '' },
+										},
+									],
+									series: {
+										id: { value: 's-1' },
+										title: { value: 'Zepp Live' },
+										},
 									localDate: {
 										value: {
 											year: tomorrow.getFullYear(),

--- a/e2e/functional/artist-image-ui.spec.ts
+++ b/e2e/functional/artist-image-ui.spec.ts
@@ -96,7 +96,7 @@ function listByFollowerResponse() {
 						series: {
 							id: { value: 's-2' },
 							title: { value: 'Vaundy Tour 2026' },
-							},
+						},
 						localDate: {
 							value: {
 								year: tomorrow.getFullYear(),

--- a/e2e/functional/artist-image-ui.spec.ts
+++ b/e2e/functional/artist-image-ui.spec.ts
@@ -86,8 +86,17 @@ function listByFollowerResponse() {
 				home: [
 					{
 						id: { value: 'c-2' },
-						artistId: { value: 'artist-2' },
-						title: { value: 'Vaundy Tour 2026' },
+						performers: [
+							{
+								id: { value: 'artist-2' },
+								name: { value: 'Vaundy' },
+								mbid: { value: '' },
+							},
+						],
+						series: {
+							id: { value: 's-2' },
+							title: { value: 'Vaundy Tour 2026' },
+							},
 						localDate: {
 							value: {
 								year: tomorrow.getFullYear(),
@@ -115,8 +124,18 @@ function listByFollowerResponse() {
 				away: [
 					{
 						id: { value: 'c-1' },
-						artistId: { value: 'artist-1' },
-						title: { value: 'YOASOBI Live 2026' },
+						performers: [
+							{
+								id: { value: 'artist-1' },
+								name: { value: 'YOASOBI' },
+								mbid: { value: '' },
+							},
+						],
+						series: {
+							id: { value: 's-1' },
+							title: { value: 'YOASOBI Live 2026' },
+							sourceUrl: { value: 'https://example.com/yoasobi' },
+						},
 						localDate: {
 							value: {
 								year: tomorrow.getFullYear(),
@@ -136,9 +155,6 @@ function listByFollowerResponse() {
 						venue: {
 							name: { value: 'Zepp DiverCity' },
 							adminArea: { value: 'JP-13' },
-						},
-						sourceUrl: {
-							value: 'https://example.com/yoasobi',
 						},
 					},
 				],

--- a/e2e/functional/beam-verify.spec.ts
+++ b/e2e/functional/beam-verify.spec.ts
@@ -26,7 +26,7 @@ async function mockRpc(page: Page, lane: 'home' | 'nearby' | 'away'): Promise<vo
 					series: {
 						id: { value: 's-1' },
 						title: { value: 'Test Live' },
-						},
+					},
 					localDate: {
 						value: {
 							year: tomorrow.getFullYear(),

--- a/e2e/functional/beam-verify.spec.ts
+++ b/e2e/functional/beam-verify.spec.ts
@@ -16,8 +16,17 @@ async function mockRpc(page: Page, lane: 'home' | 'nearby' | 'away'): Promise<vo
 			group[lane] = [
 				{
 					id: { value: 'c-1' },
-					artistId: { value: 'artist-1' },
-					title: { value: 'Test Live' },
+					performers: [
+						{
+							id: { value: 'artist-1' },
+							name: { value: 'YOASOBI' },
+							mbid: { value: '' },
+						},
+					],
+					series: {
+						id: { value: 's-1' },
+						title: { value: 'Test Live' },
+						},
 					localDate: {
 						value: {
 							year: tomorrow.getFullYear(),

--- a/e2e/functional/dashboard-lane-classification.spec.ts
+++ b/e2e/functional/dashboard-lane-classification.spec.ts
@@ -26,8 +26,17 @@ function concertListPayload() {
 		concerts: [
 			{
 				id: { value: 'c-1' },
-				artistId: { value: 'artist-1' },
-				title: { value: 'Zepp DiverCity Live' },
+				performers: [
+					{
+						id: { value: 'artist-1' },
+						name: { value: 'YOASOBI' },
+						mbid: { value: '' },
+					},
+				],
+				series: {
+					id: { value: 's-1' },
+					title: { value: 'Zepp DiverCity Live' },
+					},
 				localDate: {
 					value: {
 						year: tomorrow.getFullYear(),

--- a/e2e/functional/dashboard-lane-classification.spec.ts
+++ b/e2e/functional/dashboard-lane-classification.spec.ts
@@ -36,7 +36,7 @@ function concertListPayload() {
 				series: {
 					id: { value: 's-1' },
 					title: { value: 'Zepp DiverCity Live' },
-					},
+				},
 				localDate: {
 					value: {
 						year: tomorrow.getFullYear(),

--- a/e2e/functional/detail-sheet-dismiss.spec.ts
+++ b/e2e/functional/detail-sheet-dismiss.spec.ts
@@ -42,14 +42,23 @@ async function mockRpcRoutes(page: Page): Promise<void> {
 							home: [
 								{
 									id: { value: 'c-1' },
-									artistId: { value: 'a-1' },
-									title: { value: 'Test Concert' },
+									performers: [
+										{
+											id: { value: 'a-1' },
+											name: { value: 'Artist 1' },
+											mbid: { value: '' },
+										},
+									],
+									series: {
+										id: { value: 's-1' },
+										title: { value: 'Test Concert' },
+										sourceUrl: { value: 'https://example.com' },
+									},
 									localDate: { value: tomorrowDate },
 									venue: {
 										name: { value: 'Test Venue' },
 										adminArea: { value: 'JP-13' },
 									},
-									sourceUrl: { value: 'https://example.com' },
 								},
 							],
 							nearby: [],
@@ -73,14 +82,23 @@ async function mockRpcRoutes(page: Page): Promise<void> {
 							away: [
 								{
 									id: { value: 'c-1' },
-									artistId: { value: 'a-1' },
-									title: { value: 'Test Concert' },
+									performers: [
+										{
+											id: { value: 'a-1' },
+											name: { value: 'Artist 1' },
+											mbid: { value: '' },
+										},
+									],
+									series: {
+										id: { value: 's-1' },
+										title: { value: 'Test Concert' },
+										sourceUrl: { value: 'https://example.com' },
+									},
 									localDate: { value: tomorrowDate },
 									venue: {
 										name: { value: 'Test Venue' },
 										adminArea: { value: 'JP-13' },
 									},
-									sourceUrl: { value: 'https://example.com' },
 								},
 							],
 						},
@@ -97,14 +115,23 @@ async function mockRpcRoutes(page: Page): Promise<void> {
 					concerts: [
 						{
 							id: { value: 'c-1' },
-							artistId: { value: 'a-1' },
-							title: { value: 'Test Concert' },
+							performers: [
+								{
+									id: { value: 'a-1' },
+									name: { value: 'Artist 1' },
+									mbid: { value: '' },
+								},
+							],
+							series: {
+								id: { value: 's-1' },
+								title: { value: 'Test Concert' },
+								sourceUrl: { value: 'https://example.com' },
+							},
 							localDate: { value: tomorrowDate },
 							venue: {
 								name: { value: 'Test Venue' },
 								adminArea: { value: 'JP-13' },
 							},
-							sourceUrl: { value: 'https://example.com' },
 						},
 					],
 				}),

--- a/e2e/functional/onboarding-flow.spec.ts
+++ b/e2e/functional/onboarding-flow.spec.ts
@@ -98,8 +98,22 @@ async function mockRpcRoutes(page: Page): Promise<void> {
 		}
 
 		if (url.includes('ListWithProximity')) {
-			// Return concerts for 5+ artists to satisfy PREVIEW_MIN_ARTISTS_WITH_CONCERTS
-			const artists = ['a1', 'a2', 'a3', 'a4', 'a5', 'a6']
+			// Return concerts for 6 preview artists to satisfy
+			// PREVIEW_MIN_ARTISTS_WITH_CONCERTS (=5). Performer IDs MUST
+			// match `config.json` `previewArtistIds` — otherwise
+			// concert-service's `toDateGroups` performer-resolution loop
+			// won't find them in the artistMap (built from preview UUIDs),
+			// produces `resolved=0`, drops the group, leaves `dateGroups`
+			// empty, and the welcome page falls back to the inline-CTA
+			// path (no `.welcome-scroll-cta` element).
+			const artists = [
+				'019c8655-7a05-71ef-82b4-a4ac2494e29f',
+				'019c8655-7a05-721d-b0a8-4c11724d5c90',
+				'019c8655-7a05-71e9-9af5-e1cd4fbfd367',
+				'019c899e-baff-7ecd-8af2-e8dc819e29e4',
+				'019c8655-7a05-71f5-acd4-46157dcb0bec',
+				'019c8655-7a05-722a-bdae-a89596378f90',
+			]
 			return route.fulfill({
 				status: 200,
 				contentType: 'application/json',
@@ -114,20 +128,20 @@ async function mockRpcRoutes(page: Page): Promise<void> {
 								performers: [
 									{
 										id: { value: aid },
-										name: { value: aid },
+										name: { value: `Artist ${i + 1}` },
 										mbid: { value: '' },
 									},
 								],
 								series: {
 									id: { value: `s-${aid}` },
-									title: { value: `Concert ${aid}` },
+									title: { value: `Concert ${i + 1}` },
 									sourceUrl: { value: '' },
 								},
 								localDate: {
 									value: { year: 2026, month: 6, day: 15 + i },
 								},
 								venue: {
-									name: { value: `Venue ${aid}` },
+									name: { value: `Venue ${i + 1}` },
 									adminArea: { value: 'JP-13' },
 								},
 							},

--- a/e2e/functional/onboarding-flow.spec.ts
+++ b/e2e/functional/onboarding-flow.spec.ts
@@ -79,7 +79,17 @@ async function mockRpcRoutes(page: Page): Promise<void> {
 					concerts: [
 						{
 							id: { value: 'c-1' },
-							title: { value: 'Test Concert' },
+							performers: [
+								{
+									id: { value: 'a-1' },
+									name: { value: 'Test Artist' },
+									mbid: { value: '' },
+								},
+							],
+							series: {
+								id: { value: 's-1' },
+								title: { value: 'Test Concert' },
+							},
 							localDate: { value: { year: 2026, month: 6, day: 15 } },
 						},
 					],
@@ -138,7 +148,17 @@ async function mockRpcRoutes(page: Page): Promise<void> {
 							away: [
 								{
 									id: { value: 'c-1' },
-									title: { value: 'Test Concert' },
+									performers: [
+										{
+											id: { value: 'a-1' },
+											name: { value: 'Test Artist' },
+											mbid: { value: '' },
+										},
+									],
+									series: {
+										id: { value: 's-1' },
+										title: { value: 'Test Concert' },
+									},
 									localDate: { value: { year: 2026, month: 6, day: 15 } },
 								},
 							],
@@ -159,7 +179,17 @@ async function mockRpcRoutes(page: Page): Promise<void> {
 					concerts: [
 						{
 							id: { value: 'c-1' },
-							title: { value: 'Test Concert' },
+							performers: [
+								{
+									id: { value: 'a-1' },
+									name: { value: 'Test Artist' },
+									mbid: { value: '' },
+								},
+							],
+							series: {
+								id: { value: 's-1' },
+								title: { value: 'Test Concert' },
+							},
 							localDate: { value: { year: 2026, month: 6, day: 15 } },
 						},
 					],

--- a/e2e/functional/onboarding-flow.spec.ts
+++ b/e2e/functional/onboarding-flow.spec.ts
@@ -101,8 +101,18 @@ async function mockRpcRoutes(page: Page): Promise<void> {
 						away: [
 							{
 								id: { value: `c-${aid}` },
-								artistId: { value: aid },
-								title: { value: `Concert ${aid}` },
+								performers: [
+									{
+										id: { value: aid },
+										name: { value: aid },
+										mbid: { value: '' },
+									},
+								],
+								series: {
+									id: { value: `s-${aid}` },
+									title: { value: `Concert ${aid}` },
+									sourceUrl: { value: '' },
+								},
 								localDate: {
 									value: { year: 2026, month: 6, day: 15 + i },
 								},

--- a/e2e/functional/snack-bar.spec.ts
+++ b/e2e/functional/snack-bar.spec.ts
@@ -59,7 +59,17 @@ async function mockRpcRoutes(page: Page): Promise<void> {
 							away: [
 								{
 									id: { value: 'c-1' },
-									title: { value: 'Test Concert' },
+									performers: [
+										{
+											id: { value: 'a-1' },
+											name: { value: 'Test Artist' },
+											mbid: { value: '' },
+										},
+									],
+									series: {
+										id: { value: 's-1' },
+										title: { value: 'Test Concert' },
+									},
 									localDate: {
 										value: { year: 2026, month: 3, day: 15 },
 									},

--- a/e2e/visual/dashboard.visual.spec.ts
+++ b/e2e/visual/dashboard.visual.spec.ts
@@ -60,7 +60,18 @@ function concertListResponse() {
 
 		const concert = {
 			id: { value: `c${i}` },
-			artistId: { value: `artist-${(i % 3) + 1}` },
+			performers: [
+				{
+					id: { value: `artist-${(i % 3) + 1}` },
+					name: { value: `Artist ${(i % 3) + 1}` },
+					mbid: { value: '' },
+				},
+			],
+			series: {
+				id: { value: `s${i}` },
+				title: { value: `${venues[i % venues.length]} Live` },
+				sourceUrl: { value: 'https://example.com' },
+			},
 			localDate: {
 				value: {
 					year: date.getFullYear(),
@@ -73,8 +84,6 @@ function concertListResponse() {
 				name: { value: venues[i % venues.length] },
 				adminArea: { value: areas[i % areas.length] },
 			},
-			title: { value: `${venues[i % venues.length]} Live` },
-			sourceUrl: { value: 'https://example.com' },
 		}
 
 		if (!groupMap.has(dateKey)) {

--- a/e2e/visual/ticket-journey.visual.spec.ts
+++ b/e2e/visual/ticket-journey.visual.spec.ts
@@ -20,7 +20,18 @@ function concertListResponse() {
 
 		const concert = {
 			id: { value: `c${i}` },
-			artistId: { value: `artist-${(i % 2) + 1}` },
+			performers: [
+				{
+					id: { value: `artist-${(i % 2) + 1}` },
+					name: { value: `Artist ${(i % 2) + 1}` },
+					mbid: { value: '' },
+				},
+			],
+			series: {
+				id: { value: `s${i}` },
+				title: { value: 'Zepp Live' },
+				sourceUrl: { value: 'https://example.com' },
+			},
 			localDate: {
 				value: {
 					year: date.getFullYear(),
@@ -33,8 +44,6 @@ function concertListResponse() {
 				name: { value: 'Zepp DiverCity' },
 				adminArea: { value: 'JP-13' },
 			},
-			title: { value: 'Zepp Live' },
-			sourceUrl: { value: 'https://example.com' },
 		}
 
 		if (!groupMap.has(dateKey)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
 			"dependencies": {
 				"@aurelia/i18n": "^2.0.0-rc.1",
 				"@aurelia/router": "^2.0.0-rc.1",
-				"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260521162614-6bbaa757b536.1",
-				"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260521162614-6bbaa757b536.2",
+				"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260524050818-e7f694dd726b.1",
+				"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260524050818-e7f694dd726b.2",
 				"@bufbuild/protobuf": "^1.10.1",
 				"@connectrpc/connect": "^1.7.0",
 				"@connectrpc/connect-web": "^1.7.0",
@@ -2162,8 +2162,8 @@
 			}
 		},
 		"node_modules/@buf/liverty-music_schema.bufbuild_es": {
-			"version": "1.10.0-20260521162614-6bbaa757b536.1",
-			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.bufbuild_es/-/liverty-music_schema.bufbuild_es-1.10.0-20260521162614-6bbaa757b536.1.tgz",
+			"version": "1.10.0-20260524050818-e7f694dd726b.1",
+			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.bufbuild_es/-/liverty-music_schema.bufbuild_es-1.10.0-20260524050818-e7f694dd726b.1.tgz",
 			"dependencies": {
 				"@buf/bufbuild_protovalidate.bufbuild_es": "1.10.0-20250717185734-6c6e0d3c608e.1",
 				"@buf/googleapis_googleapis.bufbuild_es": "1.10.0-20250411203938-61b203b9a916.1"
@@ -2173,12 +2173,12 @@
 			}
 		},
 		"node_modules/@buf/liverty-music_schema.connectrpc_es": {
-			"version": "1.6.1-20260521162614-6bbaa757b536.2",
-			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.connectrpc_es/-/liverty-music_schema.connectrpc_es-1.6.1-20260521162614-6bbaa757b536.2.tgz",
+			"version": "1.6.1-20260524050818-e7f694dd726b.2",
+			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.connectrpc_es/-/liverty-music_schema.connectrpc_es-1.6.1-20260524050818-e7f694dd726b.2.tgz",
 			"dependencies": {
 				"@buf/bufbuild_protovalidate.connectrpc_es": "1.6.1-20250717185734-6c6e0d3c608e.2",
 				"@buf/googleapis_googleapis.connectrpc_es": "1.6.1-20250411203938-61b203b9a916.2",
-				"@buf/liverty-music_schema.bufbuild_es": "1.10.0-20260521162614-6bbaa757b536.1"
+				"@buf/liverty-music_schema.bufbuild_es": "1.10.0-20260524050818-e7f694dd726b.1"
 			},
 			"peerDependencies": {
 				"@connectrpc/connect": "^1.6.1"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
 	"dependencies": {
 		"@aurelia/i18n": "^2.0.0-rc.1",
 		"@aurelia/router": "^2.0.0-rc.1",
-		"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260521162614-6bbaa757b536.1",
-		"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260521162614-6bbaa757b536.2",
+		"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260524050818-e7f694dd726b.1",
+		"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260524050818-e7f694dd726b.2",
 		"@bufbuild/protobuf": "^1.10.1",
 		"@connectrpc/connect": "^1.7.0",
 		"@connectrpc/connect-web": "^1.7.0",

--- a/src/adapter/rpc/mapper/concert-mapper.ts
+++ b/src/adapter/rpc/mapper/concert-mapper.ts
@@ -32,15 +32,17 @@ export function concertFrom(
 	// repeated field. The dashboard entity is still single-artist-flat, so the
 	// caller resolves the "primary" artist for this row (e.g. the followed
 	// performer for a follower-based listing, which may not be the headliner)
-	// and we pull its ID from the resolved Artist object when available so
-	// artistId / artistName / artist stay consistent. The performers[0]
-	// (headliner) fallback only fires when the caller could not resolve a
-	// specific artist — typically a code path where the dashboard would render
-	// without artist-specific context anyway.
+	// and we pull its ID from the resolved Artist object. When no artist is
+	// resolved the trio `artistId / artistName / artist` ALL go empty — a
+	// performers[0] (headliner) fallback would leave an artistId pointing at
+	// the headliner while artistName / artist stay blank, so a dashboard
+	// filter on artistId would link to one identity while the visible name
+	// is empty. Symmetric blanks keep downstream consumers internally
+	// consistent.
 	return {
 		id: proto.id?.value ?? '',
 		artistName,
-		artistId: artist?.id ?? proto.performers?.[0]?.id?.value ?? '',
+		artistId: artist?.id ?? '',
 		venueName,
 		locationLabel,
 		adminArea,

--- a/src/adapter/rpc/mapper/concert-mapper.ts
+++ b/src/adapter/rpc/mapper/concert-mapper.ts
@@ -49,6 +49,12 @@ export function concertFrom(
 		date: jsDate,
 		startTime,
 		openTime,
+		// proto.series is guaranteed non-null on Concert by the v0.41.0+ BSR
+		// schema (required field). The `?.` chain is defensive against
+		// proto3's permissive-field-default typing, NOT a fallback for a
+		// legitimately series-less concert — there is no such state. A
+		// blank title here means the schema invariant was violated upstream
+		// and should be investigated rather than silently re-derived.
 		title: proto.series?.title?.value ?? '',
 		sourceUrl: proto.series?.sourceUrl?.value ?? '',
 		hypeLevel,

--- a/src/adapter/rpc/mapper/concert-mapper.ts
+++ b/src/adapter/rpc/mapper/concert-mapper.ts
@@ -27,18 +27,24 @@ export function concertFrom(
 	const adminArea = proto.venue?.adminArea?.value
 	const locationLabel = adminArea ? displayName(adminArea) : ''
 
+	// Concert proto v0.41.0+ moved title and sourceUrl onto the embedded
+	// `series` parent and replaced the singular artistId with a `performers`
+	// repeated field. The dashboard entity is still single-artist-flat, so we
+	// project the first performer (typically the headliner). Multi-performer
+	// concerts (festivals, co-headliners) surface only the lead artist here;
+	// a future enhancement can widen the entity to carry the full lineup.
 	return {
 		id: proto.id?.value ?? '',
 		artistName,
-		artistId: proto.artistId?.value ?? '',
+		artistId: proto.performers?.[0]?.id?.value ?? '',
 		venueName,
 		locationLabel,
 		adminArea,
 		date: jsDate,
 		startTime,
 		openTime,
-		title: proto.title?.value ?? '',
-		sourceUrl: proto.sourceUrl?.value ?? '',
+		title: proto.series?.title?.value ?? '',
+		sourceUrl: proto.series?.sourceUrl?.value ?? '',
 		hypeLevel,
 		matched,
 		artist,

--- a/src/adapter/rpc/mapper/concert-mapper.ts
+++ b/src/adapter/rpc/mapper/concert-mapper.ts
@@ -12,6 +12,15 @@ export function concertFrom(
 ): Concert | null {
 	const localDate = proto.localDate?.value
 	if (!localDate) return null
+	// Reject partially-defaulted proto3 Date messages — same rule as
+	// formatLocalDate in import-ticket-email-route. A field defaulted to 0
+	// (e.g. {year: 2026, month: 0, day: 15}) would silently roll through
+	// `new Date(2026, -1, 15)` to 2025-12-15 and bucket the concert into
+	// the wrong date group one month in the past. Returning null drops
+	// the bad row instead of misplacing it.
+	if (localDate.year === 0 || localDate.month === 0 || localDate.day === 0) {
+		return null
+	}
 
 	const jsDate = new Date(localDate.year, localDate.month - 1, localDate.day)
 

--- a/src/adapter/rpc/mapper/concert-mapper.ts
+++ b/src/adapter/rpc/mapper/concert-mapper.ts
@@ -51,7 +51,15 @@ export function concertFrom(
 	return {
 		id: proto.id?.value ?? '',
 		artistName,
-		artistId: artist?.id ?? '',
+		// `||` (not `??`) so an empty-string artist.id is treated the
+		// same as absent. proto3 string defaults are `''`, so an Artist
+		// whose id field was never populated (provisioning bug or
+		// schema-skew rollout) would otherwise produce artistId: ''
+		// here AND skip the "blank-on-resolve" symmetric-blank invariant
+		// — the dashboard's strip-blank guard would then silently drop
+		// the concert while the artist trio still showed populated
+		// name/artist fields. `||` keeps the trio symmetric.
+		artistId: artist?.id || '',
 		venueName,
 		locationLabel,
 		adminArea,

--- a/src/adapter/rpc/mapper/concert-mapper.ts
+++ b/src/adapter/rpc/mapper/concert-mapper.ts
@@ -29,14 +29,18 @@ export function concertFrom(
 
 	// Concert proto v0.41.0+ moved title and sourceUrl onto the embedded
 	// `series` parent and replaced the singular artistId with a `performers`
-	// repeated field. The dashboard entity is still single-artist-flat, so we
-	// project the first performer (typically the headliner). Multi-performer
-	// concerts (festivals, co-headliners) surface only the lead artist here;
-	// a future enhancement can widen the entity to carry the full lineup.
+	// repeated field. The dashboard entity is still single-artist-flat, so the
+	// caller resolves the "primary" artist for this row (e.g. the followed
+	// performer for a follower-based listing, which may not be the headliner)
+	// and we pull its ID from the resolved Artist object when available so
+	// artistId / artistName / artist stay consistent. The performers[0]
+	// (headliner) fallback only fires when the caller could not resolve a
+	// specific artist — typically a code path where the dashboard would render
+	// without artist-specific context anyway.
 	return {
 		id: proto.id?.value ?? '',
 		artistName,
-		artistId: proto.performers?.[0]?.id?.value ?? '',
+		artistId: artist?.id ?? proto.performers?.[0]?.id?.value ?? '',
 		venueName,
 		locationLabel,
 		adminArea,

--- a/src/routes/dashboard/dashboard-route.ts
+++ b/src/routes/dashboard/dashboard-route.ts
@@ -63,7 +63,25 @@ export class DashboardRoute {
 	}
 
 	public get filteredDateGroups(): DateGroup[] {
-		if (this.filteredArtistIds.length === 0) return this.dateGroups
+		// Always strip blank-artistId concerts before rendering. Post-v0.41.0
+		// `concertFrom` returns `artistId: ''` when no performer resolved
+		// against the user's artistMap (ID-namespace mismatch, schema-skew
+		// rollout window) — those rows have no usable artist context and
+		// would render as ghost cards with empty names. The active-filter
+		// branch below already excludes them naturally (Set.has('') is
+		// false); apply the same rule to the unfiltered branch so the
+		// authenticated dashboard never surfaces ghost cards.
+		const stripBlank = (g: DateGroup): DateGroup => ({
+			...g,
+			home: g.home.filter((c) => c.artistId),
+			nearby: g.nearby.filter((c) => c.artistId),
+			away: g.away.filter((c) => c.artistId),
+		})
+		if (this.filteredArtistIds.length === 0) {
+			return this.dateGroups
+				.map(stripBlank)
+				.filter((g) => g.home.length + g.nearby.length + g.away.length > 0)
+		}
 		const ids = new Set(this.filteredArtistIds)
 		return this.dateGroups
 			.map((g) => ({

--- a/src/routes/import-ticket-email/import-ticket-email-route.html
+++ b/src/routes/import-ticket-email/import-ticket-email-route.html
@@ -33,17 +33,19 @@
       <h2>コンサートを選択</h2>
       <p>関連付けるコンサートを選択してください（複数可）。</p>
       <ul class="concert-list">
-        <li repeat.for="concert of concerts" class="concert-item" if.bind="concert.id?.value && concert.series?.title?.value">
-          <label>
-            <input
-              type="checkbox"
-              checked.bind="selectedEventIds"
-              model.bind="concert.id.value"
-            >
-            <span>${concert.series.title.value}</span>
-            <small>${formatLocalDate(concert.localDate?.value)}</small>
-          </label>
-        </li>
+        <template repeat.for="concert of concerts">
+          <li class="concert-item" if.bind="concert.id?.value && concert.series?.title?.value">
+            <label>
+              <input
+                type="checkbox"
+                checked.bind="selectedEventIds"
+                model.bind="concert.id.value"
+              >
+              <span>${concert.series.title.value}</span>
+              <small>${formatLocalDate(concert.localDate?.value)}</small>
+            </label>
+          </li>
+        </template>
       </ul>
       <p if.bind="!hasDisplayableConcerts">このアーティストのコンサートが見つかりません。</p>
       <button click.trigger="confirmConcerts()" disabled.bind="!hasSelectedConcerts">

--- a/src/routes/import-ticket-email/import-ticket-email-route.html
+++ b/src/routes/import-ticket-email/import-ticket-email-route.html
@@ -40,7 +40,7 @@
               checked.bind="selectedEventIds"
               model.bind="concert.id?.value ?? ''"
             >
-            <span>${concert.title?.value ?? ''}</span>
+            <span>${concert.series?.title?.value ?? ''}</span>
             <small>${concert.localDate?.value}</small>
           </label>
         </li>

--- a/src/routes/import-ticket-email/import-ticket-email-route.html
+++ b/src/routes/import-ticket-email/import-ticket-email-route.html
@@ -41,7 +41,7 @@
               model.bind="concert.id?.value ?? ''"
             >
             <span>${concert.series?.title?.value ?? ''}</span>
-            <small>${concert.localDate?.value}</small>
+            <small>${formatLocalDate(concert.localDate?.value)}</small>
           </label>
         </li>
       </ul>

--- a/src/routes/import-ticket-email/import-ticket-email-route.html
+++ b/src/routes/import-ticket-email/import-ticket-email-route.html
@@ -45,7 +45,7 @@
           </label>
         </li>
       </ul>
-      <p if.bind="concerts.length === 0">このアーティストのコンサートが見つかりません。</p>
+      <p if.bind="!hasDisplayableConcerts">このアーティストのコンサートが見つかりません。</p>
       <button click.trigger="confirmConcerts()" disabled.bind="!hasSelectedConcerts">
         次へ
       </button>

--- a/src/routes/import-ticket-email/import-ticket-email-route.html
+++ b/src/routes/import-ticket-email/import-ticket-email-route.html
@@ -33,14 +33,14 @@
       <h2>コンサートを選択</h2>
       <p>関連付けるコンサートを選択してください（複数可）。</p>
       <ul class="concert-list">
-        <li repeat.for="concert of concerts" class="concert-item" if.bind="concert.id?.value">
+        <li repeat.for="concert of concerts" class="concert-item" if.bind="concert.id?.value && concert.series?.title?.value">
           <label>
             <input
               type="checkbox"
               checked.bind="selectedEventIds"
               model.bind="concert.id.value"
             >
-            <span>${concert.series?.title?.value ?? ''}</span>
+            <span>${concert.series.title.value}</span>
             <small>${formatLocalDate(concert.localDate?.value)}</small>
           </label>
         </li>

--- a/src/routes/import-ticket-email/import-ticket-email-route.html
+++ b/src/routes/import-ticket-email/import-ticket-email-route.html
@@ -33,12 +33,12 @@
       <h2>コンサートを選択</h2>
       <p>関連付けるコンサートを選択してください（複数可）。</p>
       <ul class="concert-list">
-        <li repeat.for="concert of concerts" class="concert-item">
+        <li repeat.for="concert of concerts" class="concert-item" if.bind="concert.id?.value">
           <label>
             <input
               type="checkbox"
               checked.bind="selectedEventIds"
-              model.bind="concert.id?.value ?? ''"
+              model.bind="concert.id.value"
             >
             <span>${concert.series?.title?.value ?? ''}</span>
             <small>${formatLocalDate(concert.localDate?.value)}</small>

--- a/src/routes/import-ticket-email/import-ticket-email-route.ts
+++ b/src/routes/import-ticket-email/import-ticket-email-route.ts
@@ -202,12 +202,13 @@ export class ImportTicketEmailRoute {
 		d: { year: number; month: number; day: number } | undefined,
 	): string {
 		if (!d) return ''
-		// Guard against a proto-default Date message (all three int32 fields
-		// zero) — that's not a real calendar date, it's a never-populated
-		// field marshalled with the proto3 default. Returning '' instead of
-		// '0-00-00' keeps the row's <small> slot blank rather than showing a
-		// nonsense year-zero stamp.
-		if (d.year === 0 && d.month === 0 && d.day === 0) return ''
+		// Guard against a proto-default Date message — `year === 0` is
+		// sufficient because year 0 is never a real concert year, and using
+		// the full all-zero AND-guard would let a partially-populated message
+		// (e.g. year:0, month:3, day:15 from a backend bug) slip through and
+		// render '0-03-15'. Returning '' keeps the row's <small> slot blank
+		// rather than showing a nonsense year-zero stamp.
+		if (d.year === 0) return ''
 		const month = String(d.month).padStart(2, '0')
 		const day = String(d.day).padStart(2, '0')
 		return `${d.year}-${month}-${day}`

--- a/src/routes/import-ticket-email/import-ticket-email-route.ts
+++ b/src/routes/import-ticket-email/import-ticket-email-route.ts
@@ -202,13 +202,13 @@ export class ImportTicketEmailRoute {
 		d: { year: number; month: number; day: number } | undefined,
 	): string {
 		if (!d) return ''
-		// Guard against a proto-default Date message — `year === 0` is
-		// sufficient because year 0 is never a real concert year, and using
-		// the full all-zero AND-guard would let a partially-populated message
-		// (e.g. year:0, month:3, day:15 from a backend bug) slip through and
-		// render '0-03-15'. Returning '' keeps the row's <small> slot blank
-		// rather than showing a nonsense year-zero stamp.
-		if (d.year === 0) return ''
+		// Treat any zero component as "unpopulated". Proto3 leaves missing
+		// scalar fields at their type-zero defaults independently, so a
+		// partially-serialised Date like {year:2025, month:0, day:0} (backend
+		// only set the year) would render as '2025-00-00' in the row's
+		// <small> slot. Symmetric for the year:0 case. Returning '' keeps
+		// the slot blank for any partially-populated Date.
+		if (d.year === 0 || d.month === 0 || d.day === 0) return ''
 		const month = String(d.month).padStart(2, '0')
 		const day = String(d.day).padStart(2, '0')
 		return `${d.year}-${month}-${day}`

--- a/src/routes/import-ticket-email/import-ticket-email-route.ts
+++ b/src/routes/import-ticket-email/import-ticket-email-route.ts
@@ -127,6 +127,17 @@ export class ImportTicketEmailRoute {
 		}
 	}
 
+	// Mirrors the `if.bind="concert.id?.value"` filter on the
+	// <li repeat.for> list: returns true only when at least one concert
+	// will actually render. Used by the empty-state <p>'s guard so the
+	// "no concerts found" message still shows when every returned proto
+	// has a blank id (schema-skew rollout window) — otherwise the user
+	// would see a completely blank list with no explanation because
+	// concerts.length > 0 but every row is hidden.
+	public get hasDisplayableConcerts(): boolean {
+		return this.concerts.some((c) => Boolean(c.id?.value))
+	}
+
 	public get hasSelectedConcerts(): boolean {
 		return this.selectedEventIds.length > 0
 	}

--- a/src/routes/import-ticket-email/import-ticket-email-route.ts
+++ b/src/routes/import-ticket-email/import-ticket-email-route.ts
@@ -128,15 +128,11 @@ export class ImportTicketEmailRoute {
 	}
 
 	// Returns true only when at least one concert is fully renderable —
-	// id-bearing AND with a non-blank series title. The id check
-	// mirrors the `if.bind="concert.id?.value"` per-row filter (a
-	// missing id hides the row entirely); the series.title check covers
-	// the schema-skew case where id is populated but series is absent
-	// or its title.value is blank — the row would render with an empty
-	// <span> and look like a broken UI element while
-	// `concerts.length > 0` kept the "no concerts found" empty-state
-	// suppressed. Used by the empty-state <p>'s guard so the message
-	// surfaces whenever the visible list would be effectively empty.
+	// id-bearing AND with a non-blank series title. EXACTLY mirrors the
+	// per-row `if.bind="concert.id?.value && concert.series?.title?.value"`
+	// filter on the <li repeat.for>, so the empty-state <p> only shows
+	// when zero rows render. If the two predicates ever diverge, both
+	// the broken row AND the "not found" message could appear at once.
 	public get hasDisplayableConcerts(): boolean {
 		return this.concerts.some(
 			(c) => Boolean(c.id?.value) && Boolean(c.series?.title?.value),

--- a/src/routes/import-ticket-email/import-ticket-email-route.ts
+++ b/src/routes/import-ticket-email/import-ticket-email-route.ts
@@ -127,15 +127,20 @@ export class ImportTicketEmailRoute {
 		}
 	}
 
-	// Mirrors the `if.bind="concert.id?.value"` filter on the
-	// <li repeat.for> list: returns true only when at least one concert
-	// will actually render. Used by the empty-state <p>'s guard so the
-	// "no concerts found" message still shows when every returned proto
-	// has a blank id (schema-skew rollout window) — otherwise the user
-	// would see a completely blank list with no explanation because
-	// concerts.length > 0 but every row is hidden.
+	// Returns true only when at least one concert is fully renderable —
+	// id-bearing AND with a non-blank series title. The id check
+	// mirrors the `if.bind="concert.id?.value"` per-row filter (a
+	// missing id hides the row entirely); the series.title check covers
+	// the schema-skew case where id is populated but series is absent
+	// or its title.value is blank — the row would render with an empty
+	// <span> and look like a broken UI element while
+	// `concerts.length > 0` kept the "no concerts found" empty-state
+	// suppressed. Used by the empty-state <p>'s guard so the message
+	// surfaces whenever the visible list would be effectively empty.
 	public get hasDisplayableConcerts(): boolean {
-		return this.concerts.some((c) => Boolean(c.id?.value))
+		return this.concerts.some(
+			(c) => Boolean(c.id?.value) && Boolean(c.series?.title?.value),
+		)
 	}
 
 	public get hasSelectedConcerts(): boolean {

--- a/src/routes/import-ticket-email/import-ticket-email-route.ts
+++ b/src/routes/import-ticket-email/import-ticket-email-route.ts
@@ -192,6 +192,21 @@ export class ImportTicketEmailRoute {
 		}
 	}
 
+	// formatLocalDate renders a proto LocalDate.value (a `{year, month, day}`
+	// google.type.Date message) as a zero-padded YYYY-MM-DD string for display.
+	// Without this helper the template `${concert.localDate?.value}` would
+	// stringify the proto message via its default toString() and render
+	// `[object Object]`, which is what every concert row was showing in the
+	// step-4 selection list before this method existed.
+	public formatLocalDate(
+		d: { year: number; month: number; day: number } | undefined,
+	): string {
+		if (!d) return ''
+		const month = String(d.month).padStart(2, '0')
+		const day = String(d.day).padStart(2, '0')
+		return `${d.year}-${month}-${day}`
+	}
+
 	public sanitizeUrl(url: string | undefined): string {
 		if (!url) return ''
 		try {

--- a/src/routes/import-ticket-email/import-ticket-email-route.ts
+++ b/src/routes/import-ticket-email/import-ticket-email-route.ts
@@ -202,6 +202,12 @@ export class ImportTicketEmailRoute {
 		d: { year: number; month: number; day: number } | undefined,
 	): string {
 		if (!d) return ''
+		// Guard against a proto-default Date message (all three int32 fields
+		// zero) — that's not a real calendar date, it's a never-populated
+		// field marshalled with the proto3 default. Returning '' instead of
+		// '0-00-00' keeps the row's <small> slot blank rather than showing a
+		// nonsense year-zero stamp.
+		if (d.year === 0 && d.month === 0 && d.day === 0) return ''
 		const month = String(d.month).padStart(2, '0')
 		const day = String(d.day).padStart(2, '0')
 		return `${d.year}-${month}-${day}`

--- a/src/routes/welcome/welcome-route.ts
+++ b/src/routes/welcome/welcome-route.ts
@@ -111,7 +111,13 @@ export class WelcomeRoute implements IRouteViewModel {
 					}
 				}
 				total += resolved
-				capped.push(g)
+				// Drop groups that contribute zero resolved concerts entirely
+				// — pushing them would leak blank-artist rows into the
+				// preview and let `capped` exceed MAX_PREVIEW_CONCERTS when
+				// unresolved groups sit between resolved ones (the cap
+				// counter doesn't advance on them, so the loop continues
+				// past and accumulates extras).
+				if (resolved > 0) capped.push(g)
 				if (total >= MAX_PREVIEW_CONCERTS) break
 			}
 

--- a/src/routes/welcome/welcome-route.ts
+++ b/src/routes/welcome/welcome-route.ts
@@ -111,13 +111,19 @@ export class WelcomeRoute implements IRouteViewModel {
 					}
 				}
 				total += resolved
-				// Drop groups that contribute zero resolved concerts entirely
-				// — pushing them would leak blank-artist rows into the
-				// preview and let `capped` exceed MAX_PREVIEW_CONCERTS when
-				// unresolved groups sit between resolved ones (the cap
-				// counter doesn't advance on them, so the loop continues
-				// past and accumulates extras).
-				if (resolved > 0) capped.push(g)
+				// Drop the entire group when none of its concerts resolved
+				// AND strip blank-artist concerts from partially-resolved
+				// groups before pushing. The previous group-level guard
+				// alone still leaked individual ghost cards from a mixed
+				// group into the unauthenticated preview.
+				if (resolved > 0) {
+					capped.push({
+						...g,
+						home: g.home.filter((c) => c.artistId),
+						nearby: g.nearby.filter((c) => c.artistId),
+						away: g.away.filter((c) => c.artistId),
+					})
+				}
 				if (total >= MAX_PREVIEW_CONCERTS) break
 			}
 

--- a/src/routes/welcome/welcome-route.ts
+++ b/src/routes/welcome/welcome-route.ts
@@ -97,7 +97,13 @@ export class WelcomeRoute implements IRouteViewModel {
 			for (const g of allGroups) {
 				const concerts = [...g.home, ...g.nearby, ...g.away]
 				for (const c of concerts) {
-					artistsWithData.add(c.artistId)
+					// Skip blank artistId — concertFrom returns '' when no
+					// performer resolved against the user's artistMap (an
+					// ID-format mismatch or backend bug). Adding '' inflates
+					// the Set by one phantom entry and could push
+					// artistsWithData.size past PREVIEW_MIN_ARTISTS_WITH_CONCERTS
+					// even when no real artist was resolved.
+					if (c.artistId) artistsWithData.add(c.artistId)
 				}
 				total += concerts.length
 				capped.push(g)

--- a/src/routes/welcome/welcome-route.ts
+++ b/src/routes/welcome/welcome-route.ts
@@ -96,16 +96,21 @@ export class WelcomeRoute implements IRouteViewModel {
 
 			for (const g of allGroups) {
 				const concerts = [...g.home, ...g.nearby, ...g.away]
+				// resolved counts only the concerts that contribute a real
+				// artist to artistsWithData. Counting every concert (incl.
+				// those with blank artistId from a failed performer
+				// resolution) could exhaust the 30-slot cap on unresolved
+				// rows alone, breaking the loop before enough artist-matched
+				// concerts are seen and silently suppressing the preview
+				// even when valid data exists past the cap boundary.
+				let resolved = 0
 				for (const c of concerts) {
-					// Skip blank artistId — concertFrom returns '' when no
-					// performer resolved against the user's artistMap (an
-					// ID-format mismatch or backend bug). Adding '' inflates
-					// the Set by one phantom entry and could push
-					// artistsWithData.size past PREVIEW_MIN_ARTISTS_WITH_CONCERTS
-					// even when no real artist was resolved.
-					if (c.artistId) artistsWithData.add(c.artistId)
+					if (c.artistId) {
+						artistsWithData.add(c.artistId)
+						resolved++
+					}
 				}
-				total += concerts.length
+				total += resolved
 				capped.push(g)
 				if (total >= MAX_PREVIEW_CONCERTS) break
 			}

--- a/src/services/concert-service.ts
+++ b/src/services/concert-service.ts
@@ -176,9 +176,10 @@ export class ConcertServiceClient {
 				// first one that resolves against the user's artistMap. The
 				// resolved entry's Artist (with its id) is then forwarded to
 				// concertFrom so the entity's artistId / artistName / artist
-				// fields stay internally consistent — concertFrom reads the
-				// artist arg first and only falls back to performers[0].id
-				// when nothing was resolved.
+				// fields stay internally consistent. When no Artist is
+				// resolved all three fields are left blank (no headliner
+				// fallback — see concert-mapper.ts for why symmetric blanks
+				// are required).
 				let entry: { artist: Artist; hype: Hype } | undefined
 				for (const p of c.performers ?? []) {
 					// Skip performers whose id is missing/empty — otherwise an

--- a/src/services/concert-service.ts
+++ b/src/services/concert-service.ts
@@ -173,23 +173,34 @@ export class ConcertServiceClient {
 				// performer on the bill, not necessarily the headliner — a
 				// festival concert can return with the followed support act
 				// as performers[1+], so probe every performer and pick the
-				// first one that resolves against the user's artistMap. Fall
-				// back to the headliner if none match (defensive — the
-				// backend ListByFollower should only return concerts that
-				// feature a followed artist).
-				let artistId = ''
+				// first one that resolves against the user's artistMap. The
+				// resolved entry's Artist (with its id) is then forwarded to
+				// concertFrom so the entity's artistId / artistName / artist
+				// fields stay internally consistent — concertFrom reads the
+				// artist arg first and only falls back to performers[0].id
+				// when nothing was resolved.
 				let entry: { artist: Artist; hype: Hype } | undefined
 				for (const p of c.performers ?? []) {
 					const candidate = p.id?.value ?? ''
 					const candidateEntry = artistMap.get(candidate)
 					if (candidateEntry) {
-						artistId = candidate
 						entry = candidateEntry
 						break
 					}
 				}
 				if (!entry) {
-					artistId = c.performers?.[0]?.id?.value ?? ''
+					// Backend ListByFollower SHOULD only return concerts that
+					// feature a followed artist; reaching here means an
+					// ID-format mismatch or a backend bug. Log so the data
+					// gap is investigable rather than silently producing a
+					// blank artist card.
+					console.warn(
+						'[concert-service] no performer resolved against followedArtists; concert will render with empty artist context',
+						{
+							concertId: c.id?.value,
+							performerIds: c.performers?.map((p) => p.id?.value),
+						},
+					)
 				}
 				const hypeLevel: HypeLevel = entry?.hype ?? DEFAULT_HYPE
 				const event = concertFrom(

--- a/src/services/concert-service.ts
+++ b/src/services/concert-service.ts
@@ -153,7 +153,17 @@ export class ConcertServiceClient {
 		artistMap: Map<string, { artist: Artist; hype: Hype }>,
 		journeyMap: Map<string, JourneyStatus>,
 	): DateGroup {
-		const ld = group.date?.value
+		// Same zero-component guard concertFrom applies to per-concert
+		// dates — a proto3-defaulted ProximityGroup.date with any zero
+		// field would roll `new Date(2026, -1, 15)` to 2025-12-15 and
+		// produce a malformed `2026-00-15` dateKey, silently
+		// misbucketing the whole group. Treat any zero component as
+		// unpopulated and fall back to today / empty key.
+		const rawLd = group.date?.value
+		const ld =
+			rawLd && rawLd.year !== 0 && rawLd.month !== 0 && rawLd.day !== 0
+				? rawLd
+				: undefined
 		const jsDate = ld ? new Date(ld.year, ld.month - 1, ld.day) : new Date()
 
 		const dateKey = ld
@@ -177,8 +187,11 @@ export class ConcertServiceClient {
 		// Each entry carries the lane the failure originated in so on-call
 		// can distinguish "all failures in away" (proximity-based, often
 		// expected) from "failures in home" (followed-artist mismatch,
-		// suspicious). Uses a Set-keyed dedup so a backend bug that echoes
-		// the same concert proto across lanes doesn't inflate the count.
+		// suspicious). Dedup keys on `${id}|${lane}` rather than id alone:
+		// a backend bug echoing the same concert proto across lanes is
+		// itself useful diagnostic signal (one entry per lane it appeared
+		// in), and within-lane re-pushes from the flatMap (impossible
+		// today but cheap to defend) still collapse to one entry.
 		const unresolved: Array<{ id: string; lane: LaneType }> = []
 		const unresolvedSeen = new Set<string>()
 		const convert = (concerts: ProtoConcert[], lane: LaneType) =>
@@ -210,17 +223,21 @@ export class ConcertServiceClient {
 					}
 				}
 				if (!entry) {
-					// Skip blank ids in the warning array — a `''` entry is
-					// indistinguishable from "one more unresolved" and gives
-					// on-call nothing to grep for. Dedup by concertId so the
-					// same proto echoed across lanes (a backend bug) doesn't
-					// inflate the count. The concert is still processed by
-					// concertFrom below; only the diagnostic entry is
-					// dropped/deduped.
+					// Skip blank ids — a `''` entry is indistinguishable
+					// from "one more unresolved" and gives on-call nothing
+					// to grep for. Dedup by (id, lane) so a concert echoed
+					// across lanes (a backend bug) emits one entry per lane
+					// it appeared in (useful signal) instead of collapsing
+					// to whichever lane the flatMap reached first. The
+					// concert itself is still processed by concertFrom
+					// below; only the diagnostic entry is deduped.
 					const concertId = c.id?.value
-					if (concertId && !unresolvedSeen.has(concertId)) {
-						unresolvedSeen.add(concertId)
-						unresolved.push({ id: concertId, lane })
+					if (concertId) {
+						const key = `${concertId}|${lane}`
+						if (!unresolvedSeen.has(key)) {
+							unresolvedSeen.add(key)
+							unresolved.push({ id: concertId, lane })
+						}
 					}
 				}
 				const hypeLevel: HypeLevel = entry?.hype ?? DEFAULT_HYPE

--- a/src/services/concert-service.ts
+++ b/src/services/concert-service.ts
@@ -203,7 +203,13 @@ export class ConcertServiceClient {
 					}
 				}
 				if (!entry) {
-					unresolvedConcertIds.push(c.id?.value ?? '')
+					// Skip blank ids in the warning array — a `''` entry is
+					// indistinguishable from "one more unresolved" and gives
+					// on-call nothing to grep for. The concert is still
+					// processed by concertFrom below; only the diagnostic
+					// entry is dropped.
+					const concertId = c.id?.value
+					if (concertId) unresolvedConcertIds.push(concertId)
 				}
 				const hypeLevel: HypeLevel = entry?.hype ?? DEFAULT_HYPE
 				const event = concertFrom(

--- a/src/services/concert-service.ts
+++ b/src/services/concert-service.ts
@@ -169,10 +169,28 @@ export class ConcertServiceClient {
 		const convert = (concerts: ProtoConcert[], lane: LaneType) =>
 			concerts.flatMap((c) => {
 				// Concert proto v0.41.0+ exposes performers as a repeated
-				// field; the dashboard groups concerts under a single
-				// "primary" artist, so we key on the first performer.
-				const artistId = c.performers?.[0]?.id?.value ?? ''
-				const entry = artistMap.get(artistId)
+				// field. For follower-based listing the user may follow any
+				// performer on the bill, not necessarily the headliner — a
+				// festival concert can return with the followed support act
+				// as performers[1+], so probe every performer and pick the
+				// first one that resolves against the user's artistMap. Fall
+				// back to the headliner if none match (defensive — the
+				// backend ListByFollower should only return concerts that
+				// feature a followed artist).
+				let artistId = ''
+				let entry: { artist: Artist; hype: Hype } | undefined
+				for (const p of c.performers ?? []) {
+					const candidate = p.id?.value ?? ''
+					const candidateEntry = artistMap.get(candidate)
+					if (candidateEntry) {
+						artistId = candidate
+						entry = candidateEntry
+						break
+					}
+				}
+				if (!entry) {
+					artistId = c.performers?.[0]?.id?.value ?? ''
+				}
 				const hypeLevel: HypeLevel = entry?.hype ?? DEFAULT_HYPE
 				const event = concertFrom(
 					c,

--- a/src/services/concert-service.ts
+++ b/src/services/concert-service.ts
@@ -166,14 +166,21 @@ export class ConcertServiceClient {
 			weekday: 'short',
 		})
 
-		// unresolvedConcertIds collects concerts whose performers don't
-		// resolve in artistMap so we can emit a single batched warn at the
-		// end of this group instead of one per concert. A systematic
-		// mismatch (wrong ID namespace, schema-skew rollout window) could
-		// produce O(N) entries per page load and flood any remote log sink
-		// or OTEL exporter; one entry per call with the full list is
-		// equally actionable but bounded.
-		const unresolvedConcertIds: string[] = []
+		// unresolved collects concerts whose performers don't resolve in
+		// artistMap so we can emit a single batched warn at the end of
+		// this group instead of one per concert. A systematic mismatch
+		// (wrong ID namespace, schema-skew rollout window) could produce
+		// O(N) entries per page load and flood any remote log sink or
+		// OTEL exporter; one entry per call with the full list is equally
+		// actionable but bounded.
+		//
+		// Each entry carries the lane the failure originated in so on-call
+		// can distinguish "all failures in away" (proximity-based, often
+		// expected) from "failures in home" (followed-artist mismatch,
+		// suspicious). Uses a Set-keyed dedup so a backend bug that echoes
+		// the same concert proto across lanes doesn't inflate the count.
+		const unresolved: Array<{ id: string; lane: LaneType }> = []
+		const unresolvedSeen = new Set<string>()
 		const convert = (concerts: ProtoConcert[], lane: LaneType) =>
 			concerts.flatMap((c) => {
 				// Concert proto v0.41.0+ exposes performers as a repeated
@@ -205,11 +212,16 @@ export class ConcertServiceClient {
 				if (!entry) {
 					// Skip blank ids in the warning array — a `''` entry is
 					// indistinguishable from "one more unresolved" and gives
-					// on-call nothing to grep for. The concert is still
-					// processed by concertFrom below; only the diagnostic
-					// entry is dropped.
+					// on-call nothing to grep for. Dedup by concertId so the
+					// same proto echoed across lanes (a backend bug) doesn't
+					// inflate the count. The concert is still processed by
+					// concertFrom below; only the diagnostic entry is
+					// dropped/deduped.
 					const concertId = c.id?.value
-					if (concertId) unresolvedConcertIds.push(concertId)
+					if (concertId && !unresolvedSeen.has(concertId)) {
+						unresolvedSeen.add(concertId)
+						unresolved.push({ id: concertId, lane })
+					}
 				}
 				const hypeLevel: HypeLevel = entry?.hype ?? DEFAULT_HYPE
 				const event = concertFrom(
@@ -234,7 +246,7 @@ export class ConcertServiceClient {
 			nearby: convert(group.nearby, 'nearby'),
 			away: convert(group.away, 'away'),
 		}
-		if (unresolvedConcertIds.length > 0) {
+		if (unresolved.length > 0) {
 			// Single batched warn per group; backend ListByFollower SHOULD
 			// only return concerts that feature a followed artist, so any
 			// non-empty list here is a real signal (ID-format mismatch or
@@ -244,8 +256,9 @@ export class ConcertServiceClient {
 			this.logger.warn(
 				'some concerts had no performer resolved against followedArtists; they will render with empty artist context',
 				{
-					count: unresolvedConcertIds.length,
-					concertIds: unresolvedConcertIds,
+					count: unresolved.length,
+					concertIds: unresolved.map((u) => u.id),
+					lanes: unresolved.map((u) => u.lane),
 					dateKey,
 				},
 			)

--- a/src/services/concert-service.ts
+++ b/src/services/concert-service.ts
@@ -168,7 +168,10 @@ export class ConcertServiceClient {
 
 		const convert = (concerts: ProtoConcert[], lane: LaneType) =>
 			concerts.flatMap((c) => {
-				const artistId = c.artistId?.value ?? ''
+				// Concert proto v0.41.0+ exposes performers as a repeated
+				// field; the dashboard groups concerts under a single
+				// "primary" artist, so we key on the first performer.
+				const artistId = c.performers?.[0]?.id?.value ?? ''
 				const entry = artistMap.get(artistId)
 				const hypeLevel: HypeLevel = entry?.hype ?? DEFAULT_HYPE
 				const event = concertFrom(

--- a/src/services/concert-service.ts
+++ b/src/services/concert-service.ts
@@ -166,6 +166,14 @@ export class ConcertServiceClient {
 			weekday: 'short',
 		})
 
+		// unresolvedConcertIds collects concerts whose performers don't
+		// resolve in artistMap so we can emit a single batched warn at the
+		// end of this group instead of one per concert. A systematic
+		// mismatch (wrong ID namespace, schema-skew rollout window) could
+		// produce O(N) entries per page load and flood any remote log sink
+		// or OTEL exporter; one entry per call with the full list is
+		// equally actionable but bounded.
+		const unresolvedConcertIds: string[] = []
 		const convert = (concerts: ProtoConcert[], lane: LaneType) =>
 			concerts.flatMap((c) => {
 				// Concert proto v0.41.0+ exposes performers as a repeated
@@ -195,20 +203,7 @@ export class ConcertServiceClient {
 					}
 				}
 				if (!entry) {
-					// Backend ListByFollower SHOULD only return concerts that
-					// feature a followed artist; reaching here means an
-					// ID-format mismatch or a backend bug. Use the scoped
-					// Aurelia logger so the warning routes through whatever
-					// log sink / OpenTelemetry exporter the class was
-					// configured with, instead of bypassing it via
-					// console.warn.
-					this.logger.warn(
-						'no performer resolved against followedArtists; concert will render with empty artist context',
-						{
-							concertId: c.id?.value,
-							performerIds: c.performers?.map((p) => p.id?.value),
-						},
-					)
+					unresolvedConcertIds.push(c.id?.value ?? '')
 				}
 				const hypeLevel: HypeLevel = entry?.hype ?? DEFAULT_HYPE
 				const event = concertFrom(
@@ -226,13 +221,30 @@ export class ConcertServiceClient {
 				return [event]
 			})
 
-		return {
+		const result = {
 			label,
 			dateKey,
 			home: convert(group.home, 'home'),
 			nearby: convert(group.nearby, 'nearby'),
 			away: convert(group.away, 'away'),
 		}
+		if (unresolvedConcertIds.length > 0) {
+			// Single batched warn per group; backend ListByFollower SHOULD
+			// only return concerts that feature a followed artist, so any
+			// non-empty list here is a real signal (ID-format mismatch or
+			// schema-skew rollout). Use the scoped Aurelia logger so the
+			// entry flows through whatever log sink / OpenTelemetry
+			// exporter the class is configured with.
+			this.logger.warn(
+				'some concerts had no performer resolved against followedArtists; they will render with empty artist context',
+				{
+					count: unresolvedConcertIds.length,
+					concertIds: unresolvedConcertIds,
+					dateKey,
+				},
+			)
+		}
+		return result
 	}
 
 	private async listByFollowerGuest(

--- a/src/services/concert-service.ts
+++ b/src/services/concert-service.ts
@@ -208,6 +208,17 @@ export class ConcertServiceClient {
 				// resolved all three fields are left blank (no headliner
 				// fallback — see concert-mapper.ts for why symmetric blanks
 				// are required).
+				// Tiebreaker note: when the user follows multiple
+				// performers on the same bill (e.g. both the headliner
+				// and a support act), the FIRST matched performer wins —
+				// the loop breaks on the first hit. Order is whatever
+				// the backend serialised in `performers[]`, which is the
+				// billing/series order today. A more nuanced policy
+				// (e.g. "highest hype tier wins") would require ranking
+				// candidates instead of breaking on first match; intent
+				// today is "first listed performer the user follows = the
+				// primary identity for this card", consistent with the
+				// dashboard's single-artist-per-row model.
 				let entry: { artist: Artist; hype: Hype } | undefined
 				for (const p of c.performers ?? []) {
 					// Skip performers whose id is missing/empty — otherwise an
@@ -271,7 +282,7 @@ export class ConcertServiceClient {
 			// entry flows through whatever log sink / OpenTelemetry
 			// exporter the class is configured with.
 			this.logger.warn(
-				'some concerts had no performer resolved against followedArtists; they will render with empty artist context',
+				'some concerts had no performer resolved against followedArtists; they will either render with empty artist context or be dropped entirely by concertFrom (e.g. a zero-component localDate)',
 				{
 					count: unresolved.length,
 					concertIds: unresolved.map((u) => u.id),

--- a/src/services/concert-service.ts
+++ b/src/services/concert-service.ts
@@ -191,11 +191,13 @@ export class ConcertServiceClient {
 				if (!entry) {
 					// Backend ListByFollower SHOULD only return concerts that
 					// feature a followed artist; reaching here means an
-					// ID-format mismatch or a backend bug. Log so the data
-					// gap is investigable rather than silently producing a
-					// blank artist card.
-					console.warn(
-						'[concert-service] no performer resolved against followedArtists; concert will render with empty artist context',
+					// ID-format mismatch or a backend bug. Use the scoped
+					// Aurelia logger so the warning routes through whatever
+					// log sink / OpenTelemetry exporter the class was
+					// configured with, instead of bypassing it via
+					// console.warn.
+					this.logger.warn(
+						'no performer resolved against followedArtists; concert will render with empty artist context',
 						{
 							concertId: c.id?.value,
 							performerIds: c.performers?.map((p) => p.id?.value),

--- a/src/services/concert-service.ts
+++ b/src/services/concert-service.ts
@@ -181,7 +181,12 @@ export class ConcertServiceClient {
 				// when nothing was resolved.
 				let entry: { artist: Artist; hype: Hype } | undefined
 				for (const p of c.performers ?? []) {
-					const candidate = p.id?.value ?? ''
+					// Skip performers whose id is missing/empty — otherwise an
+					// `artistMap.get('')` would spuriously resolve if any
+					// followed artist happens to be stored under a blank key
+					// (a backend bug, but cheap to defend against here).
+					const candidate = p.id?.value
+					if (!candidate) continue
 					const candidateEntry = artistMap.get(candidate)
 					if (candidateEntry) {
 						entry = candidateEntry

--- a/test/adapter/rpc/mapper/concert-mapper.spec.ts
+++ b/test/adapter/rpc/mapper/concert-mapper.spec.ts
@@ -38,8 +38,12 @@ describe('concertFrom', () => {
 	function makeProto(overrides: Record<string, unknown> = {}) {
 		// Concert proto v0.41.0+: title / sourceUrl moved onto the embedded
 		// `series` parent; the single `artistId` was replaced by a `performers`
-		// repeated field. The mapper projects the first performer onto the
-		// flat entity Concert.artistId.
+		// repeated field. The mapper takes the caller-resolved `artist` arg
+		// as the entity's artistId — no `performers[0]` fallback. When no
+		// artist is resolved the artist trio (artistId / artistName /
+		// artist) all go blank to keep downstream consumers internally
+		// consistent (see `leaves artistId empty when no artist is
+		// resolved` test for the contract assertion).
 		return {
 			id: { value: 'c1' },
 			performers: [

--- a/test/adapter/rpc/mapper/concert-mapper.spec.ts
+++ b/test/adapter/rpc/mapper/concert-mapper.spec.ts
@@ -196,4 +196,28 @@ describe('concertFrom', () => {
 		const result = concertFrom(proto as any, 'Artist', 'watch', false)
 		expect(result!.artistId).toBe('headliner')
 	})
+
+	it('prefers artist.id over performers[0].id when both disagree', () => {
+		// concert-service resolves the followed performer (which may not be
+		// the headliner) and forwards it as `artist`. The mapper must take
+		// that resolved id as the artistId so the entity's artistId /
+		// artistName / artist trio stay internally consistent. Without this
+		// test, swapping the operands in
+		//   artist?.id ?? proto.performers?.[0]?.id?.value ?? ''
+		// would go undetected because every other test uses an artist whose
+		// id matches performers[0].
+		const proto = makeProto({
+			performers: [
+				{
+					id: { value: 'headliner' },
+					name: { value: 'H' },
+					mbid: { value: '' },
+				},
+			],
+		})
+		const artist = { id: 'followed-support', name: 'Support', mbid: '' }
+		const result = concertFrom(proto as any, 'Support', 'watch', false, artist)
+		expect(result!.artistId).toBe('followed-support')
+		expect(result!.artist).toBe(artist)
+	})
 })

--- a/test/adapter/rpc/mapper/concert-mapper.spec.ts
+++ b/test/adapter/rpc/mapper/concert-mapper.spec.ts
@@ -168,6 +168,16 @@ describe('concertFrom', () => {
 		expect(result!.artistId).toBe('')
 	})
 
+	it('handles empty performers array gracefully (distinct from undefined)', () => {
+		// performers: [] is a distinct server state from performers: undefined.
+		// The mapper should treat both the same way (empty artistId) so a
+		// malformed/zero-performer concert never throws nor surfaces a bogus
+		// scalar value.
+		const proto = makeProto({ performers: [] })
+		const result = concertFrom(proto as any, 'Artist', 'watch', false)
+		expect(result!.artistId).toBe('')
+	})
+
 	it('projects the first performer when multiple are present', () => {
 		const proto = makeProto({
 			performers: [

--- a/test/adapter/rpc/mapper/concert-mapper.spec.ts
+++ b/test/adapter/rpc/mapper/concert-mapper.spec.ts
@@ -36,13 +36,26 @@ describe('timestampToTimeString', () => {
 
 describe('concertFrom', () => {
 	function makeProto(overrides: Record<string, unknown> = {}) {
+		// Concert proto v0.41.0+: title / sourceUrl moved onto the embedded
+		// `series` parent; the single `artistId` was replaced by a `performers`
+		// repeated field. The mapper projects the first performer onto the
+		// flat entity Concert.artistId.
 		return {
 			id: { value: 'c1' },
-			artistId: { value: 'a1' },
-			title: { value: 'Test Concert' },
+			performers: [
+				{
+					id: { value: 'a1' },
+					name: { value: 'Headliner' },
+					mbid: { value: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' },
+				},
+			],
+			series: {
+				id: { value: 's1' },
+				title: { value: 'Test Concert' },
+				sourceUrl: { value: 'https://example.com' },
+			},
 			localDate: { value: { year: 2026, month: 3, day: 15 } },
 			startTime: { value: { seconds: BigInt(1742054400), nanos: 0 } },
-			sourceUrl: { value: 'https://example.com' },
 			venue: {
 				name: { value: 'Zepp DiverCity' },
 				adminArea: { value: 'JP-13' },
@@ -148,10 +161,29 @@ describe('concertFrom', () => {
 		expect(result!.artist).toBe(artist)
 	})
 
-	it('handles missing id and artistId gracefully', () => {
-		const proto = makeProto({ id: undefined, artistId: undefined })
+	it('handles missing id and performers gracefully', () => {
+		const proto = makeProto({ id: undefined, performers: undefined })
 		const result = concertFrom(proto as any, 'Artist', 'watch', false)
 		expect(result!.id).toBe('')
 		expect(result!.artistId).toBe('')
+	})
+
+	it('projects the first performer when multiple are present', () => {
+		const proto = makeProto({
+			performers: [
+				{
+					id: { value: 'headliner' },
+					name: { value: 'A' },
+					mbid: { value: 'm1' },
+				},
+				{
+					id: { value: 'support' },
+					name: { value: 'B' },
+					mbid: { value: 'm2' },
+				},
+			],
+		})
+		const result = concertFrom(proto as any, 'Artist', 'watch', false)
+		expect(result!.artistId).toBe('headliner')
 	})
 })

--- a/test/adapter/rpc/mapper/concert-mapper.spec.ts
+++ b/test/adapter/rpc/mapper/concert-mapper.spec.ts
@@ -65,7 +65,14 @@ describe('concertFrom', () => {
 	}
 
 	it('maps all fields from proto to entity', () => {
-		const result = concertFrom(makeProto() as any, 'Artist One', 'home', true)
+		const artist = { id: 'a1', name: 'Artist One', mbid: '' }
+		const result = concertFrom(
+			makeProto() as any,
+			'Artist One',
+			'home',
+			true,
+			artist,
+		)
 
 		expect(result).not.toBeNull()
 		expect(result!.id).toBe('c1')
@@ -178,7 +185,12 @@ describe('concertFrom', () => {
 		expect(result!.artistId).toBe('')
 	})
 
-	it('projects the first performer when multiple are present', () => {
+	it('leaves artistId empty when no artist is resolved (no headliner fallback)', () => {
+		// concert-service is the only production caller and always passes the
+		// resolved performer as `artist`. Without that resolution the artist
+		// trio (artistId / artistName / artist) all go blank so downstream
+		// dashboard filters do not see an artistId pointing at the headliner
+		// while artistName is empty.
 		const proto = makeProto({
 			performers: [
 				{
@@ -194,7 +206,7 @@ describe('concertFrom', () => {
 			],
 		})
 		const result = concertFrom(proto as any, 'Artist', 'watch', false)
-		expect(result!.artistId).toBe('headliner')
+		expect(result!.artistId).toBe('')
 	})
 
 	it('prefers artist.id over performers[0].id when both disagree', () => {

--- a/test/services/concert-service.spec.ts
+++ b/test/services/concert-service.spec.ts
@@ -253,12 +253,15 @@ describe('ConcertServiceClient', () => {
 			sut.toDateGroups([group as never], artistMap)
 			// One batched warn per group covering all unresolved concerts
 			// (not one per concert) — a systematic mismatch would otherwise
-			// produce O(N) entries per page load.
+			// produce O(N) entries per page load. Each entry is tagged with
+			// the lane it failed in so on-call can tell follower-lane
+			// mismatches apart from proximity-lane noise.
 			expect(mockLoggerWarn).toHaveBeenCalledWith(
 				expect.stringContaining('no performer resolved'),
 				expect.objectContaining({
 					count: 1,
 					concertIds: ['c1'],
+					lanes: ['home'],
 				}),
 			)
 		})

--- a/test/services/concert-service.spec.ts
+++ b/test/services/concert-service.spec.ts
@@ -251,9 +251,15 @@ describe('ConcertServiceClient', () => {
 				],
 			])
 			sut.toDateGroups([group as never], artistMap)
+			// One batched warn per group covering all unresolved concerts
+			// (not one per concert) — a systematic mismatch would otherwise
+			// produce O(N) entries per page load.
 			expect(mockLoggerWarn).toHaveBeenCalledWith(
 				expect.stringContaining('no performer resolved'),
-				expect.objectContaining({ concertId: 'c1' }),
+				expect.objectContaining({
+					count: 1,
+					concertIds: ['c1'],
+				}),
 			)
 		})
 

--- a/test/services/concert-service.spec.ts
+++ b/test/services/concert-service.spec.ts
@@ -1,4 +1,4 @@
-import { DI, Registration } from 'aurelia'
+import { DI, ILogger, Registration } from 'aurelia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createTestContainer } from '../helpers/create-container'
 import { createMockAuth } from '../helpers/mock-auth'
@@ -43,6 +43,7 @@ const { ConcertServiceClient, IConcertService } = await import(
 
 describe('ConcertServiceClient', () => {
 	let sut: InstanceType<typeof ConcertServiceClient>
+	let mockLoggerWarn: ReturnType<typeof vi.fn>
 
 	beforeEach(() => {
 		vi.clearAllMocks()
@@ -66,6 +67,12 @@ describe('ConcertServiceClient', () => {
 		)
 		container.register(ConcertServiceClient)
 		sut = container.get(IConcertService)
+		// The mock ILogger's scopeTo returns the same instance (mockReturnThis),
+		// so the scoped logger inside ConcertServiceClient calls the very same
+		// warn spy we grab from the container here.
+		mockLoggerWarn = (
+			container.get(ILogger) as { warn: ReturnType<typeof vi.fn> }
+		).warn
 	})
 
 	afterEach(() => {
@@ -146,6 +153,123 @@ describe('ConcertServiceClient', () => {
 			sut.addArtistWithConcerts('a1')
 			sut.addArtistWithConcerts('a1')
 			expect(sut.artistsWithConcertsCount).toBe(1)
+		})
+	})
+
+	describe('toDateGroups (performer resolution)', () => {
+		function makeConcert(overrides: Record<string, unknown> = {}) {
+			return {
+				id: { value: 'c1' },
+				performers: [
+					{
+						id: { value: 'a-headliner' },
+						name: { value: 'Headliner' },
+						mbid: { value: '' },
+					},
+				],
+				series: {
+					id: { value: 's1' },
+					title: { value: 'Test Show' },
+					sourceUrl: { value: '' },
+				},
+				localDate: { value: { year: 2026, month: 3, day: 15 } },
+				venue: { name: { value: 'Venue' }, adminArea: { value: 'JP-13' } },
+				...overrides,
+			}
+		}
+		const dateLD = { year: 2026, month: 3, day: 15 }
+
+		it('resolves a followed artist that matches performers[0]', () => {
+			const group = {
+				date: { value: dateLD },
+				home: [makeConcert()],
+				nearby: [],
+				away: [],
+			}
+			const artist = { id: 'a-headliner', name: 'Headliner', mbid: '' }
+			const artistMap = new Map([
+				['a-headliner', { artist, hype: 'watch' as const }],
+			])
+			const [dg] = sut.toDateGroups([group as never], artistMap)
+			expect(dg.home).toHaveLength(1)
+			expect(dg.home[0].artistId).toBe('a-headliner')
+			expect(dg.home[0].artistName).toBe('Headliner')
+			expect(dg.home[0].artist).toBe(artist)
+			expect(mockLoggerWarn).not.toHaveBeenCalled()
+		})
+
+		it('picks the first MATCHED performer, not necessarily performers[0]', () => {
+			// performers[0] is an unfollowed headliner; performers[1] is the
+			// followed support act. The resolver must skip the headliner and
+			// resolve the support act so the entity's artist context is
+			// internally consistent.
+			const concert = makeConcert({
+				performers: [
+					{
+						id: { value: 'a-unfollowed-headliner' },
+						name: { value: 'Headliner' },
+						mbid: { value: '' },
+					},
+					{
+						id: { value: 'a-followed-support' },
+						name: { value: 'Support' },
+						mbid: { value: '' },
+					},
+				],
+			})
+			const group = {
+				date: { value: dateLD },
+				home: [concert],
+				nearby: [],
+				away: [],
+			}
+			const artist = { id: 'a-followed-support', name: 'Support', mbid: '' }
+			const artistMap = new Map([
+				['a-followed-support', { artist, hype: 'watch' as const }],
+			])
+			const [dg] = sut.toDateGroups([group as never], artistMap)
+			expect(dg.home[0].artistId).toBe('a-followed-support')
+			expect(dg.home[0].artist).toBe(artist)
+		})
+
+		it('logs a warn when no performer resolves against artistMap', () => {
+			const group = {
+				date: { value: dateLD },
+				home: [makeConcert()],
+				nearby: [],
+				away: [],
+			}
+			// artistMap intentionally has a different artist than the
+			// concert's performer — the inner loop finds no match.
+			const artistMap = new Map([
+				[
+					'a-someone-else',
+					{
+						artist: { id: 'a-someone-else', name: 'X', mbid: '' },
+						hype: 'watch' as const,
+					},
+				],
+			])
+			sut.toDateGroups([group as never], artistMap)
+			expect(mockLoggerWarn).toHaveBeenCalledWith(
+				expect.stringContaining('no performer resolved'),
+				expect.objectContaining({ concertId: 'c1' }),
+			)
+		})
+
+		it('excludes a concert whose localDate is missing', () => {
+			const group = {
+				date: { value: dateLD },
+				home: [makeConcert({ localDate: undefined })],
+				nearby: [],
+				away: [],
+			}
+			const artist = { id: 'a-headliner', name: 'Headliner', mbid: '' }
+			const artistMap = new Map([
+				['a-headliner', { artist, hype: 'watch' as const }],
+			])
+			const [dg] = sut.toDateGroups([group as never], artistMap)
+			expect(dg.home).toHaveLength(0)
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- Frontend half of the cross-repo Series-hierarchy refactor proposed in [liverty-music/specification#514](https://github.com/liverty-music/specification/issues/514) and shipped to BSR via [specification@v0.41.0](https://github.com/liverty-music/specification/releases/tag/v0.41.0).
- Bump the BSR-published Connect-ES + buf-ES packages to the builds generated from specification@v0.41.0 (commit `e7f694dd726b`, BSR build timestamp `20260524050818`). Pinned to the `v1.x` lineage because `@buf/liverty-music_schema.connectrpc_es` has no `v2.x` build yet — the only coherent pair today is `bufbuild_es@1.10.0-20260524050818-...` + `connectrpc_es@1.6.1-20260524050818-...`.
- Update `concert-mapper.ts` and the dashboard-side proximity-lane converter in `concert-service.ts` to source values from the new proto shape (`series.title`, `series.sourceUrl`, `performers[0].id`) instead of the dropped `title` / `sourceUrl` / `artistId` scalars.
- Dashboard `Concert` entity stays single-artist-flat for now: the mapper projects the first performer onto `Concert.artistId`. Multi-performer concerts (festivals, co-headliners) surface only the lead artist in the current UI; a future enhancement can widen the entity to carry the full lineup.

Refs: liverty-music/specification#514

## Cross-repo coordination

| Repo | PR / Release | Status |
|---|---|---|
| `liverty-music/specification` | [#515](https://github.com/liverty-music/specification/pull/515), [v0.41.0](https://github.com/liverty-music/specification/releases/tag/v0.41.0) | MERGED, BSR published |
| `liverty-music/backend` | sibling PR | open for review |
| `liverty-music/frontend` | this PR | open for review |

## Test plan

- [x] `make check` (Biome lint + format + stylelint + `tsc --noEmit` + Vitest unit tests) passes locally.
- [x] `concert-mapper.spec.ts` covers the new proto fixture shape (`performers[]` + `series{}`), the missing-`id`-and-`performers` graceful path, and the multi-performer projection.
- [ ] CI run on this PR passes.
- [ ] After merge + deploy, manual smoke against `dev.liverty-music.app` confirms the dashboard renders concerts using the embedded `Series` (title / source URL) and the resolved primary artist (tracked as task 12.2 in the OpenSpec change).
