### PR TITLE
feat(analytics): AnalyticsService runtime + page-view emission (Batch 3a)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
 				"i18next-browser-languagedetector": "^8.2.1",
 				"matter-js": "^0.20.0",
 				"oidc-client-ts": "^3.4.1",
+				"posthog-js": "^1.376.4",
 				"qrcode": "^1.5.4",
 				"snarkjs": "^0.7.6",
 				"workbox-background-sync": "^7.4.0"
@@ -3160,6 +3161,52 @@
 				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
+		"node_modules/@opentelemetry/exporter-logs-otlp-http": {
+			"version": "0.208.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.208.0.tgz",
+			"integrity": "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api-logs": "0.208.0",
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/otlp-exporter-base": "0.208.0",
+				"@opentelemetry/otlp-transformer": "0.208.0",
+				"@opentelemetry/sdk-logs": "0.208.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/api-logs": {
+			"version": "0.208.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+			"integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/core": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+			"integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
 		"node_modules/@opentelemetry/instrumentation": {
 			"version": "0.212.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.212.0.tgz",
@@ -3195,6 +3242,118 @@
 				"@opentelemetry/api": "^1.3.0"
 			}
 		},
+		"node_modules/@opentelemetry/otlp-exporter-base": {
+			"version": "0.208.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
+			"integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/otlp-transformer": "0.208.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+			"integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/otlp-transformer": {
+			"version": "0.208.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
+			"integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api-logs": "0.208.0",
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/resources": "2.2.0",
+				"@opentelemetry/sdk-logs": "0.208.0",
+				"@opentelemetry/sdk-metrics": "2.2.0",
+				"@opentelemetry/sdk-trace-base": "2.2.0",
+				"protobufjs": "^7.3.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/api-logs": {
+			"version": "0.208.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+			"integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+			"integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+			"integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+			"integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/resources": "2.2.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
 		"node_modules/@opentelemetry/resources": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.1.tgz",
@@ -3202,6 +3361,113 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "2.5.1",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-logs": {
+			"version": "0.208.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
+			"integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api-logs": "0.208.0",
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/resources": "2.2.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.4.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/api-logs": {
+			"version": "0.208.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+			"integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+			"integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+			"integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-metrics": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
+			"integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/resources": "2.2.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.9.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+			"integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+			"integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.2.0",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
@@ -3279,6 +3545,84 @@
 			"engines": {
 				"node": ">=18"
 			}
+		},
+		"node_modules/@posthog/core": {
+			"version": "1.29.13",
+			"resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.29.13.tgz",
+			"integrity": "sha512-7Me5zaeAue/wmA364Go8ChYbsVAfNAHbtDxXopWu3D6hq9PVScUcauRgjD1njgvP8NzN91SrIllE+pri3XvJVw==",
+			"license": "MIT",
+			"dependencies": {
+				"@posthog/types": "1.376.4"
+			}
+		},
+		"node_modules/@posthog/types": {
+			"version": "1.376.4",
+			"resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.376.4.tgz",
+			"integrity": "sha512-EoDEvA925lf6yxPpbP4wozlXgu4b9WEqxZlFBUDd4k2akP5R/RWyHpvQT8aYyfY6BtSLn8TnVwxPQOM4b90isA==",
+			"license": "MIT"
+		},
+		"node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/codegen": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+			"integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/fetch": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+			"integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1"
+			}
+		},
+		"node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/inquire": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+			"integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/utf8": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+			"integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@rollup/plugin-babel": {
 			"version": "5.3.1",
@@ -4060,7 +4404,6 @@
 			"version": "22.19.8",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.8.tgz",
 			"integrity": "sha512-ebO/Yl+EAvVe8DnMfi+iaAyIqYdK0q/q0y0rw82INWEKJOBe6b/P3YWE8NW7oOlF/nXFNrHwhARrN/hdgDkraA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.21.0"
@@ -4087,7 +4430,7 @@
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
 			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/@vitest/coverage-v8": {
@@ -5245,6 +5588,17 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/core-js": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+			"integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/core-js"
+			}
+		},
 		"node_modules/core-js-compat": {
 			"version": "3.48.0",
 			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.48.0.tgz",
@@ -5753,6 +6107,15 @@
 				"url": "https://bevry.me/fund"
 			}
 		},
+		"node_modules/dompurify": {
+			"version": "3.4.7",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
+			"integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
+			"license": "(MPL-2.0 OR Apache-2.0)",
+			"optionalDependencies": {
+				"@types/trusted-types": "^2.0.7"
+			}
+		},
 		"node_modules/dunder-proto": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -6224,6 +6587,12 @@
 				"wasmcurves": "0.2.2",
 				"web-worker": "1.2.0"
 			}
+		},
+		"node_modules/fflate": {
+			"version": "0.4.8",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+			"integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+			"license": "MIT"
 		},
 		"node_modules/filelist": {
 			"version": "1.0.4",
@@ -7911,6 +8280,12 @@
 			"integrity": "sha512-jLlHnlsPSJjpwUfcNyUxXCl33AYg2cHhIf9QhGL2T4iPT0XPB+xP1LRKFPgIg1M/sg9kAJvy94w9CzBNrfnstA==",
 			"license": "MIT"
 		},
+		"node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"license": "Apache-2.0"
+		},
 		"node_modules/loupe": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -8768,6 +9143,49 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/posthog-js": {
