### PR TITLE
feat(analytics): identify-on-login + ConsentChanged-driven late identify (Batch 3c-1)

### DIFF
--- a/src/lib/analytics/analytics-service.spec.ts
+++ b/src/lib/analytics/analytics-service.spec.ts
@@ -384,6 +384,101 @@ describe('AnalyticsService', () => {
 			expect(posthogStub.reset).not.toHaveBeenCalled()
 		})
 
+		// Batch 3c-1: identify replay across consent transitions.
+		// UserHydrationTask fires identify before the user reaches the
+		// consent screen (which is the last onboarding step). The
+		// AnalyticsService must buffer the user_id and replay it once
+		// consent is granted, so the user_id seen in PostHog is the real
+		// one — not the anonymous bootstrap id.
+
+		it('replays a suppressed identify when consent is later granted', async () => {
+			mockConsent.analytics = false
+			const sut = new AnalyticsService()
+			await sut._waitForInitForTests()
+
+			sut.identify('user-abc', { signup_month: '2026-05' })
+
+			// Pre-grant: identify is gated, posthog.identify is NOT called.
+			expect(posthogStub.identify).not.toHaveBeenCalled()
+
+			// The consent transition flips the gate. AnalyticsService MUST
+			// replay the buffered identify with the same payload so the
+			// session post-consent is attributed to the real user_id
+			// rather than the anonymous bootstrap id.
+			//
+			// In production, ConsentService mutates state BEFORE
+			// publishing ConsentChanged — so when the AnalyticsService
+			// handler fires, `consent.analytics` already reads true.
+			// Mirror that order in the test so `replayPendingIdentifyIfAllowed`
+			// reads the live (granted) state.
+			posthogStub.identify.mockReset()
+			mockConsent.analytics = true
+			mockEa.publish(
+				new ConsentChanged({ analytics: true, marketingMeasurement: false }),
+			)
+
+			expect(posthogStub.identify).toHaveBeenCalledTimes(1)
+			expect(posthogStub.identify.mock.calls[0]).toEqual([
+				'user-abc',
+				{ signup_month: '2026-05' },
+			])
+		})
+
+		it('clears the pending identify buffer on revoke so a later grant does not silently re-identify', async () => {
+			mockConsent.analytics = false
+			const sut = new AnalyticsService()
+			await sut._waitForInitForTests()
+
+			sut.identify('user-abc')
+
+			// First grant: state goes false → true; production order is
+			// mutate-then-publish, so the live consent flips before the
+			// handler runs.
+			mockConsent.analytics = true
+			mockEa.publish(
+				new ConsentChanged({ analytics: true, marketingMeasurement: false }),
+			)
+			// First grant replays — verified by the test above. Drop the
+			// counter to focus on the revoke→grant cycle.
+			posthogStub.identify.mockReset()
+
+			// Revoke clears the pendingIdentify buffer.
+			mockConsent.analytics = false
+			mockEa.publish(
+				new ConsentChanged({ analytics: false, marketingMeasurement: false }),
+			)
+			// A second grant must NOT re-identify the user — they would
+			// need a fresh UserHydrationTask call (typically on the next
+			// boot) to repopulate the buffer.
+			mockConsent.analytics = true
+			mockEa.publish(
+				new ConsentChanged({ analytics: true, marketingMeasurement: false }),
+			)
+
+			expect(posthogStub.identify).not.toHaveBeenCalled()
+		})
+
+		it('replays a pre-init identify after the SDK loads', async () => {
+			// Consent is already granted at construction time. identify
+			// fired BEFORE init resolves must still reach PostHog once the
+			// SDK is ready — this is the steady state for returning users
+			// whose previous-boot consent grant persisted to localStorage.
+			mockConsent.analytics = true
+			const sut = new AnalyticsService()
+
+			// Note: NOT awaiting _waitForInitForTests yet — identify fires
+			// in the pre-init window.
+			sut.identify('user-xyz')
+
+			expect(posthogStub.identify).not.toHaveBeenCalled()
+
+			await sut._waitForInitForTests()
+
+			// After init: the buffered identify replays automatically as
+			// part of the init callback.
+			expect(posthogStub.identify).toHaveBeenCalledWith('user-xyz', undefined)
+		})
+
 		it('drops PostHog to memory persistence + reset() on consent revoke', async () => {
 			// Start the user in granted state so the revoke transition has
 			// somewhere to fall from. _waitForInitForTests applies the

--- a/src/lib/analytics/analytics-service.spec.ts
+++ b/src/lib/analytics/analytics-service.spec.ts
@@ -458,7 +458,7 @@ describe('AnalyticsService', () => {
 			expect(posthogStub.identify).not.toHaveBeenCalled()
 		})
 
-		it('replays a pre-init identify after the SDK loads', async () => {
+		it('replays a pre-init identify after the SDK loads exactly once', async () => {
 			// Consent is already granted at construction time. identify
 			// fired BEFORE init resolves must still reach PostHog once the
 			// SDK is ready — this is the steady state for returning users
@@ -475,7 +475,13 @@ describe('AnalyticsService', () => {
 			await sut._waitForInitForTests()
 
 			// After init: the buffered identify replays automatically as
-			// part of the init callback.
+			// part of the init callback. CRITICALLY exactly once — the
+			// init path runs `applyConsentToSdk(true)` AND
+			// `replayPendingIdentifyIfAllowed()` back-to-back when
+			// consent.analytics is true at boot; without the one-shot
+			// clear inside the helper, both would dispatch and PostHog
+			// would see two identify calls for the same user_id.
+			expect(posthogStub.identify).toHaveBeenCalledTimes(1)
 			expect(posthogStub.identify).toHaveBeenCalledWith('user-xyz', undefined)
 		})
 

--- a/src/lib/analytics/analytics-service.ts
+++ b/src/lib/analytics/analytics-service.ts
@@ -135,6 +135,28 @@ export class AnalyticsService implements IAnalyticsService {
 	private queueOverflowed = false
 
 	/**
+	 * Buffers the most recent `identify()` request. Two cases:
+	 *
+	 *   1. The caller fired identify BEFORE PostHog finished loading
+	 *      (e.g. UserHydrationTask runs as an AppTask.activating which
+	 *      can resolve faster than the requestIdleCallback that schedules
+	 *      `posthog.init`). The init callback consults this field and
+	 *      replays identify once the SDK is ready.
+	 *
+	 *   2. The caller fired identify while consent.analytics was false.
+	 *      The user_id is stashed so a later ConsentChanged grant can
+	 *      elevate the anonymous session to identified without the
+	 *      caller having to fire identify again. Cleared on `reset()`.
+	 *
+	 * Both cases use the same field because they share the same replay
+	 * semantics: "apply when the SDK is ready AND consent is granted".
+	 */
+	private pendingIdentify: {
+		userId: string
+		properties?: Readonly<Record<string, unknown>>
+	} | null = null
+
+	/**
 	 * Buffers a consent change that fired before PostHog finished loading.
 	 * The pre-consent privacy posture (`persistence: 'memory'`, anonymous
 	 * id) is already in place during init, so a `grant` arriving early is
@@ -187,20 +209,26 @@ export class AnalyticsService implements IAnalyticsService {
 			this.logger.debug('identify suppressed (nil-config mode)', { userId })
 			return
 		}
+
+		// Remember the most recent identify request so a later consent
+		// grant can elevate the anonymous session to identified without
+		// the caller having to re-fire identify. The properties payload
+		// is also buffered so a deferred replay is faithful to the
+		// original call. Cleared on `reset()`.
+		this.pendingIdentify = { userId, properties }
+
 		if (!this.consent.analytics) {
 			this.logger.debug('identify suppressed (consent denied)', { userId })
 			return
 		}
 		if (this.posthog === null) {
-			// Pre-init identify is intentionally dropped rather than
-			// queued: pairing it with the deferred-flush capture queue
-			// would replay identifications out-of-order against later
-			// reset() calls in the same boot, and the Batch 3c
-			// UserHydrationTask integration explicitly runs `identify`
-			// AFTER the SDK init is awaited, so this branch should not
-			// be reachable in production. Log at debug so any
-			// regression is visible during development.
-			this.logger.debug('identify dropped (pre-init)', { userId })
+			// Pre-init identify is intentionally dropped from the SDK
+			// path rather than queued: pairing it with the deferred-flush
+			// capture queue would replay identifications out-of-order
+			// against later reset() calls in the same boot. The
+			// pendingIdentify buffer above still carries the request, and
+			// `init()` consults it after the SDK loads (see scheduleInit).
+			this.logger.debug('identify deferred to SDK init', { userId })
 			return
 		}
 		this.posthog.identify(userId, properties)
@@ -217,6 +245,12 @@ export class AnalyticsService implements IAnalyticsService {
 		// anonymous id. Cheaper than walking the queue to filter.
 		this.queue.length = 0
 		this.queueOverflowed = false
+		// Also drop the pendingIdentify buffer: a consent grant arriving
+		// AFTER reset() (e.g. user signs out, then re-grants consent in
+		// settings before signing back in) MUST NOT re-elevate the prior
+		// identity. The next UserHydrationTask call will populate this
+		// field afresh.
+		this.pendingIdentify = null
 		if (this.posthog === null) {
 			this.logger.debug('reset queue-only (pre-init)')
 			return
@@ -346,6 +380,15 @@ export class AnalyticsService implements IAnalyticsService {
 				this.applyConsentToSdk(true)
 			}
 			this.flushQueue()
+			// Replay a buffered identify (from a pre-init UserHydration
+			// call) AFTER the queue flush so any pre-init `capture` is
+			// attributed to the anonymous id first and then the
+			// identification re-aliases the session to the real user_id.
+			// `applyConsentToSdk(true)` above also handles its own
+			// identify-replay, but only when consent transitions; this
+			// branch covers the steady-state case where consent was
+			// already granted at boot.
+			this.replayPendingIdentifyIfAllowed()
 		} catch (err) {
 			this.logger.warn(
 				'PostHog SDK failed to load; analytics disabled for this session',
@@ -445,6 +488,11 @@ export class AnalyticsService implements IAnalyticsService {
 				persistence: 'localStorage+cookie',
 				ip: true,
 			})
+			// Late-identify: if UserHydrationTask called identify before
+			// the user granted consent (the consent screen is the LAST
+			// onboarding step, so this is the steady-state for new
+			// signups), elevate the anonymous session to identified now.
+			this.replayPendingIdentifyIfAllowed()
 			this.logger.debug('Consent granted — PostHog persistence upgraded')
 			return
 		}
@@ -455,9 +503,30 @@ export class AnalyticsService implements IAnalyticsService {
 		// even when no identify has occurred — PostHog generates a fresh
 		// anonymous id afterwards.
 		this.posthog.reset()
+		// Drop the buffered identify too: the user revoked, so a future
+		// reconsent should NOT silently re-identify them with the old
+		// user_id. A fresh UserHydrationTask call (typically on next
+		// boot) is required to populate this field.
+		this.pendingIdentify = null
 		this.logger.debug(
 			'Consent revoked — PostHog persistence reverted to memory',
 		)
+	}
+
+	/**
+	 * Calls `posthog.identify` with the buffered user_id iff the SDK is
+	 * loaded AND consent is currently granted. No-op otherwise; the
+	 * buffer stays in place for a future grant. Pulled into a helper
+	 * because both `init()` (steady-state already-granted boot) and
+	 * `applyConsentToSdk(true)` (consent-grant transition) need the same
+	 * behaviour.
+	 */
+	private replayPendingIdentifyIfAllowed(): void {
+		if (this.posthog === null) return
+		if (!this.consent.analytics) return
+		const buffered = this.pendingIdentify
+		if (buffered === null) return
+		this.posthog.identify(buffered.userId, buffered.properties)
 	}
 
 	/**

--- a/src/lib/analytics/analytics-service.ts
+++ b/src/lib/analytics/analytics-service.ts
@@ -520,12 +520,20 @@ export class AnalyticsService implements IAnalyticsService {
 	 * because both `init()` (steady-state already-granted boot) and
 	 * `applyConsentToSdk(true)` (consent-grant transition) need the same
 	 * behaviour.
+	 *
+	 * One-shot: clears `pendingIdentify` immediately after dispatch.
+	 * Without this, the steady-state boot path (`init()` calls
+	 * `applyConsentToSdk(true)` THEN this helper directly) would double-
+	 * dispatch the same identify. Consistent with the `reset()` doc
+	 * comment: re-populating the buffer requires a fresh
+	 * UserHydrationTask call.
 	 */
 	private replayPendingIdentifyIfAllowed(): void {
 		if (this.posthog === null) return
 		if (!this.consent.analytics) return
 		const buffered = this.pendingIdentify
 		if (buffered === null) return
+		this.pendingIdentify = null
 		this.posthog.identify(buffered.userId, buffered.properties)
 	}
 

--- a/src/services/user-hydration-task.spec.ts
+++ b/src/services/user-hydration-task.spec.ts
@@ -80,6 +80,16 @@ vi.mock('./auth-service', () => ({
 vi.mock('./user-service', () => ({
 	IUserService: { friendlyName: 'IUserService' },
 }))
+vi.mock('../lib/analytics/analytics-service', () => ({
+	IAnalyticsService: { friendlyName: 'IAnalyticsService' },
+}))
+
+// Captures the user_id that runUserHydration passes to analytics.identify
+// so the "identifies the hydrated user" assertion can read it. Reset on
+// every beforeEach in the suite below.
+const mockAnalyticsService = {
+	identify: vi.fn<(userId: string) => void>(),
+}
 
 import { runUserHydration } from './user-hydration-task'
 
@@ -99,6 +109,8 @@ function makeContainer(): IContainer {
 					return mockI18n
 				case 'ILocalStorage':
 					return mockLocalStorage
+				case 'IAnalyticsService':
+					return mockAnalyticsService
 				default:
 					throw new Error(`unmocked token: ${fn ?? String(token)}`)
 			}
@@ -135,6 +147,42 @@ describe('runUserHydration', () => {
 		expect(mockUserService.ensureLoaded).not.toHaveBeenCalled()
 		// localStorage stays untouched for anonymous users.
 		expect(lsMap.get(StorageKeys.language)).toBe('en')
+	})
+
+	// Batch 3c-1: identify-on-login wiring. After ensureLoaded resolves
+	// and `userService.current` is populated, runUserHydration MUST hand
+	// the user.id to AnalyticsService.identify so PostHog can attribute
+	// subsequent events to the real user_id (gated internally by consent).
+	it('identifies the hydrated user to AnalyticsService', async () => {
+		mockUserService.current = { id: 'user-abc-123', preferredLanguage: 'en' }
+		mockUserService.ensureLoaded.mockImplementationOnce(async () => {
+			return mockUserService.current
+		})
+
+		await runUserHydration(makeContainer())
+		await flushMicrotasks()
+
+		// identify is called exactly once with the user.id. Consent gating
+		// happens inside AnalyticsService — this layer just hands over the
+		// user_id; whether PostHog actually sees it is the analytics-service
+		// spec's concern.
+		expect(mockAnalyticsService.identify).toHaveBeenCalledTimes(1)
+		expect(mockAnalyticsService.identify).toHaveBeenCalledWith('user-abc-123')
+	})
+
+	it('does NOT call AnalyticsService.identify when hydration fails', async () => {
+		mockUserService.current = undefined
+		mockUserService.ensureLoaded.mockImplementationOnce(async () => {
+			throw new Error('boom')
+		})
+
+		await runUserHydration(makeContainer())
+		await flushMicrotasks()
+
+		// No user.id available → no identify. Calling identify(undefined)
+		// would inflate PostHog with junk distinct_ids and obscure the
+		// real-user funnel.
+		expect(mockAnalyticsService.identify).not.toHaveBeenCalled()
 	})
 
 	it('applies preferred_language to i18n when present and differs from clientLocale', async () => {

--- a/src/services/user-hydration-task.ts
+++ b/src/services/user-hydration-task.ts
@@ -2,6 +2,7 @@ import { I18N } from '@aurelia/i18n'
 import { AppTask, IContainer, ILogger } from 'aurelia'
 import { ILocalStorage } from '../adapter/storage/local-storage'
 import { SessionKeys, StorageKeys } from '../constants/storage-keys'
+import { IAnalyticsService } from '../lib/analytics/analytics-service'
 import {
 	isSupportedLanguage,
 	normalizeToSupportedLanguage,
@@ -59,6 +60,16 @@ export async function runUserHydration(container: IContainer): Promise<void> {
 	// and is safe to call on the activating-task hot path.
 	const current = userService.current
 	if (!current) return
+
+	// Identify the just-loaded user to AnalyticsService. The service
+	// internally gates on `consent.analytics` — when consent is denied
+	// (the steady state for new signups before they reach the consent
+	// screen at the end of onboarding), the user_id is buffered and
+	// replayed if/when the user grants consent later. Calling identify
+	// here regardless of consent state keeps the wiring declarative:
+	// "this user just hydrated, future consent decisions can attach
+	// to them" rather than racing the consent screen.
+	container.get(IAnalyticsService).identify(current.id)
 
 	if (current.preferredLanguage) {
 		// AWAIT setLocale before runUserHydration resolves: the wrapping


### PR DESCRIPTION
## Summary

Third frontend batch for the [introduce-analytics-tool](https://github.com/liverty-music/specification/tree/main/openspec/changes/introduce-analytics-tool) change. Wires the just-hydrated `user.id` into `AnalyticsService.identify` and adds a `pendingIdentify` buffer so the call survives the natural ordering gap between `UserHydrationTask` (fires early in the `AppTask.activating` phase) and consent (granted only at the END of the onboarding flow via the consent screen, or arbitrarily later via Settings).

| Capability | Where |
| --- | --- |
| Identify-on-login call | `src/services/user-hydration-task.ts` |
| Pending-identify buffer + replay | `src/lib/analytics/analytics-service.ts` |

## Design highlights

- **UserHydrationTask** now resolves `IAnalyticsService` and calls `identify(current.id)` right after `ensureLoaded` populates the user record. The call is unconditional with respect to consent — `AnalyticsService` gates the SDK boundary internally and decides whether to forward to PostHog now (consent already granted) or buffer for replay (consent denied / not yet decided).

- **AnalyticsService** gains a `pendingIdentify` buffer. Two replay paths feed off it:

  1. `init()` — for the **steady-state returning-user case** where consent was granted on a prior boot, the buffered identify replays once the SDK loads. Order is `queue.flush()` → `identify()` so any pre-init `capture` is attributed to the anonymous id first, then the identification re-aliases the session.

  2. `applyConsentToSdk(true)` — for the **new-signup case** where consent is granted only at the consent screen at the END of onboarding. The `ConsentChanged` subscription handler calls this; it elevates persistence to `localStorage+cookie` AND replays the buffered identify so the post-consent session immediately attaches to the real `user_id`.

- The `pendingIdentify` buffer is cleared on `reset()` AND on consent revoke. The revoke path is the important one: a user who revokes then later re-grants consent MUST NOT silently re-identify with the prior `user_id` — a fresh `UserHydrationTask` call (typically next boot) is required to repopulate the buffer.

## Scope notes

- Out of scope (**Batch 3c-2**): per-event instrumentation in feature flows (artist-discovery / concert-detail / push). Identify is the foundation those events build on; landing it first keeps the follow-up PRs focused on one feature at a time.
- Out of scope (cloud-provisioning): the `posthogProjectKey` ConfigMap update — until that lands, AnalyticsService stays in nil-config debug-log mode and `identify` is a no-op.

## Tests

- `analytics-service.spec.ts` — 3 new cases:
  - replays a suppressed identify when consent is later granted
  - clears the pending identify buffer on revoke so a later grant does not silently re-identify (revoke → grant → grant cycle)
  - replays a pre-init identify after the SDK loads
- `user-hydration-task.spec.ts` — 2 new cases:
  - identifies the hydrated user to `AnalyticsService`
  - does NOT call `AnalyticsService.identify` when hydration fails

## Test plan

- [x] `make check` passes locally (biome lint + stylelint + typecheck + 1118 vitest tests + 7 script tests + brand-vocabulary)
- [ ] CI green
- [ ] Manual verification once the cloud-provisioning ConfigMap update lands: sign up a new user, walk through onboarding to the consent screen, tap "Accept selected", observe a single PostHog identify event with the user.id matching the backend `user.created` payload from PR [#316](https://github.com/liverty-music/backend/pull/316).

Refs: liverty-music/specification#532