### PR TITLE
ci(deploy): guarantee a dev image for every main commit (build-or-inherit)

### DIFF
--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -137,19 +137,25 @@ jobs:
       #   * any build-relevant file changed -> build (produces a fresh image)
       #   * none changed                     -> inherit the parent tip's digest
       #     so this commit still gets a :<sha> image (byte-identical to parent).
-      # Unknown parent (zero `before` SHA on branch creation / force-push, or
-      # an unresolvable parent commit) -> build: the conservative choice that
-      # always produces a fresh image rather than risk a wrong inherit.
+      # Force-push and branch-creation are NOT inheritable and route to build:
+      #   * force-push: `github.event.before` is the previous, now-orphaned tip
+      #     (a real non-zero SHA, flagged by `github.event.forced == true`) that
+      #     is not necessarily an ancestor of the new tip.
+      #   * branch creation: `github.event.before` is the zero SHA
+      #     (`github.event.created == true`).
+      # An otherwise-unresolvable parent commit also defaults to build.
       - name: Decide build vs inherit (push path)
         if: github.event_name == 'push'
         id: decide
         env:
           BEFORE: ${{ github.event.before }}
           SHA: ${{ github.sha }}
+          FORCED: ${{ github.event.forced }}
+          CREATED: ${{ github.event.created }}
         run: |
           set -uo pipefail