+			"version": "1.376.4",
+			"resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.376.4.tgz",
+			"integrity": "sha512-SGhZWMBpd9GyV1+Klhx/vRwyy/reRRpJGYc1n1rYG9+LAML/YUEIrfl3Y2CLvuwmhKbPVY5W98Z7pAVQ88Qf1A==",
+			"license": "SEE LICENSE IN LICENSE",
+			"dependencies": {
+				"@opentelemetry/api": "^1.9.0",
+				"@opentelemetry/api-logs": "^0.208.0",
+				"@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
+				"@opentelemetry/resources": "^2.2.0",
+				"@opentelemetry/sdk-logs": "^0.208.0",
+				"@posthog/core": "1.29.13",
+				"@posthog/types": "1.376.4",
+				"core-js": "^3.38.1",
+				"dompurify": "^3.3.2",
+				"fflate": "^0.4.8",
+				"preact": "^10.28.2",
+				"query-selector-shadow-dom": "^1.0.1",
+				"web-vitals": "^5.1.0"
+			}
+		},
+		"node_modules/posthog-js/node_modules/@opentelemetry/api-logs": {
+			"version": "0.208.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+			"integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/preact": {
+			"version": "10.29.2",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+			"integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/preact"
+			}
+		},
 		"node_modules/pretty-bytes": {
 			"version": "6.1.1",
 			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
@@ -8825,6 +9243,30 @@
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/protobufjs": {
+			"version": "7.6.1",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
+			"integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.5",
+				"@protobufjs/eventemitter": "^1.1.1",
+				"@protobufjs/fetch": "^1.1.1",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/inquire": "^1.1.2",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.1",
+				"@types/node": ">=13.7.0",
+				"long": "^5.3.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
 		},
 		"node_modules/public-encrypt": {
 			"version": "4.0.3",
@@ -8903,6 +9345,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/query-selector-shadow-dom": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+			"integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+			"license": "MIT"
 		},
 		"node_modules/querystring-es3": {
 			"version": "0.2.1",
@@ -10789,7 +11237,6 @@
 			"version": "6.21.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
 			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/unicode-canonical-property-names-ecmascript": {
@@ -12537,6 +12984,12 @@
 			"dependencies": {
 				"wasmbuilder": "0.0.16"
 			}
+		},
+		"node_modules/web-vitals": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+			"integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/web-worker": {
 			"version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"i18next-browser-languagedetector": "^8.2.1",
 		"matter-js": "^0.20.0",
 		"oidc-client-ts": "^3.4.1",
+		"posthog-js": "^1.376.4",
 		"qrcode": "^1.5.4",
 		"snarkjs": "^0.7.6",
 		"workbox-background-sync": "^7.4.0"

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -1,5 +1,6 @@
 import { IRouter, IRouterEvents, route } from '@aurelia/router'
 import { type IDisposable, ILogger, resolve } from 'aurelia'
+import { Events, IAnalyticsService } from './lib/analytics/analytics-service'
 import { IAuthService } from './services/auth-service'
 import { IErrorBoundaryService } from './services/error-boundary-service'
 import { IOnboardingService } from './services/onboarding-service'
@@ -78,6 +79,7 @@ export class AppShell {
 	public readonly auth = resolve(IAuthService)
 	public readonly onboarding = resolve(IOnboardingService)
 	private readonly errorBoundary = resolve(IErrorBoundaryService)
+	private readonly analytics = resolve(IAnalyticsService)
 	private readonly logger = resolve(ILogger).scopeTo('AppShell')
 
 	private readonly subscriptions: IDisposable[] = []
@@ -121,6 +123,25 @@ export class AppShell {
 				).instructions
 				const name = instruction?.[0]?.component?.name ?? 'unknown'
 				this.errorBoundary.addBreadcrumb('navigation', name)
+
+				// Analytics page-view emission. PII discipline (see
+				// services/analytics-events.ts lines 51–72):
+				//   - path: window.location.pathname ONLY. Never include
+				//     `.search` (the auth/callback route carries OIDC
+				//     `code` / `state` tokens there) or `.hash`. The
+				//     router updates window.location synchronously
+				//     before publishing navigation-end, so reading
+				//     `pathname` here is the live value for the just-
+				//     completed navigation.
+				//   - title: read from document.title which the router
+				//     has already set from the static `title:` on each
+				//     route definition. This is the static label, not
+				//     anything derived from a query string or user input,
+				//     so it is safe to forward to PostHog.
+				const path =
+					typeof window !== 'undefined' ? window.location.pathname : ''
+				const title = typeof document !== 'undefined' ? document.title : ''
+				this.analytics.capture(Events.PageViewed, { path, title })
 			}),
 		)
 	}

--- a/src/config/app-config.ts
+++ b/src/config/app-config.ts
@@ -22,6 +22,23 @@ export interface AppConfig {
 	readonly previewArtistIds: readonly string[]
 	readonly previewArtistNames: readonly string[]
 	readonly logLevel: 'trace' | 'debug' | 'info' | 'warn' | 'error'
+	/**
+	 * PostHog Cloud EU ingestion host. Optional — when omitted the
+	 * AnalyticsService falls back to the EU default
+	 * (`https://eu.i.posthog.com`). Kept independent from
+	 * `posthogProjectKey` so a future regional override can flip the host
+	 * without forcing a key rotation.
+	 */
+	readonly posthogApiHost?: string
+	/**
+	 * PostHog public project API key. Optional — when omitted (or empty)
+	 * the AnalyticsService runs in nil-config mode: no SDK init, no
+	 * network calls, every capture is debug-logged and dropped. Mirrors
+	 * the backend's `client == nil` posture so missing analytics never
+	 * breaks the product surface. The cloud-provisioning ConfigMap that
+	 * serves `/config.json` will populate this in a follow-up PR.
+	 */
+	readonly posthogProjectKey?: string
 }
 
 export const IAppConfig = DI.createInterface<AppConfig>('IAppConfig')
@@ -134,6 +151,14 @@ function validateAppConfig(parsed: unknown): AppConfig {
 		)
 	}
 
+	// posthogApiHost / posthogProjectKey are optional and absent from
+	// every existing ConfigMap until cloud-provisioning's follow-up PR
+	// lands. `readOptionalString` returns undefined (not '') for missing
+	// keys so AnalyticsService can distinguish "not yet configured" from
+	// "explicitly disabled".
+	const posthogApiHost = readOptionalString(o, 'posthogApiHost')
+	const posthogProjectKey = readOptionalString(o, 'posthogProjectKey')
+
 	return {
 		environment: env as AppConfig['environment'],
 		apiBaseUrl: requireString(o, 'apiBaseUrl'),
@@ -149,6 +174,8 @@ function validateAppConfig(parsed: unknown): AppConfig {
 		previewArtistIds,
 		previewArtistNames,
 		logLevel: logLevel as AppConfig['logLevel'],
+		...(posthogApiHost !== undefined ? { posthogApiHost } : {}),
+		...(posthogProjectKey !== undefined ? { posthogProjectKey } : {}),
 	}
 }
 
