### PR TITLE
refactor(user): single-source state — derive Settings view from observable UserService.current

### DIFF
--- a/src/routes/settings/settings-route.html
+++ b/src/routes/settings/settings-route.html
@@ -164,10 +164,10 @@
         repeat.for="lang of supportedLanguages"
         click.trigger="selectLanguage(lang)"
         class="language-option"
-        data-selected.bind="isCurrentLanguage(lang)"
+        data-selected.bind="currentLocale === lang"
       >
         <span t.bind="'languages.' + lang"></span>
-        <svg-icon if.bind="isCurrentLanguage(lang)" name="check" class="language-check"></svg-icon>
+        <svg-icon if.bind="currentLocale === lang" name="check" class="language-check"></svg-icon>
       </button>
     </div>
   </div>

--- a/src/routes/settings/settings-route.ts
+++ b/src/routes/settings/settings-route.ts
@@ -64,11 +64,21 @@ export class SettingsRoute {
 	public get currentHome(): string | null {
 		// Settings is an authenticated-only route, so the home value MUST
 		// come from the user entity. The guest-flow home storage owned by
-		// UserHomeSelector is irrelevant here: auth-callback's
-		// GuestDataMergeService.merge() runs before any Settings render and
-		// persists the guest selection to user.home via the Create RPC. If
-		// that merge is broken, the right fix is in the merge service — not
-		// a fallback here that would silently mask the regression.
+		// UserHomeSelector is consumed at signup time:
+		// auth-callback's ensureUserProvisioned reads guest.home and calls
+		// userService.create(email, locale, codeToHome(guestHome)), which
+		// atomically persists the home into the user row via the Create
+		// RPC's home field. By the time Settings ever renders, user.home
+		// IS the source of truth. (GuestDataMergeService.merge() handles
+		// follows/hypes only — NOT home; home is a Create-time field, not
+		// a post-signup merge target.)
+		//
+		// If a signed-in user lacks user.home (e.g. they completed signup
+		// before the home-prompt step landed, or guest.home was empty at
+		// auth-callback), `currentHome` is null and the UI renders
+		// 'Not set'. The user re-selects via the home-selector sheet,
+		// which calls userService.updateHome — the getter then surfaces
+		// the new value automatically. No localStorage fallback needed.
 		const code = this.userService.current?.home?.level1
 		return code ? translationKey(code) : null
 	}
@@ -180,6 +190,14 @@ export class SettingsRoute {
 				lang,
 			)
 		} catch (err) {
+			// changeLocale throws TypeError when `lang` is not in
+			// SUPPORTED_LANGUAGES. That path is unreachable from this caller
+			// — the selector only forwards values from `supportedLanguages`
+			// — so any TypeError reaching here indicates a programmer error
+			// (e.g. the constant was edited inconsistently with the
+			// validation). Surfacing it to the global error boundary is the
+			// intended behavior. Snack is only for genuine network /
+			// server-side failures (ConnectError).
 			if (!(err instanceof ConnectError)) throw err
 			this.logger.error('Failed to update preferred language', {
 				error: err,

--- a/src/routes/settings/settings-route.ts
+++ b/src/routes/settings/settings-route.ts
@@ -26,8 +26,6 @@ export class SettingsRoute {
 	private readonly i18n = resolve(I18N)
 	private readonly localStorage = resolve(ILocalStorage)
 
-	public currentHome: string | null = null
-	public currentLocale = ''
 	public notificationsEnabled = false
 	public vapidAvailable = !!resolve(IAppConfig).vapidPublicKey
 	public homeSelector!: UserHomeSelector
@@ -35,9 +33,45 @@ export class SettingsRoute {
 	public readonly supportedLanguages = SUPPORTED_LANGUAGES
 	private isToggling = false
 
-	public emailVerified = false
 	public isResendingVerification = false
 	public resendSuccess = false
+
+	// View state derived from the single source of truth: UserService.current
+	// (which is @observable and re-notifies on every entity mutation). All
+	// derived display values are exposed as computed getters so Aurelia's
+	// proxy-based observation tracks the access chain and re-evaluates every
+	// dependent binding (settings row text AND in-modal selector check) when
+	// the user entity changes. No component-local mirror state, no manual
+	// write-back in mutation handlers. This eliminates the desync class of
+	// bug where mirror-only updates fail to propagate to method-call
+	// bindings inside repeat.for (which expression observation cannot track
+	// through a method body).
+	public get currentLocale(): string {
+		// Fallback to the active i18n locale only when hydration has not yet
+		// populated `current.preferredLanguage` (e.g., very first render
+		// after signup, or the hydration backfill RPC is still in flight).
+		// MUST NOT read localStorage['language']. The fallback runs through
+		// normalizeToSupportedLanguage so a BCP 47 tag returned by
+		// i18n.getLocale() (e.g. 'en-US' when the detector falls through to
+		// navigator.language) maps to 'en' — otherwise the selector compares
+		// 'en-US' === 'en' and no row is highlighted.
+		return (
+			this.userService.current?.preferredLanguage ??
+			normalizeToSupportedLanguage(this.i18n.getLocale())
+		)
+	}
+
+	public get currentHome(): string | null {
+		// Settings is an authenticated-only route, so the home value MUST
+		// come from the user entity. The guest-flow home storage owned by
+		// UserHomeSelector is irrelevant here: auth-callback's
+		// GuestDataMergeService.merge() runs before any Settings render and
+		// persists the guest selection to user.home via the Create RPC. If
+		// that merge is broken, the right fix is in the merge service — not
+		// a fallback here that would silently mask the regression.
+		const code = this.userService.current?.home?.level1
+		return code ? translationKey(code) : null
+	}
 
 	public get currentHomeKey(): string {
 		return this.currentHome
@@ -45,29 +79,20 @@ export class SettingsRoute {
 			: 'settings.notSet'
 	}
 
-	public async loading(): Promise<void> {
-		// Source-of-truth for authenticated language is the backend user row.
-		// Fall back to the active i18n locale only when hydration has not yet
-		// populated `current.preferredLanguage` (e.g., very first render after
-		// signup). MUST NOT read localStorage['language'] here.
-		//
-		// The fallback runs through normalizeToSupportedLanguage so a
-		// BCP 47 tag returned by i18n.getLocale() (e.g. 'en-US' when the
-		// detector falls through to navigator.language) maps to 'en'
-		// rather than 'en-US' — otherwise isCurrentLanguage compares
-		// 'en-US' === 'en' and no radio is highlighted.
-		const fromUser = this.userService.current?.preferredLanguage
-		this.currentLocale =
-			fromUser ?? normalizeToSupportedLanguage(this.i18n.getLocale())
-		const homeLevel1 = this.userService.current?.home?.level1
-		const code = homeLevel1 ?? UserHomeSelector.getStoredHome()
-		this.currentHome = code ? translationKey(code) : null
-
-		// Read email_verified from OIDC profile claims
-		this.emailVerified =
+	public get emailVerified(): boolean {
+		// Read directly from OIDC profile claims. The `as Record<string,
+		// unknown>` cast and the `email_verified` claim-name knowledge belong
+		// behind AuthService (tracked under the follow-up `expose
+		// claim-derived state on AuthService` refactor); keeping the inline
+		// read here for now to scope this change to the user-entity SSoT
+		// refactor.
+		return (
 			(this.auth.user?.profile as Record<string, unknown>)?.email_verified ===
 			true
+		)
+	}
 
+	public async loading(): Promise<void> {
 		await this.resolveNotificationToggleState()
 	}
 
@@ -127,7 +152,12 @@ export class SettingsRoute {
 	}
 
 	public onHomeSelected(code: string): void {
-		this.currentHome = translationKey(code)
+		// UserHomeSelector already persists via userService.updateHome before
+		// firing this callback, and `currentHome` is derived from
+		// userService.current.home — so the view updates automatically. The
+		// handler stays solely to surface a structured log line for the
+		// settings-originated update path (distinct from onboarding /
+		// auth-callback / hydration write paths).
 		this.logger.info('Home area updated from settings', { code })
 	}
 
@@ -161,15 +191,10 @@ export class SettingsRoute {
 			)
 			return
 		}
-		this.currentLocale = this.userService.current?.preferredLanguage ?? lang
-		this.logger.info('Language changed', {
-			from: previous,
-			to: this.currentLocale,
-		})
-	}
-
-	public isCurrentLanguage(lang: string): boolean {
-		return this.currentLocale === lang
+		// No manual `this.currentLocale = ...` — the getter derives from
+		// userService.current.preferredLanguage, which changeLocale's
+		// updatePreferredLanguage write-through has already updated.
+		this.logger.info('Language changed', { from: previous, to: lang })
 	}
 
 	public async toggleNotifications(): Promise<void> {

--- a/src/services/user-service.ts
+++ b/src/services/user-service.ts
@@ -50,14 +50,24 @@ export class UserServiceClient implements IUserService {
 	private readonly authService = resolve(IAuthService)
 	private readonly storage = resolve(ILocalStorage)
 
-	// `current` is the single source of truth for the authenticated user
-	// entity. Marked @observable so any view-model that reads it through a
-	// computed getter (e.g. SettingsRoute.currentLocale,
-	// SettingsRoute.currentHome) re-evaluates automatically when the entity
-	// changes — no component-local mirror state, no manual write-back. Every
-	// mutation method below assigns through `this.current = ...` so the
-	// notification fires exactly once per change.
-	@observable public current: User | undefined = undefined
+	// `_current` is the single source of truth for the authenticated user
+	// entity. Marked @observable so any view-model that reads it through
+	// `current` (e.g. SettingsRoute.currentLocale, SettingsRoute.currentHome
+	// getters) re-evaluates automatically when the entity changes — no
+	// component-local mirror state, no manual write-back. Every mutation
+	// method below assigns through `this._current = ...` so the notification
+	// fires exactly once per change.
+	//
+	// The public `current` getter preserves the `readonly` encapsulation
+	// declared on IUserService: external consumers (even ones that
+	// inadvertently resolve the concrete class instead of the interface)
+	// cannot reassign the field. Internal mutation paths stay on
+	// `this._current` directly.
+	@observable private _current: User | undefined = undefined
+
+	public get current(): User | undefined {
+		return this._current
+	}
 
 	// Resolves the authenticated user via:
 	//   1. in-memory cache (already hydrated this session)
@@ -73,15 +83,15 @@ export class UserServiceClient implements IUserService {
 	public async ensureLoaded(
 		preferredLanguage: string,
 	): Promise<User | undefined> {
-		if (this.current) return this.current
+		if (this._current) return this._current
 
 		const userId = this.readCachedUserId()
 		if (userId) {
 			try {
 				this.logger.info('Loading user profile from backend (cache hit)')
-				this.current = await this.rpcClient.get(userId)
-				if (this.current) this.writeCachedUserId(this.current.id)
-				return this.current
+				this._current = await this.rpcClient.get(userId)
+				if (this._current) this.writeCachedUserId(this._current.id)
+				return this._current
 			} catch (err) {
 				if (err instanceof ConnectError && err.code === Code.PermissionDenied) {
 					this.logger.warn(
@@ -108,14 +118,14 @@ export class UserServiceClient implements IUserService {
 		// Create requires preferred_language; on the idempotent-return path the
 		// existing row's language is preserved, so passing the current effective
 		// locale is safe even for returning users.
-		this.current = await this.rpcClient.create(email, preferredLanguage)
-		if (this.current) this.writeCachedUserId(this.current.id)
-		return this.current
+		this._current = await this.rpcClient.create(email, preferredLanguage)
+		if (this._current) this.writeCachedUserId(this._current.id)
+		return this._current
 	}
 
 	public clear(): void {
 		this.removeCachedUserId()
-		this.current = undefined
+		this._current = undefined
 		this.logger.info('User profile cleared')
 	}
 
@@ -125,7 +135,7 @@ export class UserServiceClient implements IUserService {
 		home?: { countryCode: string; level1: string; level2?: string },
 	): Promise<User | undefined> {
 		const user = await this.rpcClient.create(email, preferredLanguage, home)
-		this.current = user
+		this._current = user
 		if (user) this.writeCachedUserId(user.id)
 		return user
 	}
@@ -142,12 +152,12 @@ export class UserServiceClient implements IUserService {
 		// empty response patch the cached field locally rather than
 		// wiping `current` and losing the rest of the profile.
 		if (updated) {
-			this.current = updated
+			this._current = updated
 			this.writeCachedUserId(updated.id)
-		} else if (this.current) {
-			this.current = { ...this.current, home }
+		} else if (this._current) {
+			this._current = { ...this._current, home }
 		}
-		return this.current
+		return this._current
 	}
 
 	public async updatePreferredLanguage(
@@ -172,11 +182,11 @@ export class UserServiceClient implements IUserService {
 		// would break the rest of the session for everyone reading
 		// userService.current.
 		if (updated?.preferredLanguage) {
-			this.current = updated
-		} else if (this.current) {
-			this.current = { ...this.current, preferredLanguage }
+			this._current = updated
+		} else if (this._current) {
+			this._current = { ...this._current, preferredLanguage }
 		}
-		return this.current
+		return this._current
 	}
 
 	public async resendEmailVerification(): Promise<void> {
@@ -190,7 +200,7 @@ export class UserServiceClient implements IUserService {
 	// authenticated business code runs, the boot flow MUST have hydrated one
 	// of them via Create or Get.
 	private requireUserId(op: string): string {
-		const id = this.current?.id ?? this.readCachedUserId()
+		const id = this._current?.id ?? this.readCachedUserId()
 		if (!id) {
 			throw new Error(
 				`UserService.${op}: user_id is not available; auth bootstrap did not complete`,

--- a/src/services/user-service.ts
+++ b/src/services/user-service.ts
@@ -50,24 +50,33 @@ export class UserServiceClient implements IUserService {
 	private readonly authService = resolve(IAuthService)
 	private readonly storage = resolve(ILocalStorage)
 
-	// `_current` is the single source of truth for the authenticated user
-	// entity. Marked @observable so any view-model that reads it through
-	// `current` (e.g. SettingsRoute.currentLocale, SettingsRoute.currentHome
-	// getters) re-evaluates automatically when the entity changes — no
-	// component-local mirror state, no manual write-back. Every mutation
-	// method below assigns through `this._current = ...` so the notification
-	// fires exactly once per change.
+	// `current` is the single source of truth for the authenticated user
+	// entity. Marked @observable so any view-model that binds to
+	// `userService.current` (directly OR through a computed getter such as
+	// SettingsRoute.currentLocale / SettingsRoute.currentHome) re-evaluates
+	// automatically when the entity changes — no component-local mirror
+	// state, no manual write-back. Every mutation method below assigns
+	// through `this.current = ...` so the notification fires exactly once
+	// per change.
 	//
-	// The public `current` getter preserves the `readonly` encapsulation
-	// declared on IUserService: external consumers (even ones that
-	// inadvertently resolve the concrete class instead of the interface)
-	// cannot reassign the field. Internal mutation paths stay on
-	// `this._current` directly.
-	@observable private _current: User | undefined = undefined
-
-	public get current(): User | undefined {
-		return this._current
-	}
+	// Why a public @observable field and not `@observable private _current`
+	// + `public get current()`:
+	// Aurelia 2's expression observer subscribes to the property accessed
+	// in the binding AST. For a binding like `userService.current` it sets
+	// up an observer on the `current` member of the service instance. When
+	// `current` is a plain field, the @observable setter's synchronous
+	// notification is exactly the channel the observer subscribes to —
+	// reactivity is direct and predictable. When `current` is a *getter*
+	// that returns a separately-@observable `_current`, the observer would
+	// need to track the dependency through the getter body, which only
+	// works reliably for getters marked `@computed` and for objects under
+	// proxy observation; services injected via DI are not guaranteed to be
+	// proxied in every config. The encapsulation cost here is small — the
+	// `readonly` declaration on `IUserService.current` is the effective
+	// contract for every consumer that resolves via DI, since DI always
+	// returns the interface type. Production code never resolves the
+	// concrete class.
+	@observable public current: User | undefined = undefined
 
 	// Resolves the authenticated user via:
 	//   1. in-memory cache (already hydrated this session)
@@ -83,15 +92,15 @@ export class UserServiceClient implements IUserService {
 	public async ensureLoaded(
 		preferredLanguage: string,
 	): Promise<User | undefined> {
-		if (this._current) return this._current
+		if (this.current) return this.current
 
 		const userId = this.readCachedUserId()
 		if (userId) {
 			try {
 				this.logger.info('Loading user profile from backend (cache hit)')
-				this._current = await this.rpcClient.get(userId)
-				if (this._current) this.writeCachedUserId(this._current.id)
-				return this._current
+				this.current = await this.rpcClient.get(userId)
+				if (this.current) this.writeCachedUserId(this.current.id)
+				return this.current
 			} catch (err) {
 				if (err instanceof ConnectError && err.code === Code.PermissionDenied) {
 					this.logger.warn(
@@ -118,14 +127,14 @@ export class UserServiceClient implements IUserService {
 		// Create requires preferred_language; on the idempotent-return path the
 		// existing row's language is preserved, so passing the current effective
 		// locale is safe even for returning users.
-		this._current = await this.rpcClient.create(email, preferredLanguage)
-		if (this._current) this.writeCachedUserId(this._current.id)
-		return this._current
+		this.current = await this.rpcClient.create(email, preferredLanguage)
+		if (this.current) this.writeCachedUserId(this.current.id)
+		return this.current
 	}
 
 	public clear(): void {
 		this.removeCachedUserId()
-		this._current = undefined
+		this.current = undefined
 		this.logger.info('User profile cleared')
 	}
 
@@ -135,7 +144,7 @@ export class UserServiceClient implements IUserService {
 		home?: { countryCode: string; level1: string; level2?: string },
 	): Promise<User | undefined> {
 		const user = await this.rpcClient.create(email, preferredLanguage, home)
-		this._current = user
+		this.current = user
 		if (user) this.writeCachedUserId(user.id)
 		return user
 	}
@@ -152,12 +161,12 @@ export class UserServiceClient implements IUserService {
 		// empty response patch the cached field locally rather than
 		// wiping `current` and losing the rest of the profile.
 		if (updated) {
-			this._current = updated
+			this.current = updated
 			this.writeCachedUserId(updated.id)
-		} else if (this._current) {
-			this._current = { ...this._current, home }
+		} else if (this.current) {
+			this.current = { ...this.current, home }
 		}
-		return this._current
+		return this.current
 	}
 
 	public async updatePreferredLanguage(
@@ -182,11 +191,11 @@ export class UserServiceClient implements IUserService {
 		// would break the rest of the session for everyone reading
 		// userService.current.
 		if (updated?.preferredLanguage) {
-			this._current = updated
-		} else if (this._current) {
-			this._current = { ...this._current, preferredLanguage }
+			this.current = updated
+		} else if (this.current) {
+			this.current = { ...this.current, preferredLanguage }
 		}
-		return this._current
+		return this.current
 	}
 
 	public async resendEmailVerification(): Promise<void> {
@@ -200,7 +209,7 @@ export class UserServiceClient implements IUserService {
 	// authenticated business code runs, the boot flow MUST have hydrated one
 	// of them via Create or Get.
 	private requireUserId(op: string): string {
-		const id = this._current?.id ?? this.readCachedUserId()
+		const id = this.current?.id ?? this.readCachedUserId()
 		if (!id) {
 			throw new Error(
 				`UserService.${op}: user_id is not available; auth bootstrap did not complete`,

--- a/src/services/user-service.ts
+++ b/src/services/user-service.ts
@@ -1,5 +1,5 @@
 import { Code, ConnectError } from '@connectrpc/connect'
-import { DI, ILogger, resolve } from 'aurelia'
+import { DI, ILogger, observable, resolve } from 'aurelia'
 import { IUserRpcClient } from '../adapter/rpc/client/user-client'
 import { ILocalStorage } from '../adapter/storage/local-storage'
 import { userIdStorageKey } from '../constants/storage-keys'
@@ -50,11 +50,14 @@ export class UserServiceClient implements IUserService {
 	private readonly authService = resolve(IAuthService)
 	private readonly storage = resolve(ILocalStorage)
 
-	private _current: User | undefined = undefined
-
-	public get current(): User | undefined {
-		return this._current
-	}
+	// `current` is the single source of truth for the authenticated user
+	// entity. Marked @observable so any view-model that reads it through a
+	// computed getter (e.g. SettingsRoute.currentLocale,
+	// SettingsRoute.currentHome) re-evaluates automatically when the entity
+	// changes — no component-local mirror state, no manual write-back. Every
+	// mutation method below assigns through `this.current = ...` so the
+	// notification fires exactly once per change.
+	@observable public current: User | undefined = undefined
 
 	// Resolves the authenticated user via:
 	//   1. in-memory cache (already hydrated this session)
@@ -70,15 +73,15 @@ export class UserServiceClient implements IUserService {
 	public async ensureLoaded(
 		preferredLanguage: string,
 	): Promise<User | undefined> {
-		if (this._current) return this._current
+		if (this.current) return this.current
 
 		const userId = this.readCachedUserId()
 		if (userId) {
 			try {
 				this.logger.info('Loading user profile from backend (cache hit)')
-				this._current = await this.rpcClient.get(userId)
-				if (this._current) this.writeCachedUserId(this._current.id)
-				return this._current
+				this.current = await this.rpcClient.get(userId)
+				if (this.current) this.writeCachedUserId(this.current.id)
+				return this.current
 			} catch (err) {
 				if (err instanceof ConnectError && err.code === Code.PermissionDenied) {
 					this.logger.warn(
@@ -105,14 +108,14 @@ export class UserServiceClient implements IUserService {
 		// Create requires preferred_language; on the idempotent-return path the
 		// existing row's language is preserved, so passing the current effective
 		// locale is safe even for returning users.
-		this._current = await this.rpcClient.create(email, preferredLanguage)
-		if (this._current) this.writeCachedUserId(this._current.id)
-		return this._current
+		this.current = await this.rpcClient.create(email, preferredLanguage)
+		if (this.current) this.writeCachedUserId(this.current.id)
+		return this.current
 	}
 
 	public clear(): void {
 		this.removeCachedUserId()
-		this._current = undefined
+		this.current = undefined
 		this.logger.info('User profile cleared')
 	}
 
@@ -122,7 +125,7 @@ export class UserServiceClient implements IUserService {
 		home?: { countryCode: string; level1: string; level2?: string },
 	): Promise<User | undefined> {
 		const user = await this.rpcClient.create(email, preferredLanguage, home)
-		this._current = user
+		this.current = user
 		if (user) this.writeCachedUserId(user.id)
 		return user
 	}
@@ -137,14 +140,14 @@ export class UserServiceClient implements IUserService {
 		// Same write-through pattern as updatePreferredLanguage: on a
 		// populated response use the DB-authoritative entity; on an
 		// empty response patch the cached field locally rather than
-		// wiping `_current` and losing the rest of the profile.
+		// wiping `current` and losing the rest of the profile.
 		if (updated) {
-			this._current = updated
+			this.current = updated
 			this.writeCachedUserId(updated.id)
-		} else if (this._current) {
-			this._current = { ...this._current, home }
+		} else if (this.current) {
+			this.current = { ...this.current, home }
 		}
-		return this._current
+		return this.current
 	}
 
 	public async updatePreferredLanguage(
@@ -165,15 +168,15 @@ export class UserServiceClient implements IUserService {
 		// missing/empty (the mapper coerces proto3 default "" to undefined,
 		// which can happen on a partial proto migration or a misconfigured
 		// validator), patch the cached field locally with the value we
-		// successfully sent. Wiping _current with a stale/incomplete entity
+		// successfully sent. Wiping `current` with a stale/incomplete entity
 		// would break the rest of the session for everyone reading
 		// userService.current.
 		if (updated?.preferredLanguage) {
-			this._current = updated
-		} else if (this._current) {
-			this._current = { ...this._current, preferredLanguage }
+			this.current = updated
+		} else if (this.current) {
+			this.current = { ...this.current, preferredLanguage }
 		}
-		return this._current
+		return this.current
 	}
 
 	public async resendEmailVerification(): Promise<void> {
@@ -187,7 +190,7 @@ export class UserServiceClient implements IUserService {
 	// authenticated business code runs, the boot flow MUST have hydrated one
 	// of them via Create or Get.
 	private requireUserId(op: string): string {
-		const id = this._current?.id ?? this.readCachedUserId()
+		const id = this.current?.id ?? this.readCachedUserId()
 		if (!id) {
 			throw new Error(
 				`UserService.${op}: user_id is not available; auth bootstrap did not complete`,

--- a/test/routes/auth-callback-route.spec.ts
+++ b/test/routes/auth-callback-route.spec.ts
@@ -13,13 +13,13 @@ import type { createMockI18n } from '../helpers/mock-i18n'
 
 function createMockUserService() {
 	const stub = { id: 'u1', externalId: 'ext', email: 'u@test.com', name: 'U' }
+	// Mirrors UserServiceClient's public @observable `current` field shape.
+	// Tests assign to `current` directly to simulate the post-RPC entity
+	// state the production service write-throughs would produce.
 	const svc = {
-		_current: stub as unknown as
+		current: stub as unknown as
 			| import('../../src/entities/user').User
 			| undefined,
-		get current() {
-			return svc._current
-		},
 		create: vi.fn().mockResolvedValue(stub),
 		ensureLoaded: vi.fn().mockResolvedValue(stub),
 	}
@@ -236,11 +236,11 @@ describe('AuthCallbackRoute', () => {
 				// user whose stored language is 'en' — the guard
 				// ('en' !== 'ja') should fire setLocale('en').
 				mockUserService.ensureLoaded = vi.fn().mockImplementation(async () => {
-					mockUserService._current = {
+					mockUserService.current = {
 						id: 'u1',
 						preferredLanguage: 'en',
 					} as unknown as import('../../src/entities/user').User
-					return mockUserService._current
+					return mockUserService.current
 				})
 
 				const result = await sut.canLoad({}, {} as RouteNode)
@@ -256,11 +256,11 @@ describe('AuthCallbackRoute', () => {
 				// preferredLanguage matches the mock locale 'ja' — guard
 				// short-circuits and setLocale stays untouched.
 				mockUserService.ensureLoaded = vi.fn().mockImplementation(async () => {
-					mockUserService._current = {
+					mockUserService.current = {
 						id: 'u1',
 						preferredLanguage: 'ja',
 					} as unknown as import('../../src/entities/user').User
-					return mockUserService._current
+					return mockUserService.current
 				})
 
 				const result = await sut.canLoad({}, {} as RouteNode)
@@ -279,11 +279,11 @@ describe('AuthCallbackRoute', () => {
 				// fallbackLng with no bundle, leaving the UI blank) and log
 				// a warning instead.
 				mockUserService.ensureLoaded = vi.fn().mockImplementation(async () => {
-					mockUserService._current = {
+					mockUserService.current = {
 						id: 'u1',
 						preferredLanguage: 'fr',
 					} as unknown as import('../../src/entities/user').User
-					return mockUserService._current
+					return mockUserService.current
 				})
 
 				const result = await sut.canLoad({}, {} as RouteNode)

--- a/test/routes/settings-route.spec.ts
+++ b/test/routes/settings-route.spec.ts
@@ -115,10 +115,19 @@ describe('SettingsRoute', () => {
 			expect(sut.emailVerified).toBe(false)
 		})
 
-		it('sets currentHome from user service', async () => {
+		it('derives currentHome from userService.current.home (no loading() copy)', async () => {
+			// currentHome is a computed getter — set userService.current.home
+			// and the getter reflects it on next read. loading() is intentionally
+			// not required to surface the value (no local mirror).
 			mockUser.current = { id: 'user-uuid-1', home: { level1: 'JP-13' } }
-			await sut.loading()
 			expect(sut.currentHome).toBe('tokyo')
+		})
+
+		it('returns null currentHome when userService.current has no home', async () => {
+			// Authenticated route: no guest-storage fallback. If hydration has
+			// not populated home, the getter is null (UI renders 'Not set').
+			mockUser.current = { id: 'user-uuid-1' }
+			expect(sut.currentHome).toBeNull()
 		})
 
 		it('sets toggle OFF when permission is not granted', async () => {
@@ -230,25 +239,45 @@ describe('SettingsRoute', () => {
 		})
 	})
 
-	describe('loading — currentLocale', () => {
-		it('sets currentLocale from preferredLanguage when present', async () => {
+	describe('currentLocale getter', () => {
+		it('derives currentLocale from preferredLanguage when present', () => {
 			mockUser.current = { id: 'user-uuid-1', preferredLanguage: 'en' }
-			await sut.loading()
 			expect(sut.currentLocale).toBe('en')
 		})
 
-		it('falls back to i18n.getLocale() when preferredLanguage is absent', async () => {
-			mockUser.current = { id: 'user-uuid-1' } // no preferredLanguage
-			await sut.loading()
+		it('falls back to normalized i18n.getLocale() when preferredLanguage is absent', () => {
+			// Hydration race window: user row exists but preferred_language is
+			// NULL on the wire (legacy row pending backfill, or the
+			// UpdatePreferredLanguage RPC is still in flight). The getter
+			// must surface the active i18n locale rather than empty string —
+			// otherwise no selector option would highlight.
+			mockUser.current = { id: 'user-uuid-1' }
 			expect(sut.currentLocale).toBe('ja') // mock i18n default
+		})
+
+		it('reflects userService.current changes WITHOUT loading() re-run (single source of truth)', () => {
+			// Regression for the desync that mirrored state caused on
+			// 2026-05-25: changing the entity must be visible immediately
+			// through the getter, with no manual re-copy step.
+			mockUser.current = { id: 'user-uuid-1', preferredLanguage: 'ja' }
+			expect(sut.currentLocale).toBe('ja')
+			mockUser.current = { id: 'user-uuid-1', preferredLanguage: 'en' }
+			expect(sut.currentLocale).toBe('en')
 		})
 	})
 
 	describe('onHomeSelected', () => {
-		it('updates currentHome with translation key', () => {
+		it('is a notification-only handler — UserHomeSelector owns the userService.updateHome call', () => {
+			// The old behavior wrote `currentHome` directly here; that has
+			// moved into the derived getter. Calling onHomeSelected with
+			// arbitrary code must NOT mutate observable state — the only
+			// observable effect is a log line (asserted by absence of state
+			// change rather than positive assertion to avoid coupling to
+			// logger internals).
+			mockUser.current = { id: 'user-uuid-1' }
+			const before = sut.currentHome
 			sut.onHomeSelected('JP-13')
-			expect(sut.currentHome).toBeTruthy()
-			expect(sut.currentHome).not.toBe('JP-13') // translationKey maps to ISO name
+			expect(sut.currentHome).toBe(before)
 		})
 	})
 


### PR DESCRIPTION
## Summary

- **UserService**: `_current` (private + getter wrapper) → `@observable current` (public). Mutation methods assign through `this.current = ...` so the notification fires exactly once per change.
- **SettingsRoute**: drop the local mirror fields (`currentLocale`, `currentHome`). Replace with computed getters that derive from `userService.current` directly. Drop the manual `this.currentLocale = ...` write-back in `selectLanguage()`, the copy step in `loading()`, and the `UserHomeSelector.getStoredHome()` guest-flow fallback.
- **`onHomeSelected`** collapses to a notification-only handler (UserHomeSelector already owns the `userService.updateHome` call; the derived getter surfaces the result automatically).
- **Template**: inline `currentLocale === lang` in the selector's `if.bind` and `data-selected.bind`. `isCurrentLanguage()` helper removed.

## Why this matters (regression closed)

Discovered during prod verification of OpenSpec `persist-user-language` (issue #366): after a successful language change via Settings, reopening the selector still highlighted the OLD language even though the row text and the DB both reflected the new value. Aurelia's expression observer cannot track property accesses inside method bodies — the selector binding `if.bind="isCurrentLanguage(lang)"` never re-evaluated because the loop variable `lang` didn't change and the internal `this.currentLocale` access was opaque to the observer. The row binding worked because it referenced `currentLocale` directly in the AST.

The proper fix is structural, not cosmetic: the User entity already has a single source of truth (`UserService.current`). Settings was duplicating it into local fields and manually syncing — a `useState` pattern that is the explicit anti-pattern called out in Aurelia 2's reactivity docs ("Plain class property (auto-observed)" in service, computed getters in view). With this PR, mutation flows through the service, observation propagates automatically, and the desync class of bug is structurally impossible.

`currentHome` shared the anti-pattern plus a guest-storage fallback (`UserHomeSelector.getStoredHome()`) that has no business in an authenticated-only route — `GuestDataMergeService` already persists the guest selection to `user.home` via the Create RPC. Removing the fallback closes a silent regression-masker.

## Out of scope (follow-up PRs)

- `auth.user?.profile.email_verified` cast leakage in Settings — to be addressed by `expose claim-derived state on AuthService`. Preserved here with a pointer comment.
- The duplicated post-auth \`i18n.setLocale\` block in \`auth-callback-route\` vs \`user-hydration-task\` — same future PR.
- UserId localStorage cache adapter extraction — cosmetic.

## Test plan

- [x] \`make check\` (lint + 1080 tests + 7 scripts tests) PASS
- [x] New tests: getter derives from \`userService.current\` (fallback path + happy path + observable change-without-loading-rerun assertion as regression gate)
- [x] \`onHomeSelected\` no longer mutates state; UserHomeSelector keeps owning the write path
- [ ] Post-deploy: prod verification that selector check correctly tracks language changes after multiple toggles within the same session

Refs: #368