### PR TITLE
feat(analytics): artist-discovery flow instrumentation (Batch 3c-2a)

### DIFF
--- a/src/routes/discovery/discovery-route.ts
+++ b/src/routes/discovery/discovery-route.ts
@@ -4,6 +4,10 @@ import { IEventAggregator, ILogger, resolve, watch } from 'aurelia'
 import type { DnaOrbCanvas } from '../../components/dna-orb/dna-orb-canvas'
 import { Snack } from '../../components/snack-bar/snack'
 import type { Artist } from '../../entities/artist'
+import {
+	Events,
+	IAnalyticsService,
+} from '../../lib/analytics/analytics-service'
 import { IArtistServiceClient } from '../../services/artist-service-client'
 import { IConcertService } from '../../services/concert-service'
 import { IFollowServiceClient } from '../../services/follow-service-client'
@@ -27,6 +31,7 @@ export class DiscoveryRoute {
 	private readonly ea = resolve(IEventAggregator)
 	private readonly guest = resolve(IGuestService)
 	private readonly concertService = resolve(IConcertService)
+	private readonly analytics = resolve(IAnalyticsService)
 	private readonly logger = resolve(ILogger).scopeTo('DiscoveryRoute')
 	public readonly i18n = resolve(I18N)
 
@@ -49,6 +54,12 @@ export class DiscoveryRoute {
 			onExitSearchMode: () => this.dnaOrbCanvas?.resume(),
 			onError: (key) =>
 				this.ea.publish(new Snack(this.i18n.tr(key), 'warning')),
+			onSearchCompleted: ({ queryLength, resultCount }) => {
+				this.analytics.capture(Events.ArtistSearch, {
+					query_length: queryLength,
+					result_count: resultCount,
+				})
+			},
 		},
 		resolve(ILogger).scopeTo('SearchController'),
 	)
@@ -224,6 +235,21 @@ export class DiscoveryRoute {
 			artist: artist.name,
 		})
 
+		// Analytics: bubble-tap simultaneously surfaces the artist on
+		// screen (viewed) and expresses follow intent (follow.requested).
+		// Both fire BEFORE the followService call so the events capture
+		// intent regardless of follow outcome — backend
+		// artist.follow.completed (PR #317) is the trust-critical outcome
+		// signal that pairs with follow.requested for the funnel.
+		this.analytics.capture(Events.ArtistDiscoveryViewed, {
+			artist_id: artistId,
+			source: 'discovery_orb',
+		})
+		this.analytics.capture(Events.ArtistFollowRequested, {
+			artist_id: artistId,
+			source: 'discovery_orb',
+		})
+
 		// Optimistic UI: remove from pool
 		this.bubbles.pool.remove(artistId)
 