@@ -163,6 +190,27 @@ function requireString(o: Record<string, unknown>, key: string): string {
 function optionalString(o: Record<string, unknown>, key: string): string {
 	const v = o[key]
 	if (v === undefined || v === null) return ''
+	if (typeof v !== 'string') {
+		throw new Error(`config.json field '${key}' must be a string`)
+	}
+	return v
+}
+
+/**
+ * Returns `undefined` when the key is absent or null; rejects
+ * non-string values loudly so a malformed ConfigMap surfaces during
+ * boot rather than at first analytics call. Empty string is preserved
+ * as-is — AnalyticsService treats `''` and `undefined` identically for
+ * the nil-config gate, but keeping the distinction here lets a future
+ * inspector tell "the key is set to empty deliberately" from "the key
+ * was forgotten" in the wild config dump.
+ */
+function readOptionalString(
+	o: Record<string, unknown>,
+	key: string,
+): string | undefined {
+	const v = o[key]
+	if (v === undefined || v === null) return undefined
 	if (typeof v !== 'string') {
 		throw new Error(`config.json field '${key}' must be a string`)
 	}

--- a/src/lib/analytics/analytics-service.spec.ts
+++ b/src/lib/analytics/analytics-service.spec.ts
@@ -1,0 +1,311 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppConfig } from '../../config/app-config'
+import { Events } from '../../services/analytics-events'
+
+// ── PostHog SDK mock ───────────────────────────────────────────────────────
+//
+// `import('posthog-js')` is awaited inside AnalyticsService.init(). Vitest
+// resolves the dynamic import against this `vi.mock` so no real SDK code
+// (and no network) runs. We expose the captured init args + a per-test
+// resettable spy bag via the module's `default` export, matching the
+// shape AnalyticsService consumes (`module.default.init/capture/...`).
+
+const posthogStub = {
+	init: vi.fn(),
+	capture: vi.fn(),
+	identify: vi.fn(),
+	reset: vi.fn(),
+	getFeatureFlag: vi.fn(),
+}
+
+vi.mock('posthog-js', () => ({
+	default: posthogStub,
+}))
+
+// ── OpenTelemetry mock ─────────────────────────────────────────────────────
+//
+// AnalyticsService calls `trace.getActiveSpan()` at every dispatch. The
+// span return value is controlled per-test via `setActiveSpanForTest()`
+// so we can cover the "trace_id injected" and "trace_id omitted" branches
+// without standing up a real tracer provider.
+
+let activeSpan:
+	| {
+			spanContext: () => { traceId: string; spanId: string; traceFlags: number }
+	  }
+	| undefined
+
+function setActiveSpan(traceId: string | undefined): void {
+	activeSpan =
+		traceId === undefined
+			? undefined
+			: {
+					spanContext: () => ({ traceId, spanId: 'abc', traceFlags: 1 }),
+				}
+}
+
+vi.mock('@opentelemetry/api', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@opentelemetry/api')>()
+	return {
+		...actual,
+		trace: {
+			...actual.trace,
+			getActiveSpan: () => activeSpan,
+		},
+	}
+})
+
+// ── Aurelia DI mock ────────────────────────────────────────────────────────
+//
+// Same `friendlyName`-keyed resolver stub the existing `concert-service`
+// spec uses. `config` and `consent` are mutated per-test via the
+// references captured below, so the SUT sees the runtime values selected
+// by the test without re-instantiating the mock map.
+
+const mockLogger = {
+	scopeTo: () => ({
+		trace: vi.fn(),
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	}),
+}
+
+const mockConfig: { current: Partial<AppConfig> } = {
+	current: { posthogProjectKey: 'phc_test_key' },
+}
+
+const mockConsent: { analytics: boolean; marketingMeasurement: boolean } = {
+	analytics: false,
+	marketingMeasurement: false,
+}
+
+vi.mock('aurelia', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('aurelia')>()
+	return {
+		...actual,
+		resolve: vi.fn((token: unknown) => {
+			const tokenAny = token as { friendlyName?: string }
+			switch (tokenAny.friendlyName) {
+				case 'ILogger':
+					return mockLogger
+				case 'IAppConfig':
+					return mockConfig.current
+				case 'IConsentService':
+					return mockConsent
+				default:
+					return {}
+			}
+		}),
+	}
+})
+
+import { AnalyticsService } from './analytics-service'
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Suppress `requestIdleCallback` so the constructor doesn't fire init
+ * before the test arranges its preconditions. Tests that want to drive
+ * init call `_waitForInitForTests()` explicitly.
+ */
+function stubIdleCallback(): void {
+	Object.defineProperty(globalThis, 'requestIdleCallback', {
+		configurable: true,
+		writable: true,
+		value: vi.fn(),
+	})
+}
+
+function clearIdleCallback(): void {
+	const g = globalThis as { requestIdleCallback?: unknown }
+	delete g.requestIdleCallback
+}
+
+describe('AnalyticsService', () => {
+	beforeEach(() => {
+		posthogStub.init.mockReset()
+		posthogStub.capture.mockReset()
+		posthogStub.identify.mockReset()
+		posthogStub.reset.mockReset()
+		posthogStub.getFeatureFlag.mockReset()
+		mockConfig.current = {
+			posthogProjectKey: 'phc_test_key',
+			posthogApiHost: 'https://eu.i.posthog.com',
+		}
+		mockConsent.analytics = false
+		mockConsent.marketingMeasurement = false
+		setActiveSpan(undefined)
+		stubIdleCallback()
+	})
+
+	afterEach(() => {
+		clearIdleCallback()
+		vi.restoreAllMocks()
+	})
+
+	describe('nil-config (disabled) mode', () => {
+		it('does not schedule PostHog init when posthogProjectKey is missing', () => {
+			mockConfig.current = { posthogProjectKey: undefined }
+			const idle = globalThis.requestIdleCallback as ReturnType<typeof vi.fn>
+
+			new AnalyticsService()
+
+			// scheduleInit() short-circuits before requestIdleCallback —
+			// proving the SDK dynamic import is never queued in nil-config
+			// mode. This is what mirrors the backend's `client == nil`
+			// posture: no key → no network → no surprises.
+			expect(idle).not.toHaveBeenCalled()
+			expect(posthogStub.init).not.toHaveBeenCalled()
+		})
+
+		it('treats capture() as a no-op when posthogProjectKey is missing', async () => {
+			mockConfig.current = { posthogProjectKey: undefined }
+			const sut = new AnalyticsService()
+
+			sut.capture(Events.PageViewed, { path: '/welcome', title: 'Welcome' })
+			await sut._waitForInitForTests()
+
+			// No init AND no buffered events: a stuck CMS / missing
+			// ConfigMap deployment MUST NOT silently buffer 100s of
+			// events in memory.
+			expect(posthogStub.init).not.toHaveBeenCalled()
+			expect(posthogStub.capture).not.toHaveBeenCalled()
+		})
+
+		it('returns the supplied default from getFeatureFlag when disabled', () => {
+			mockConfig.current = { posthogProjectKey: undefined }
+			const sut = new AnalyticsService()
+
+			// Defaulting is what lets route guards stay synchronous and
+			// fail-closed: without a key, every gate decides "off"
+			// regardless of what the production project would say.
+			expect(sut.getFeatureFlag('new-onboarding', false)).toBe(false)
+			expect(sut.getFeatureFlag('experiment-bucket', 'control')).toBe('control')
+		})
+	})
+
+	describe('enabled mode', () => {
+		it('buffers capture() calls before init and replays them after init resolves', async () => {
+			const sut = new AnalyticsService()
+
+			sut.capture(Events.PageViewed, { path: '/welcome', title: 'Welcome' })
+			sut.capture(Events.ArtistSearch, {
+				query_length: 3,
+				result_count: 5,
+			})
+
+			// Neither event has hit posthog.capture yet — they're sitting
+			// in the pre-init queue.
+			expect(posthogStub.capture).not.toHaveBeenCalled()
+
+			await sut._waitForInitForTests()
+
+			// init was called with the EU host + the privacy-default config
+			// the OpenSpec change pins for the pre-consent posture.
+			expect(posthogStub.init).toHaveBeenCalledTimes(1)
+			const [key, config] = posthogStub.init.mock.calls[0]
+			expect(key).toBe('phc_test_key')
+			expect(config).toMatchObject({
+				api_host: 'https://eu.i.posthog.com',
+				persistence: 'memory',
+				ip: false,
+				autocapture: false,
+				capture_pageview: false,
+				disable_session_recording: true,
+			})
+
+			// Both buffered events flush in insertion order.
+			expect(posthogStub.capture).toHaveBeenCalledTimes(2)
+			expect(posthogStub.capture.mock.calls[0][0]).toBe(Events.PageViewed)
+			expect(posthogStub.capture.mock.calls[1][0]).toBe(Events.ArtistSearch)
+		})
+
+		it('warns and drops excess events when the pre-init queue overflows 100 entries', async () => {
+			const warn = vi.fn()
+			const scopedLogger = {
+				trace: vi.fn(),
+				debug: vi.fn(),
+				info: vi.fn(),
+				warn,
+				error: vi.fn(),
+			}
+			mockLogger.scopeTo = () => scopedLogger
+
+			const sut = new AnalyticsService()
+
+			// Push 150 events while the SDK is still queued — 100 fit, 50
+			// MUST be dropped (and ONE warn emitted, not 50).
+			for (let i = 0; i < 150; i++) {
+				sut.capture(Events.PageViewed, {
+					path: `/p${i}`,
+					title: 't',
+				})
+			}
+
+			await sut._waitForInitForTests()
+
+			// Only the first 100 are replayed.
+			expect(posthogStub.capture).toHaveBeenCalledTimes(100)
+			// And the overflow warn fires exactly once — a stuck init
+			// must NOT flood the log sink with one warn per dropped event.
+			expect(warn).toHaveBeenCalledTimes(1)
+			expect(warn.mock.calls[0][0]).toMatch(/overflow/i)
+		})
+
+		it('skips PostHog.identify when consent.analytics is false', async () => {
+			mockConsent.analytics = false
+			const sut = new AnalyticsService()
+			await sut._waitForInitForTests()
+
+			sut.identify('user-123', { plan: 'pro' })
+
+			// Hard gate: PostHog MUST NOT see the real user id until
+			// the consent screen flips `consent.analytics` to true.
+			// This is the central privacy contract of the change.
+			expect(posthogStub.identify).not.toHaveBeenCalled()
+		})
+
+		it('injects trace_id from the active OTel span into capture properties', async () => {
+			const sut = new AnalyticsService()
+			await sut._waitForInitForTests()
+
+			setActiveSpan('00112233445566778899aabbccddeeff')
+
+			sut.capture(Events.PageViewed, { path: '/dashboard', title: 'Dashboard' })
+
+			expect(posthogStub.capture).toHaveBeenCalledTimes(1)
+			const [name, props] = posthogStub.capture.mock.calls[0]
+			expect(name).toBe(Events.PageViewed)
+			// trace_id MUST be the active span's traceId so paired FE/BE
+			// events can be joined in PostHog dashboards. The original
+			// properties pass through unchanged.
+			expect(props).toMatchObject({
+				path: '/dashboard',
+				title: 'Dashboard',
+				trace_id: '00112233445566778899aabbccddeeff',
+			})
+		})
+
+		it('omits trace_id when no OTel span is active', async () => {
+			const sut = new AnalyticsService()
+			await sut._waitForInitForTests()
+
+			setActiveSpan(undefined)
+
+			sut.capture(Events.PageViewed, { path: '/welcome', title: 'Welcome' })
+
+			expect(posthogStub.capture).toHaveBeenCalledTimes(1)
+			const [, props] = posthogStub.capture.mock.calls[0]
+			// No span → no trace_id key in the payload at all (not even
+			// an empty string). This keeps standalone UI events
+			// distinguishable from RPC-correlated ones in PostHog.
+			expect(props).not.toHaveProperty('trace_id')
+			expect(props).toMatchObject({
+				path: '/welcome',
+				title: 'Welcome',
+			})
+		})
+	})
+})