-          if [ -z "${BEFORE}" ] || [ "${BEFORE}" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
-            echo "Parent commit unavailable (BEFORE=${BEFORE}); defaulting to build."
+          if [ "${FORCED}" = "true" ] || [ "${CREATED}" = "true" ] || [ -z "${BEFORE}" ] || [ "${BEFORE}" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+            echo "Force-push / branch-creation / unresolvable parent (forced=${FORCED} created=${CREATED} before=${BEFORE}) -> build."
             echo "mode=build" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -246,6 +252,10 @@ jobs:
           BEFORE: ${{ github.event.before }}
           SHA: ${{ github.sha }}
         run: |
+          # NOTE: -e is intentionally NOT set here — the resolve() calls below
+          # are expected to return non-zero on a missing tag (that drives the
+          # :main fallback), and `digest=$(resolve ...)` would abort under -e.
+          # -e is enabled explicitly just before the crane copy sequence.
           set -uo pipefail
           resolve() { gcloud artifacts docker images describe "$1" --format='value(image_summary.digest)' 2>/dev/null; }
           # The parent push tip (event.before) has a :<sha> image by induction.
@@ -259,6 +269,8 @@ jobs:
             exit 1
           fi
           echo "Inheriting digest ${digest} onto :${SHA}, :main, :latest."
+          # Abort immediately if any of the three retags fails.
+          set -e
           crane copy "${DEV_AR_IMAGE}@${digest}" "${DEV_AR_IMAGE}:${SHA}"
           crane copy "${DEV_AR_IMAGE}@${digest}" "${DEV_AR_IMAGE}:main"
           crane copy "${DEV_AR_IMAGE}@${digest}" "${DEV_AR_IMAGE}:latest"

--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -1,7 +1,13 @@
 name: Deploy Frontend
 
 # Dual trigger:
-#  - push to main      -> dev build, dev AR (liverty-music-dev/frontend)
+#  - push to main      -> dev AR (liverty-music-dev/frontend). Every push to
+#                         main runs this workflow (no paths: trigger gate). A
+#                         per-run "build vs inherit" decision over the pushed
+#                         range (event.before..sha) picks build (docker
+#                         build-push) or inherit (crane-copy the parent tip's
+#                         dev digest onto :<sha>, re-point :main/:latest — used
+#                         when the push changed no build-relevant file).
 #  - release published -> retag dev AR digest into prod AR
 #                         (liverty-music-prod/frontend)
 #
@@ -14,22 +20,16 @@ name: Deploy Frontend
 # image divergence) that the env-agnostic bundle (per
 # `adopt-runtime-config-for-frontend`) made obsolete.
 #
-# The `paths:` filter only applies to push events. Release events fire on
-# any published Release regardless of file diff.
+# Per OpenSpec change `guarantee-dev-image-per-main-commit`, the `paths:`
+# trigger gate was removed so EVERY main commit gets a resolvable dev
+# `:<sha>` image (by build or by parent-digest inheritance). This makes
+# "any main commit is releasable" a true invariant: a release cut on main
+# HEAD always resolves a dev image. The former glob set now drives the
+# in-workflow build-vs-inherit decision instead of gating the trigger.
 on:
   push:
     branches:
       - main
-    paths:
-      - 'src/**'
-      - 'public/**'
-      - 'scripts/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'vite.config.ts'
-      - 'Dockerfile'
-      - 'Caddyfile'
-      - '.github/workflows/push-image.yaml'
   release:
     types: [published]
   workflow_dispatch:
@@ -78,6 +78,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Full history so the push-path "build vs inherit" decision can
+          # diff the pushed range (event.before..sha), and so the release
+          # path's ancestry verification has main's history available.
+          fetch-depth: 0
 
       # Defensive guard layer 2 (runtime verification): for release events,
       # confirm the checked-out commit (`github.sha`, == the tag's commit)
@@ -96,7 +101,7 @@ jobs:
         run: |
           git fetch origin main --depth=100
           if ! git merge-base --is-ancestor HEAD origin/main; then
-            echo "::error::Release tag at $(git rev-parse HEAD) is not reachable from origin/main ($(git rev-parse origin/main)). Refusing to push prod images. Cut releases on main HEAD only."
+            echo "::error::Release tag at $(git rev-parse HEAD) is not reachable from origin/main ($(git rev-parse origin/main)). Refusing to push prod images. Cut releases on a commit reachable from main — main HEAD is always valid, since every main commit has a resolvable dev image (guarantee-dev-image-per-main-commit)."
             exit 1
           fi
 
@@ -123,18 +128,55 @@ jobs:
       - name: Configure Docker
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev
 
-      - name: Set Image URI (dev path)
+      # =====================================================================
+      # Push path: decide build vs inherit
+      # =====================================================================
+      # The `paths:` trigger gate was removed (guarantee-dev-image-per-main-commit)
+      # so every push to main runs this workflow. Replicate the former glob set
+      # as an in-workflow decision over the pushed range event.before..sha:
+      #   * any build-relevant file changed -> build (produces a fresh image)
+      #   * none changed                     -> inherit the parent tip's digest
+      #     so this commit still gets a :<sha> image (byte-identical to parent).
+      # Unknown parent (zero `before` SHA on branch creation / force-push, or
+      # an unresolvable parent commit) -> build: the conservative choice that
+      # always produces a fresh image rather than risk a wrong inherit.
+      - name: Decide build vs inherit (push path)
         if: github.event_name == 'push'
+        id: decide
+        env:
+          BEFORE: ${{ github.event.before }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -uo pipefail
+          if [ -z "${BEFORE}" ] || [ "${BEFORE}" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+            echo "Parent commit unavailable (BEFORE=${BEFORE}); defaulting to build."
+            echo "mode=build" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed=$(git diff --name-only "${BEFORE}" "${SHA}")
+          echo "Changed files in ${BEFORE}..${SHA}:"
+          echo "${changed}"
+          # Build glob set (kept in lock-step with the prior `on.push.paths`).
+          if echo "${changed}" | grep -qE '^src/|^public/|^scripts/|^package\.json$|^package-lock\.json$|^vite\.config\.ts$|^Dockerfile$|^Caddyfile$|^\.github/workflows/push-image\.yaml$'; then
+            echo "Build-relevant change detected -> build."
+            echo "mode=build" >> "$GITHUB_OUTPUT"
+          else
+            echo "No build-relevant change -> inherit parent digest."
+            echo "mode=inherit" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set Image URI (dev path)
+        if: github.event_name == 'push' && steps.decide.outputs.mode == 'build'
         run: echo "IMAGE_URI=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE }}" >> $GITHUB_ENV
 
       # Dev tag set: :latest (consumed by ArgoCD Image Updater for dev
       # auto-rollout) + :sha (immutable digest pointer) + :main.
       - name: Set Image Tags (dev path)
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && steps.decide.outputs.mode == 'build'
         run: echo "IMAGE_TAGS=${{ env.IMAGE_URI }}:latest,${{ env.IMAGE_URI }}:${{ github.sha }},${{ env.IMAGE_URI }}:main" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && steps.decide.outputs.mode == 'build'
         uses: docker/setup-buildx-action@v3
 
       # No env-specific build-args: per OpenSpec archive
@@ -145,7 +187,7 @@ jobs:
       # template-stripping regressions (the class of bug that produced
       # the v1.0.0 blank-screen Sev-1).
       - name: Build and Push Docker Image
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && steps.decide.outputs.mode == 'build'
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -188,8 +230,38 @@ jobs:
       # Auth: `crane` reads `~/.docker/config.json` populated by the
       # `Configure Docker` step above.
       - name: Install crane
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || (github.event_name == 'push' && steps.decide.outputs.mode == 'inherit')
         uses: imjasonh/setup-crane@v0.4
+
+      # =====================================================================
+      # Push/inherit path: this commit changed nothing build-relevant, so its
+      # image is byte-identical to the parent push tip's. Copy the parent's
+      # digest onto :<sha> (and re-point :main, :latest) — no rebuild. This
+      # keeps the "every main commit has a resolvable dev :<sha>" invariant.
+      # =====================================================================
+      - name: Inherit parent dev AR digest (push path, no rebuild)
+        if: github.event_name == 'push' && steps.decide.outputs.mode == 'inherit'
+        env:
+          DEV_AR_IMAGE: ${{ env.REGION }}-docker.pkg.dev/liverty-music-dev/${{ env.REPOSITORY }}/${{ env.IMAGE }}
+          BEFORE: ${{ github.event.before }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -uo pipefail
+          resolve() { gcloud artifacts docker images describe "$1" --format='value(image_summary.digest)' 2>/dev/null; }
+          # The parent push tip (event.before) has a :<sha> image by induction.
+          digest=$(resolve "${DEV_AR_IMAGE}:${BEFORE}")
+          if [ -z "${digest}" ]; then
+            echo "Parent :${BEFORE} not resolvable; falling back to the :main tag digest."
+            digest=$(resolve "${DEV_AR_IMAGE}:main")
+          fi
+          if [ -z "${digest}" ]; then
+            echo "::error::Cannot resolve a parent dev image for ${DEV_AR_IMAGE} (tried :${BEFORE} and :main). The inherit chain is broken. Seed it by pushing a build-relevant change (any src/** / package.json / Dockerfile) to main, which forces a fresh build. Not writing :${SHA} to avoid pinning a wrong digest."
+            exit 1
+          fi
+          echo "Inheriting digest ${digest} onto :${SHA}, :main, :latest."
+          crane copy "${DEV_AR_IMAGE}@${digest}" "${DEV_AR_IMAGE}:${SHA}"
+          crane copy "${DEV_AR_IMAGE}@${digest}" "${DEV_AR_IMAGE}:main"
+          crane copy "${DEV_AR_IMAGE}@${digest}" "${DEV_AR_IMAGE}:latest"
 
       - name: Resolve dev AR digest for github.sha
         if: github.event_name == 'release'
@@ -218,7 +290,7 @@ jobs:
               sleep 60
             fi
           done
-          echo "::error::dev AR tag :${GITHUB_SHA} not found after 6 attempts (~5 min total wait). Either the dev build for this commit failed, or the release was cut on a non-main commit. See docs/runbooks/prod-image-tag-pinning.md#retag-failure-recovery in cloud-provisioning."
+          echo "::error::dev AR tag :${GITHUB_SHA} not found after 6 attempts (~5 min total wait). Given the every-main-commit-has-an-image invariant (guarantee-dev-image-per-main-commit), the push-path build/inherit for this commit is still in-flight or failed — do NOT re-target an earlier commit; re-run the push-path 'Deploy Frontend' run for this SHA. See docs/runbooks/prod-image-tag-pinning.md#retag-failure-recovery in cloud-provisioning."
           exit 1
 
       - name: Promote dev AR digest to prod AR (semver tag)

--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -264,10 +264,13 @@ jobs:
           # Errors are classified like the release-path resolve (auth -> fail
           # fast; transient -> retry; NOT_FOUND -> chain-broken) so an IAM/5xx
           # failure is not misreported as a "seed the chain" instruction. -e
-          # is enabled only around the crane copies.
-          set -uo pipefail
+          # is safe to keep on throughout: every gcloud call is guarded by
+          # `|| rc=$?` or sits inside an `if`, so a non-zero resolve does not
+          # abort the step.
+          set -euo pipefail
           stderr_file=$(mktemp)
           digest=""
+          body=""
           for attempt in $(seq 1 3); do
             rc=0
             digest=$(gcloud artifacts docker images describe "${DEV_AR_IMAGE}:${BEFORE}" \
@@ -286,12 +289,12 @@ jobs:
           done
           rm -f "$stderr_file"
           if [ -z "${digest}" ]; then
-            echo "::error::Cannot resolve parent dev image ${DEV_AR_IMAGE}:${BEFORE} after 3 attempts. The inherit chain is broken — the parent push failed or never wrote :${BEFORE}. Seed by pushing a build-relevant change (any src/** / package.json / Dockerfile) to main to force a fresh build, then re-cut the release on the new HEAD. Not writing :${SHA} to avoid pinning a wrong digest."
+            echo "::error::Cannot resolve parent dev image ${DEV_AR_IMAGE}:${BEFORE} after 3 attempts. The inherit chain is broken — the parent push failed or never wrote :${BEFORE}. Seed by pushing a build-relevant change (any src/** / package.json / Dockerfile) to main to force a fresh build, then re-cut the release on the new HEAD. Not writing :${SHA} to avoid pinning a wrong digest. Last gcloud stderr: ${body}"
             exit 1
           fi
           echo "Inheriting digest ${digest} onto :${SHA}, :main, :latest."
-          # Abort immediately if any of the three retags fails.
-          set -e
+          # -e (set at the top of this step) aborts immediately if any of the
+          # three retags fails.
           crane copy "${DEV_AR_IMAGE}@${digest}" "${DEV_AR_IMAGE}:${SHA}"
           crane copy "${DEV_AR_IMAGE}@${digest}" "${DEV_AR_IMAGE}:main"
           crane copy "${DEV_AR_IMAGE}@${digest}" "${DEV_AR_IMAGE}:latest"

--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -287,9 +287,10 @@ jobs:
               sleep 20
             fi
           done
+          final_stderr=$(cat "$stderr_file" 2>/dev/null || echo "(no stderr captured)")
           rm -f "$stderr_file"
           if [ -z "${digest}" ]; then
-            echo "::error::Cannot resolve parent dev image ${DEV_AR_IMAGE}:${BEFORE} after 3 attempts. The inherit chain is broken — the parent push failed or never wrote :${BEFORE}. Seed by pushing a build-relevant change (any src/** / package.json / Dockerfile) to main to force a fresh build, then re-cut the release on the new HEAD. Not writing :${SHA} to avoid pinning a wrong digest. Last gcloud stderr: ${body}"
+            echo "::error::Cannot resolve parent dev image ${DEV_AR_IMAGE}:${BEFORE} after 3 attempts. The inherit chain is broken — the parent push failed or never wrote :${BEFORE}. Seed by pushing a build-relevant change (any src/** / package.json / Dockerfile) to main to force a fresh build, then re-cut the release on the new HEAD. Not writing :${SHA} to avoid pinning a wrong digest. Last gcloud stderr: ${final_stderr}"
             exit 1
           fi
           echo "Inheriting digest ${digest} onto :${SHA}, :main, :latest."

--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -252,20 +252,41 @@ jobs:
           BEFORE: ${{ github.event.before }}
           SHA: ${{ github.sha }}
         run: |
-          # NOTE: -e is intentionally NOT set here — the resolve() calls below
-          # are expected to return non-zero on a missing tag (that drives the
-          # :main fallback), and `digest=$(resolve ...)` would abort under -e.
-          # -e is enabled explicitly just before the crane copy sequence.
+          # Resolve ONLY the parent push tip's digest (event.before). By
+          # induction + the `concurrency` serialization, :<before> exists in
+          # steady state. There is deliberately NO fallback to :main or any
+          # other tag: it would only fire when :<before> is missing (parent
+          # run FAILED), and in that gapped state :main can point at an older
+          # commit whose tree differs — inheriting it would pin non-equivalent
+          # bytes onto :<sha> and silently ship the wrong bundle to prod. A
+          # missing :<before> means the chain is genuinely broken -> fail loud.
+          #
+          # Errors are classified like the release-path resolve (auth -> fail
+          # fast; transient -> retry; NOT_FOUND -> chain-broken) so an IAM/5xx
+          # failure is not misreported as a "seed the chain" instruction. -e
+          # is enabled only around the crane copies.
           set -uo pipefail
-          resolve() { gcloud artifacts docker images describe "$1" --format='value(image_summary.digest)' 2>/dev/null; }
-          # The parent push tip (event.before) has a :<sha> image by induction.
-          digest=$(resolve "${DEV_AR_IMAGE}:${BEFORE}")
+          stderr_file=$(mktemp)
+          digest=""
+          for attempt in $(seq 1 3); do
+            rc=0
+            digest=$(gcloud artifacts docker images describe "${DEV_AR_IMAGE}:${BEFORE}" \
+              --format='value(image_summary.digest)' 2>"$stderr_file") || rc=$?
+            if [ "$rc" -eq 0 ] && [ -n "$digest" ]; then break; fi
+            body=$(cat "$stderr_file")
+            if echo "$body" | grep -qE 'PERMISSION_DENIED|Permission .* denied|HTTPError 403|403 Forbidden|UNAUTHENTICATED|401'; then
+              echo "::error::Auth failure resolving ${DEV_AR_IMAGE}:${BEFORE} (dev AR read) — NOT a missing-tag/chain problem. Check the dev build service account's AR read access. stderr: ${body}"
+              rm -f "$stderr_file"; exit 1
+            fi
+            digest=""
+            if [ "$attempt" -lt 3 ]; then
+              echo "Attempt ${attempt}/3: ${DEV_AR_IMAGE}:${BEFORE} not resolvable yet (${body}); retrying in 20s..."
+              sleep 20
+            fi
+          done
+          rm -f "$stderr_file"
           if [ -z "${digest}" ]; then
-            echo "Parent :${BEFORE} not resolvable; falling back to the :main tag digest."
-            digest=$(resolve "${DEV_AR_IMAGE}:main")
-          fi
-          if [ -z "${digest}" ]; then
-            echo "::error::Cannot resolve a parent dev image for ${DEV_AR_IMAGE} (tried :${BEFORE} and :main). The inherit chain is broken. Seed it by pushing a build-relevant change (any src/** / package.json / Dockerfile) to main, which forces a fresh build. Not writing :${SHA} to avoid pinning a wrong digest."
+            echo "::error::Cannot resolve parent dev image ${DEV_AR_IMAGE}:${BEFORE} after 3 attempts. The inherit chain is broken — the parent push failed or never wrote :${BEFORE}. Seed by pushing a build-relevant change (any src/** / package.json / Dockerfile) to main to force a fresh build, then re-cut the release on the new HEAD. Not writing :${SHA} to avoid pinning a wrong digest."
             exit 1
           fi
           echo "Inheriting digest ${digest} onto :${SHA}, :main, :latest."


### PR DESCRIPTION
## Summary

Per OpenSpec `guarantee-dev-image-per-main-commit` (spec liverty-music/specification#536). Symmetric with backend liverty-music/backend#314.

- Drop the `paths:` trigger gate — every push to `main` runs the workflow.
- **Decide build vs inherit** by diffing `event.before..sha` against the build glob set.
- **Inherit path**: when no build-relevant file changed, `crane copy` the parent tip's `web-app` digest onto `:<sha>` and re-point `:main`/`:latest` — no rebuild (byte-identical to parent).
- Align the release digest-resolve + on-main guidance with the invariant; `fetch-depth: 0` for the range diff. `workflow_dispatch` + smoke job unchanged.

## Notes

- The deploy workflow runs on push-to-main / release, **not** on PRs, so PR CI does not exercise the new logic. First real run is the post-merge build (which self-seeds HEAD's image, since editing this file matches the build globs).
- Live verification of the inherit path uses dev AR (registry, up); dev-cluster ArgoCD checks are deferred while dev is stopped.

close: #376