@@ -284,6 +310,19 @@ export class DiscoveryRoute {
 
 		this.logger.info('Following artist from search', {
 			artist: artist.name,
+		})
+
+		// Same intent-capture pattern as the bubble-tap path: both
+		// viewed and follow.requested fire BEFORE the followService call
+		// so search-driven discovery shows up in the funnel even when
+		// the backend follow eventually fails.
+		this.analytics.capture(Events.ArtistDiscoveryViewed, {
+			artist_id: artistId,
+			source: 'search_result',
+		})
+		this.analytics.capture(Events.ArtistFollowRequested, {
+			artist_id: artistId,
+			source: 'search_result',
 		})
 
 		try {

--- a/src/routes/discovery/search-controller.ts
+++ b/src/routes/discovery/search-controller.ts
@@ -9,6 +9,14 @@ export interface SearchControllerCallbacks {
 	onEnterSearchMode(): void
 	onExitSearchMode(): void
 	onError(message: string): void
+	/**
+	 * Called once per successful, non-stale search after the result set is
+	 * assigned. Carries the fields the artist.search analytics event needs
+	 * (query_length, result_count). NOT called for stale-query early returns
+	 * or thrown searches — analytics MUST only fire on actual completions
+	 * so the search-quality funnel is not polluted by aborted attempts.
+	 */
+	onSearchCompleted(detail: { queryLength: number; resultCount: number }): void
 }
 
 export class SearchController {
@@ -66,6 +74,10 @@ export class SearchController {
 			const results = await this.client.search(query)
 			if (this.searchQuery.trim() !== query) return
 			this.searchResults = results
+			this.callbacks.onSearchCompleted({
+				queryLength: query.length,
+				resultCount: results.length,
+			})
 		} catch (err) {
 			this.logger.warn('Search failed', err)
 			this.callbacks.onError('discovery.searchFailed')

--- a/test/routes/discovery/search-controller.spec.ts
+++ b/test/routes/discovery/search-controller.spec.ts
@@ -27,6 +27,7 @@ describe('SearchController', () => {
 			onEnterSearchMode: vi.fn(),
 			onExitSearchMode: vi.fn(),
 			onError: vi.fn(),
+			onSearchCompleted: vi.fn(),
 		}
 
 		sut = new SearchController(mockClient, mockCallbacks, createMockLogger())
@@ -118,6 +119,73 @@ describe('SearchController', () => {
 			expect(sut.searchResults).toHaveLength(0)
 			expect(sut.isSearching).toBe(false)
 			expect(mockCallbacks.onExitSearchMode).toHaveBeenCalled()
+		})
+	})
+
+	describe('onSearchCompleted analytics signal', () => {
+		// Batch 3c-2a: the discovery-route subscribes via this callback to
+		// fire the artist.search analytics event. The callback MUST be
+		// invoked exactly once per successful, non-stale search with the
+		// observed query length and result count — anything else would
+		// pollute the search-quality funnel (aborted searches, failures,
+		// or stale responses inflating the count).
+
+		it('invokes onSearchCompleted with query length + result count on success', async () => {
+			const results = [
+				makeArtist('a1', 'Artist 1'),
+				makeArtist('a2', 'Artist 2'),
+			]
+			;(mockClient.search as ReturnType<typeof vi.fn>).mockResolvedValue(
+				results,
+			)
+
+			sut.searchQuery = 'beatles'
+			sut.onQueryChanged('beatles')
+			await vi.advanceTimersByTimeAsync(300)
+			// Drain the awaited search promise + the synchronous code that
+			// follows it.
+			await vi.advanceTimersByTimeAsync(0)
+
+			expect(mockCallbacks.onSearchCompleted).toHaveBeenCalledTimes(1)
+			expect(mockCallbacks.onSearchCompleted).toHaveBeenCalledWith({
+				queryLength: 7,
+				resultCount: 2,
+			})
+		})
+
+		it('does NOT fire on stale-response early return', async () => {
+			;(mockClient.search as ReturnType<typeof vi.fn>).mockResolvedValue([
+				makeArtist('a1', 'Stale'),
+			])
+
+			sut.searchQuery = 'first'
+			sut.onQueryChanged('first')
+			await vi.advanceTimersByTimeAsync(150)
+			sut.searchQuery = 'second'
+			await vi.advanceTimersByTimeAsync(150)
+			await vi.advanceTimersByTimeAsync(0)
+
+			// The response for 'first' arrived after the user typed
+			// 'second'. The stale-query guard short-circuits BEFORE the
+			// callback — analytics MUST stay quiet.
+			expect(mockCallbacks.onSearchCompleted).not.toHaveBeenCalled()
+		})
+
+		it('does NOT fire when search throws', async () => {
+			;(mockClient.search as ReturnType<typeof vi.fn>).mockRejectedValue(
+				new Error('network'),
+			)
+
+			sut.searchQuery = 'fail'
+			sut.onQueryChanged('fail')
+			await vi.advanceTimersByTimeAsync(300)
+			await vi.advanceTimersByTimeAsync(0)
+
+			expect(mockCallbacks.onSearchCompleted).not.toHaveBeenCalled()
+			// onError IS fired for the failure (existing contract).
+			expect(mockCallbacks.onError).toHaveBeenCalledWith(
+				'discovery.searchFailed',
+			)
 		})
 	})
 


### PR DESCRIPTION
## Summary

First per-feature instrumentation batch for the [introduce-analytics-tool](https://github.com/liverty-music/specification/tree/main/openspec/changes/introduce-analytics-tool) change. Wires three FE-side events from the catalogue into the discovery route.

| Event | Where it fires | Properties |
| --- | --- | --- |
| `artist.discovery.viewed` | `onArtistSelected` (bubble tap) + `onFollowFromSearch` (search result tap) | `artist_id`, `source` (`'discovery_orb'` \| `'search_result'`) |
| `artist.follow.requested` | Same two sites — bubble/result tap IS the follow intent in this UX | `artist_id`, `source` |
| `artist.search` | `SearchController.performSearch` success branch | `query_length`, `result_count` |

## Design highlights

- **Intent vs outcome**: Both `viewed` and `follow.requested` fire **before** the `followService.follow()` call so the events capture intent regardless of follow outcome. Backend's `artist.follow.completed` (PR [#317](https://github.com/liverty-music/backend/pull/317)) is the trust-critical outcome that pairs with `follow.requested` for the conversion funnel.
- **Idempotency**: The already-following early returns on both call sites are honoured — no duplicate `viewed`/`follow.requested` emissions when the user re-taps a followed artist.
- **SearchController decoupled from IAnalyticsService**: A new `onSearchCompleted({ queryLength, resultCount })` callback in `SearchControllerCallbacks` keeps the controller framework-agnostic. The discovery route subscribes via the callback and forwards to `analytics.capture(Events.ArtistSearch, ...)`. The callback only fires for **successful, non-stale** searches — stale-query early returns and thrown searches short-circuit before the callback so the search-quality funnel reflects real completions only.
- **trace_id**: Injected automatically by `AnalyticsService.dispatch` via `@opentelemetry/api`'s active span — call sites never plumb it.

## Tests

`search-controller.spec.ts` — 3 new cases under `onSearchCompleted analytics signal`:
- Success path fires once with the observed `queryLength` + `resultCount`.
- Stale-response early return does NOT fire.
- Thrown search does NOT fire (existing `onError` contract still triggers).

The existing `mockCallbacks` gained the new `onSearchCompleted: vi.fn()` slot — without it the callback dispatch was silently caught by `performSearch`'s try/catch and trapped as an `onError` call (caught the gap when adding the new contract).

## Scope notes

- Out of scope:
  - **Batch 3c-2b**: concert-detail instrumentation (`concert.detail.viewed`, `concert.recommendation.clicked`).
  - **Batch 3c-2c**: push subscription / notification instrumentation.
  - **Ticket lottery / purchase / entry** events — these have no FE implementation on `main` yet; they land with the features that emit them.

## Test plan

- [x] `make check` passes locally (biome lint + stylelint + typecheck + 1121 vitest tests + 7 script tests + brand-vocabulary)
- [ ] CI green
- [ ] Manual verification once the cloud-provisioning ConfigMap update lands: walk through onboarding, tap a discovery bubble, observe both `artist.discovery.viewed` and `artist.follow.requested` events in the PostHog Cloud EU dev project with matching `artist_id` + `source: 'discovery_orb'`; run a search, observe `artist.search` with the queried string's length + actual result count.

Refs: liverty-music/specification#532