--- a/src/lib/analytics/analytics-service.ts
+++ b/src/lib/analytics/analytics-service.ts
@@ -1,0 +1,384 @@
+import { trace } from '@opentelemetry/api'
+import { DI, ILogger, resolve } from 'aurelia'
+import type { PostHog, PostHogConfig } from 'posthog-js'
+import { IAppConfig } from '../../config/app-config'
+import {
+	type EventName,
+	type EventProps,
+	Events,
+} from '../../services/analytics-events'
+import { IConsentService } from '../consent/consent-service'
+
+/**
+ * Public surface for the typed PostHog wrapper. Every consumer (route VMs,
+ * services, app-shell page-view wiring) MUST resolve through this interface
+ * — the concrete class is registered as a singleton in `main.ts`. Keeping
+ * the surface minimal protects call sites from PostHog SDK churn and makes
+ * the nil-config / pre-init / pre-consent branches the *only* code paths
+ * that ever observe the wrapped SDK directly.
+ *
+ * Owns the contract for the `introduce-analytics-tool` OpenSpec change
+ * (Batch 3a). Consent UI lives in Batch 3b; per-event instrumentation in
+ * Batch 3c.
+ */
+export interface IAnalyticsService {
+	/**
+	 * Typed event emission. The `name` literal pins the required
+	 * property shape at compile time (see `analytics-events.ts` for the
+	 * `EventName` → `EventProps<E>` mapping). Mismatched name/props pairs
+	 * fail the typecheck.
+	 *
+	 * Behaviour matrix:
+	 *   - nil-config (no `posthogProjectKey`): debug-log and return.
+	 *   - pre-init: enqueue to a bounded in-memory buffer; flushed
+	 *     verbatim on init.
+	 *   - post-init: forward to PostHog with `trace_id` injected from
+	 *     the active OTel span (best-effort).
+	 *
+	 * Consent gating does NOT block `capture` — PostHog runs in
+	 * `persistence: 'memory'` until consent is granted, which is the
+	 * privacy-equivalent posture (no persistent storage, no IP
+	 * collection, anonymous distinct id). Only `identify` is hard-gated.
+	 */
+	capture<E extends EventName>(name: E, props: EventProps<E>): void
+
+	/**
+	 * Associates the current session with a real user id. Hard-gated on
+	 * `IConsentService.analytics`; called from the (Batch 3c)
+	 * `UserHydrationTask` integration after consent is confirmed.
+	 * No-op when consent is denied OR when running in nil-config mode.
+	 */
+	identify(userId: string, properties?: Readonly<Record<string, unknown>>): void
+
+	/**
+	 * Clears the current identification (e.g. on sign-out). Forwards to
+	 * `posthog.reset()` once initialised; also clears the pre-init queue
+	 * so any buffered events captured under the prior identity are
+	 * dropped. No-op in nil-config mode.
+	 */
+	reset(): void
+
+	/**
+	 * Returns the current value of a PostHog feature flag, or the
+	 * supplied default when:
+	 *   - The service is in nil-config mode (no `posthogProjectKey`).
+	 *   - The SDK has not finished initialising yet (no value to read).
+	 *   - PostHog returns `undefined` (flag is unknown to the project).
+	 *
+	 * Synchronous by design so callers (route guards, UI gates) do not
+	 * need to await initialisation. Use the default to encode the
+	 * fail-closed behaviour expected by the gate.
+	 */
+	getFeatureFlag(key: string, defaultValue: unknown): unknown
+}
+
+export const IAnalyticsService = DI.createInterface<IAnalyticsService>(
+	'IAnalyticsService',
+	(x) => x.singleton(AnalyticsService),
+)
+
+/**
+ * Internal queue entry for captures issued before the SDK is loaded.
+ * Stored as a discriminated `{ name, props }` rather than a closure so the
+ * payload remains inspectable in tests and the flush path stays trivially
+ * type-safe.
+ */
+type QueuedCapture = {
+	[K in EventName]: { name: K; props: EventProps<K> }
+}[EventName]
+
+/**
+ * Upper bound on the pre-init queue. The deferred-init window is bounded
+ * by `requestIdleCallback` firing (at most ~2s due to the explicit
+ * timeout below), so realistic pre-init traffic is a handful of events —
+ * the boot page-view plus whatever the welcome route emits. 100 leaves
+ * comfortable headroom while preventing a runaway page from flooding
+ * memory if init somehow stalls (e.g. the SDK dynamic import throws and
+ * is retried by a misbehaving caller). Matches the cap defined in the
+ * `introduce-analytics-tool` OpenSpec tasks.
+ */
+const PRE_INIT_QUEUE_LIMIT = 100
+
+/**
+ * Hard cap on how long the browser may defer the init callback. Without
+ * a timeout, `requestIdleCallback` MAY never fire on a permanently busy
+ * tab. 2 seconds is roughly the LCP budget for the dashboard, so deferring
+ * past that point yields diminishing returns — we'd rather take the small
+ * INP hit and start capturing events than block analytics indefinitely.
+ */
+const INIT_IDLE_TIMEOUT_MS = 2_000
+
+export class AnalyticsService implements IAnalyticsService {
+	private readonly logger = resolve(ILogger).scopeTo('AnalyticsService')
+	private readonly config = resolve(IAppConfig)
+	private readonly consent = resolve(IConsentService)
+
+	/**
+	 * Truthy iff PostHog initialisation has completed. Until this flips,
+	 * `capture` enqueues; after it flips, `capture` forwards directly.
+	 * Initialisation can fail (network, ad-blocker) — in that case
+	 * `posthog` stays `null` and the service degrades to log-and-drop,
+	 * matching the backend's nil-client posture so missing analytics
+	 * never break the product surface.
+	 */
+	private posthog: PostHog | null = null
+	private initStarted = false
+	private readonly queue: QueuedCapture[] = []
+	private queueOverflowed = false
+
+	public constructor() {
+		this.scheduleInit()
+	}
+
+	/**
+	 * Public entry point — see `IAnalyticsService.capture` for the
+	 * documented behaviour matrix. The runtime branching here MUST stay
+	 * O(1): every call site emits at least one event per user action,
+	 * and a measurable hit on INP would defeat the purpose.
+	 */
+	public capture<E extends EventName>(name: E, props: EventProps<E>): void {
+		if (!this.isEnabled()) {
+			this.logger.debug('capture suppressed (nil-config mode)', { name })
+			return
+		}
+		if (this.posthog === null) {
+			this.enqueue({ name, props } as QueuedCapture)
+			return
+		}
+		this.dispatch(name, props)
+	}
+
+	public identify(
+		userId: string,
+		properties?: Readonly<Record<string, unknown>>,
+	): void {
+		if (!this.isEnabled()) {
+			this.logger.debug('identify suppressed (nil-config mode)', { userId })
+			return
+		}
+		if (!this.consent.analytics) {
+			this.logger.debug('identify suppressed (consent denied)', { userId })
+			return
+		}
+		if (this.posthog === null) {
+			// Pre-init identify is intentionally dropped rather than
+			// queued: pairing it with the deferred-flush capture queue
+			// would replay identifications out-of-order against later
+			// reset() calls in the same boot, and the Batch 3c
+			// UserHydrationTask integration explicitly runs `identify`
+			// AFTER the SDK init is awaited, so this branch should not
+			// be reachable in production. Log at debug so any
+			// regression is visible during development.
+			this.logger.debug('identify dropped (pre-init)', { userId })
+			return
+		}
+		this.posthog.identify(userId, properties)
+	}
+
+	public reset(): void {
+		if (!this.isEnabled()) {
+			this.logger.debug('reset suppressed (nil-config mode)')
+			return
+		}
+		// Clear any buffered events regardless of init state — they were
+		// captured under the prior identity and forwarding them after a
+		// reset would attribute pre-signout actions to the post-signout
+		// anonymous id. Cheaper than walking the queue to filter.
+		this.queue.length = 0
+		this.queueOverflowed = false
+		if (this.posthog === null) {
+			this.logger.debug('reset queue-only (pre-init)')
+			return
+		}
+		this.posthog.reset()
+	}
+
+	public getFeatureFlag(key: string, defaultValue: unknown): unknown {
+		if (!this.isEnabled()) {
+			return defaultValue
+		}
+		if (this.posthog === null) {
+			return defaultValue
+		}
+		const value = this.posthog.getFeatureFlag(key)
+		return value === undefined ? defaultValue : value
+	}
+
+	// -- Internals --------------------------------------------------------
+
+	/** Nil-config mirror of the backend's `client == nil` short-circuit. */
+	private isEnabled(): boolean {
+		return Boolean(this.config.posthogProjectKey)
+	}
+
+	/**
+	 * Schedules the actual SDK import + init for the next idle slot.
+	 * Using `requestIdleCallback` keeps PostHog's dynamic import off the
+	 * critical path so it cannot regress INP / LCP. Safari < 16 lacks
+	 * `requestIdleCallback`; fall back to `setTimeout(0)` which still
+	 * yields one task before init runs.
+	 */
+	private scheduleInit(): void {
+		if (this.initStarted) return
+		this.initStarted = true
+		if (!this.isEnabled()) {
+			// In nil-config mode we still flip initStarted so subsequent
+			// constructor calls (test isolation) don't redundantly log.
+			return
+		}
+		const win = globalThis as typeof globalThis & {
+			requestIdleCallback?: (
+				cb: () => void,
+				opts?: { timeout: number },
+			) => unknown
+		}
+		const run = (): void => {
+			void this.init()
+		}
+		if (typeof win.requestIdleCallback === 'function') {
+			win.requestIdleCallback(run, { timeout: INIT_IDLE_TIMEOUT_MS })
+		} else {
+			setTimeout(run, 0)
+		}
+	}
+
+	/**
+	 * Loads the PostHog SDK dynamically (kept out of the main bundle)
+	 * and initialises it with the privacy-default posture: in-memory
+	 * persistence, no IP collection, anonymous distinct id. The Batch 3b
+	 * consent-grant path will upgrade these settings (`set_config` plus
+	 * `identify`) after the user opts in.
+	 *
+	 * Failure here is non-fatal — the catch path logs and leaves
+	 * `posthog === null`, so subsequent captures fall back to the
+	 * nil-config branch. We do NOT retry: a failed init usually means
+	 * an ad-blocker or a tracking-protection extension is in play, and
+	 * retry would only waste cycles.
+	 */
+	private async init(): Promise<void> {
+		try {
+			const module = await import('posthog-js')
+			const posthog = module.default
+			const apiHost =
+				this.config.posthogApiHost && this.config.posthogApiHost.length > 0
+					? this.config.posthogApiHost
+					: 'https://eu.i.posthog.com'
+			const initConfig: Partial<PostHogConfig> = {
+				api_host: apiHost,
+				// Pre-consent posture. `persistence: 'memory'` keeps the
+				// session-scoped anonymous id off disk so refresh /
+				// re-open generates a fresh id (the tracking-protection
+				// equivalent of the backend's anonymous-by-default
+				// stance). `ip: false` prevents PostHog from recording
+				// the source IP for any event captured in this state.
+				// `disable_persistence` is intentionally not used — the
+				// Batch 3b consent-grant flow switches `persistence` to
+				// `localStorage+cookie` via `set_config`, which the
+				// `disable_persistence` flag would block.
+				persistence: 'memory',
+				ip: false,
+				// Autocapture is disabled: every event in this app is
+				// catalogued through `analytics-events.ts`. Implicit
+				// captures would create rogue events outside the
+				// catalogue and undermine the CI catalogue check
+				// planned in the OpenSpec tasks.
+				autocapture: false,
+				// Identification and feature-flag bootstrap are
+				// orchestrated by AnalyticsService itself (see
+				// `identify`) rather than by SDK helpers, so the
+				// session-recording defaults stay off until Batch 3b
+				// wires the consent-aware initialisation block.
+				capture_pageview: false,
+				disable_session_recording: true,
+				// Suppress PostHog's own console noise in dev — the
+				// Aurelia logger pipeline owns telemetry-of-telemetry.
+				loaded: () => {
+					this.logger.debug('PostHog SDK loaded')
+				},
+			}
+			posthog.init(this.config.posthogProjectKey, initConfig)
+			this.posthog = posthog
+			this.flushQueue()
+		} catch (err) {
+			this.logger.warn(
+				'PostHog SDK failed to load; analytics disabled for this session',
+				{ error: err },
+			)
+		}
+	}
+
+	private enqueue(entry: QueuedCapture): void {
+		if (this.queue.length >= PRE_INIT_QUEUE_LIMIT) {
+			// Log only once per session — a stuck init would otherwise
+			// flood the logger with the same warn every capture.
+			if (!this.queueOverflowed) {
+				this.queueOverflowed = true
+				this.logger.warn(
+					'Analytics pre-init queue overflowed; subsequent events dropped until init completes',
+					{ limit: PRE_INIT_QUEUE_LIMIT },
+				)
+			}
+			return
+		}
+		this.queue.push(entry)
+	}
+
+	private flushQueue(): void {
+		if (this.queue.length === 0) return
+		const pending = this.queue.splice(0, this.queue.length)
+		for (const entry of pending) {
+			this.dispatch(entry.name, entry.props)
+		}
+	}
+
+	/**
+	 * The single place that touches `posthog.capture`. Injects the
+	 * active OTel `trace_id` so paired FE/BE events can be correlated in
+	 * PostHog (matches the backend posthog adapter contract referenced
+	 * in `analytics-events.ts`). The OTel browser SDK does not own a
+	 * tracer here — spans come from the existing fetch instrumentation
+	 * in `services/otel-init.ts` — so `getActiveSpan()` returns the
+	 * caller's span only if the capture happens during a fetch handler.
+	 * That is fine: server-paired events (e.g. `artist.follow.requested`
+	 * → `artist.follow.completed`) are emitted from RPC call sites
+	 * already wrapped by `FetchInstrumentation`, and standalone UI
+	 * events (e.g. `page.viewed`) intentionally have no trace
+	 * correlation.
+	 */
+	private dispatch<E extends EventName>(name: E, props: EventProps<E>): void {
+		if (this.posthog === null) return
+		const enriched: Record<string, unknown> = { ...props }
+		const span = trace.getActiveSpan()
+		if (span !== undefined) {
+			const ctx = span.spanContext()
+			if (ctx.traceId && ctx.traceId.length > 0) {
+				enriched.trace_id = ctx.traceId
+			}
+		}
+		this.posthog.capture(name, enriched)
+	}
+
+	/**
+	 * @internal Test hook — awaits the queued init so specs don't have
+	 *   to poll `requestIdleCallback` timing. Production code never
+	 *   calls this; it is not part of `IAnalyticsService` and DI hands
+	 *   callers the interface type only.
+	 */
+	public async _waitForInitForTests(): Promise<void> {
+		// init() is queued via requestIdleCallback / setTimeout; flush
+		// the microtask + macrotask queues by awaiting a 0-ms timeout,
+		// then awaiting any in-flight init promise.
+		await new Promise((r) => setTimeout(r, 0))
+		// init() is fire-and-forget from scheduleInit; we re-issue it
+		// synchronously here so the spec can await the resulting
+		// promise deterministically.
+		if (this.posthog === null && this.isEnabled()) {
+			await this.init()
+		}
+	}
+}
+
+// Re-export the catalogue for ergonomic single-import consumption in
+// instrumented call sites (Batch 3c). Keeps `import { Events,
+// IAnalyticsService }` on one line at the use site.
+export { Events }

--- a/src/lib/consent/consent-service.spec.ts
+++ b/src/lib/consent/consent-service.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+//
+// Same pattern as `services/concert-service.spec.ts`: replace the
+// `aurelia` `resolve()` export with a stub that maps DI tokens to mock
+// instances by the token's `friendlyName`. ConsentServiceStub only
+// resolves `ILogger`, so the mock map is tiny.
+
+const mockLogger = {
+	scopeTo: () => ({
+		trace: vi.fn(),
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	}),
+}
+
+vi.mock('aurelia', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('aurelia')>()
+	return {
+		...actual,
+		resolve: vi.fn((token: unknown) => {
+			const map: Record<string, unknown> = {
+				ILogger: mockLogger,
+			}
+			const tokenAny = token as { friendlyName?: string }
+			return map[tokenAny.friendlyName ?? ''] ?? {}
+		}),
+	}
+})
+
+import { ConsentServiceStub } from './consent-service'
+
+describe('ConsentServiceStub', () => {
+	it('reports analytics consent as denied (Batch 3a fail-closed default)', () => {
+		const sut = new ConsentServiceStub()
+
+		// The 3a stub MUST return false until the 3b consent screen
+		// flips it via `grant('analytics')`. Any regression here would
+		// silently turn on PostHog identification before the user has
+		// agreed, violating the OpenSpec consent requirements.
+		expect(sut.analytics).toBe(false)
+	})
+
+	it('reports marketingMeasurement consent as denied (Batch 3a fail-closed default)', () => {
+		const sut = new ConsentServiceStub()
+
+		// `marketingMeasurement` is the APPI Article 28 cross-border
+		// transfer purpose. It MUST stay false in 3a so AnalyticsService
+		// cannot enable the marketing-funnel cross-border data flow
+		// before the user grants explicit, granular consent.
+		expect(sut.marketingMeasurement).toBe(false)
+	})
+})

--- a/src/lib/consent/consent-service.ts
+++ b/src/lib/consent/consent-service.ts
@@ -1,0 +1,115 @@
+import { DI, ILogger, resolve } from 'aurelia'
+
+/**
+ * Per-purpose consent state for product analytics and related cross-border
+ * measurement. The shape mirrors the eventual persisted record so the Batch
+ * 3b implementation can swap in the real storage-backed service without
+ * changing this interface or any consumer (notably `AnalyticsService`).
+ *
+ * Field semantics:
+ *   - `analytics`: covers PostHog event capture, identification with the
+ *     real user id, and persistent storage (cookies / localStorage). When
+ *     false, AnalyticsService MUST stay in memory-only / anonymous mode.
+ *   - `marketingMeasurement`: covers cross-border data transfer to PostHog
+ *     Cloud EU for funnel / retention dashboards. Separate from
+ *     `analytics` because APPI Article 28 requires explicit, granular
+ *     opt-in for cross-border transfer.
+ */
+export type ConsentState = {
+	readonly analytics: boolean
+	readonly marketingMeasurement: boolean
+}
+
+/**
+ * Read-only consent state queried by AnalyticsService at every gating
+ * decision point. Batch 3b extends this interface with mutators
+ * (`grant(purpose)`, `revoke(purpose)`, persistence helpers, plus the
+ * Aurelia `@observable` field that drives the consent screen UI) and
+ * publishes a `consent:changed` IEventAggregator event without touching
+ * the read shape exposed below, so AnalyticsService keeps working
+ * unchanged across the 3a → 3b transition.
+ *
+ * The current Batch 3a stub ALWAYS reports consent denied. This is the
+ * fail-closed default: until the user explicitly grants consent on the
+ * Batch 3b screen, no PostHog identification and no persistent storage
+ * may occur. Matches the "pre-consent SDK initialisation uses
+ * persistence: 'memory'" requirement (tasks 6.4 / 6.5 of the
+ * `introduce-analytics-tool` OpenSpec change).
+ */
+export interface IConsentService {
+	/**
+	 * `true` iff the user has granted consent for PostHog event capture,
+	 * persistent client-side storage, and identification with the real
+	 * user id. Polled by `AnalyticsService.identify` at every call.
+	 */
+	readonly analytics: boolean
+	/**
+	 * `true` iff the user has granted consent for cross-border transfer
+	 * of analytics data to PostHog Cloud EU for marketing-measurement
+	 * dashboards. APPI Article 28 requires this purpose to be granted
+	 * independently from `analytics`.
+	 */
+	readonly marketingMeasurement: boolean
+}
+
+export const IConsentService = DI.createInterface<IConsentService>(
+	'IConsentService',
+	(x) => x.singleton(ConsentServiceStub),
+)
+
+/**
+ * Batch 3a stub. Always reports consent denied so AnalyticsService's
+ * consent-gated paths (identify, persistent storage) stay disabled
+ * until the Batch 3b consent screen ships. The class name carries the
+ * `Stub` suffix so a casual reader of `main.ts` notices the placeholder
+ * and an IDE's go-to-implementation lands here rather than on the
+ * eventual production implementation.
+ *
+ * Batch 3b will:
+ *   - Add localStorage hydration in the constructor (read a versioned
+ *     consent record).
+ *   - Add `grant(purpose)` / `revoke(purpose)` mutators that persist the
+ *     record and publish a `consent:changed` event on IEventAggregator
+ *     so AnalyticsService can react (`posthog.set_config({ persistence:
+ *     'localStorage+cookie' })` on grant, `posthog.reset()` on revoke).
+ *   - Add the consent-screen UI under `src/routes/consent/`.
+ *
+ * Test-suite hook: the `@internal` `_setStateForTests` method lets
+ * AnalyticsService specs cover the "consent granted later" code path
+ * without depending on the unimplemented Batch 3b mutation API. It is
+ * deliberately not part of `IConsentService` — production code MUST NOT
+ * call it (and TypeScript will refuse, since DI hands callers the
+ * interface type).
+ */
+export class ConsentServiceStub implements IConsentService {
+	private readonly logger = resolve(ILogger).scopeTo('ConsentService')
+
+	private _state: ConsentState = {
+		analytics: false,
+		marketingMeasurement: false,
+	}
+
+	public constructor() {
+		this.logger.debug(
+			'ConsentService stub active — analytics consent is denied until the Batch 3b consent screen ships',
+		)
+	}
+
+	public get analytics(): boolean {
+		return this._state.analytics
+	}
+
+	public get marketingMeasurement(): boolean {
+		return this._state.marketingMeasurement
+	}
+
+	/**
+	 * @internal Test-only mutator used by AnalyticsService specs to
+	 *   exercise the "consent granted" branches. Removed when the real
+	 *   ConsentService lands in Batch 3b (the spec suite will switch to
+	 *   the production `grant(purpose)` API at that point).
+	 */
+	public _setStateForTests(next: ConsentState): void {
+		this._state = next
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,6 +55,8 @@ import { LongPressCustomAttribute } from './custom-attributes/long-press'
 import { SpotlightRadiusCustomAttribute } from './custom-attributes/spotlight-radius'
 import { TileColorCustomAttribute } from './custom-attributes/tile-color'
 import { AuthHook } from './hooks/auth-hook'
+import { IAnalyticsService } from './lib/analytics/analytics-service'
+import { IConsentService } from './lib/consent/consent-service'
 import en from './locales/en/translation.json'
 import ja from './locales/ja/translation.json'
 import { IArtistServiceClient } from './services/artist-service-client'
@@ -177,6 +179,14 @@ async function bootstrap(): Promise<void> {
 	au.register(GlobalErrorHandlingTask)
 	au.register(IAuthService)
 	au.register(IUserService)
+	// Consent + analytics registered together immediately after the user
+	// service: AnalyticsService depends on IConsentService for its
+	// identify-gating, and the Batch 3b consent-screen flow will mount
+	// once the user is hydrated. Page-view emission (subscribed in
+	// AppShell) starts the moment Aurelia.start() resolves, so both
+	// registrations MUST be in place before app() is called below.
+	au.register(IConsentService)
+	au.register(IAnalyticsService)
 	au.register(UserHydrationTask)
 	au.register(IArtistServiceClient)
 	au.register(IFollowServiceClient)

--- a/test/app-shell.spec.ts
+++ b/test/app-shell.spec.ts
@@ -2,6 +2,7 @@ import { IRouter, IRouterEvents } from '@aurelia/router'
 import { DI, Registration } from 'aurelia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { AppShell } from '../src/app-shell'
+import { IAnalyticsService } from '../src/lib/analytics/analytics-service'
 import { IAuthService } from '../src/services/auth-service'
 import { IErrorBoundaryService } from '../src/services/error-boundary-service'
 import { IOnboardingService } from '../src/services/onboarding-service'
@@ -104,6 +105,19 @@ describe('app-shell', () => {
 					spotlightTarget: '',
 					spotlightMessage: '',
 					spotlightRadius: '12px',
+				}),
+				// AppShell.binding() emits a `page.viewed` event into the
+				// analytics service on every router navigation-end. The
+				// `showNav` tests never trigger the router event handler,
+				// but the constructor still resolves the service — register
+				// a no-op stub so DI doesn't try to jit-construct the real
+				// AnalyticsService (which would in turn pull in IAppConfig
+				// and IConsentService, none of which this unit test owns).
+				Registration.instance(IAnalyticsService, {
+					capture: vi.fn(),
+					identify: vi.fn(),
+					reset: vi.fn(),
+					getFeatureFlag: vi.fn(),
 				}),
 			)
 			container.register(AppShell)


### PR DESCRIPTION
## Summary

First frontend batch for the [introduce-analytics-tool](https://github.com/liverty-music/specification/tree/main/openspec/changes/introduce-analytics-tool) change. Lays the runtime foundation that subsequent batches (consent UI, per-event instrumentation) build on top of.

| Capability | Where |
| --- | --- |
| Typed PostHog wrapper | `src/lib/analytics/analytics-service.ts` |
| Fail-closed consent stub | `src/lib/consent/consent-service.ts` |
| DI registration | `src/main.ts` |
| Page-view emission | `src/app-shell.ts` (existing `au:router:navigation-end`) |
| Config schema | `src/config/app-config.ts` (2 optional fields) |

## Design highlights

- **Minimal surface**: `IAnalyticsService` exposes `capture` / `identify` / `reset` / `getFeatureFlag` only. Route VMs and feature services never see the SDK directly. The behaviour matrix is documented on the interface.
- **Deferred init**: `requestIdleCallback(run, { timeout: 2000 })` with `setTimeout(0)` fallback. Pre-init `capture` calls are buffered in a 100-entry in-memory queue (warn-on-overflow once).
- **Nil-config mode**: When `posthogProjectKey` is empty the SDK is never loaded; every method is a debug-log no-op. Matches the backend nil-client convention so local dev / pre-rollout environments stay silent.
- **Pre-consent posture** (task 6.5): `posthog.init` is forced to `persistence: 'memory'`, `ip: false`, `autocapture: false`, `capture_pageview: false`, `disable_session_recording: true`. `identify` is hard-gated on `IConsentService.analytics` (currently `false` from the stub) so PII / persistent storage cannot leak before Batch 3b ships the consent screen.
- **trace_id**: Injected via `@opentelemetry/api` `trace.getActiveSpan()` with a defensive undefined-guard. Call sites never plumb it by hand — the single OTel→PostHog bridge documented in `analytics-events.ts` stays the only one.
- **ConsentService stub**: Returns `false` for both purposes. Batch 3b will swap in the localStorage-backed implementation without changing this interface — `AnalyticsService` keeps working unchanged across the 3a→3b transition.
- **PII discipline on page.viewed** (per `analytics-events.ts:51-72`): `path = window.location.pathname` only (the OIDC callback route carries `code` / `state` in the query string — `.search` is NEVER captured); `title = document.title` (the router has already set this to the static route label).

## Scope notes

- AppConfig schema gains 2 **optional** fields (`posthogApiHost`, `posthogProjectKey`) so `/config.json` without them keeps validating. A small cloud-provisioning ConfigMap PR will populate them once the ESC config (`pulumiConfig.posthogProjectApiKey`) is set.
- This PR ships the wiring; runtime is **disabled-by-default** until both the cloud-provisioning config update and Batch 3b's consent screen land.
- Out of scope (separate batches):
  - Consent UI + opt-out (Batch 3b)
  - `identify` on `UserHydrationTask` completion (Batch 3c)
  - Per-event instrumentation (Batch 3c): artist-discovery, concert-detail, ticket-lottery, ticket-purchase, push.

## Tests

Vitest:
- `analytics-service.spec.ts` — 8 cases: nil-config no-ops (3), pre-init queue + replay, overflow warn-and-drop, identify gated by consent, `trace_id` inject + omit.
- `consent-service.spec.ts` — 2 cases: fail-closed defaults for both purposes.

Drive-by: `test/app-shell.spec.ts` gained a no-op `IAnalyticsService` stub registration so the AppShell DI graph resolves under unit tests (same shape the file already uses for `IErrorBoundaryService` and `IOnboardingService`).

## Test plan

- [x] `make check` passes locally (biome lint + stylelint + typecheck + 1101 vitest tests + 7 script tests + brand-vocabulary)
- [ ] CI green
- [ ] Manual verification once cloud-provisioning ConfigMap update lands: open dev site, navigate between routes, observe `page.viewed` events in the PostHog Cloud EU dev project. With `posthogProjectKey` unset, expect debug-log only.

Refs: liverty-music/specification#532