### PR TITLE
feat(analytics): concert-detail flow + recommendation clicks (Batch 3c-2b)

### DIFF
--- a/src/components/live-highway/concert-highway.html
+++ b/src/components/live-highway/concert-highway.html
@@ -29,6 +29,7 @@
             event.bind="ev"
             lane="home"
             readonly.bind="isReadonly"
+            position.bind="$index"
             beam-index.bind="beamIndexMap[ev.id] ?? null"
           ></event-card>
         </li>
@@ -38,6 +39,7 @@
             event.bind="ev"
             lane="nearby"
             readonly.bind="isReadonly"
+            position.bind="$index"
             beam-index.bind="beamIndexMap[ev.id] ?? null"
           ></event-card>
         </li>
@@ -47,6 +49,7 @@
             event.bind="ev"
             lane="away"
             readonly.bind="isReadonly"
+            position.bind="$index"
             beam-index.bind="beamIndexMap[ev.id] ?? null"
           ></event-card>
         </li>

--- a/src/components/live-highway/event-card.ts
+++ b/src/components/live-highway/event-card.ts
@@ -9,7 +9,6 @@ import type { LaneType, LiveEvent } from './live-event'
 export class EventCard {
 	@bindable public event!: LiveEvent
 	@bindable public lane: LaneType = 'home'
-	/** `null` marks surfaces that skip position tracking — emitting `0` there would skew CTR metrics. */
 	@bindable public position: number | null = null
 	public logoError = false
 

--- a/src/components/live-highway/event-card.ts
+++ b/src/components/live-highway/event-card.ts
@@ -9,16 +9,7 @@ import type { LaneType, LiveEvent } from './live-event'
 export class EventCard {
 	@bindable public event!: LiveEvent
 	@bindable public lane: LaneType = 'home'
-	/**
-	 * 0-based position of this card within its lane (`repeat.for` `$index`
-	 * from concert-highway.html). Powers the `position` property on the
-	 * `concert.recommendation.clicked` analytics event so the
-	 * recommendation engine can correlate click-through against the
-	 * backend's `concert.recommendation.served` impression metric. Left
-	 * as `null` for callers that do not yet bind it; the click handler
-	 * skips the analytics emission in that case rather than capturing a
-	 * misleading `0`.
-	 */
+	/** `null` marks surfaces that skip position tracking — emitting `0` there would skew CTR metrics. */
 	@bindable public position: number | null = null
 	public logoError = false
 
@@ -56,14 +47,8 @@ export class EventCard {
 
 	public onClick(): void {
 		if (this.readonly) return
-		// Fire concert.recommendation.clicked BEFORE the custom event
-		// dispatch so the analytics signal is captured even if the
-		// downstream bottom-sheet open path throws. `position === null`
-		// indicates a caller that has not opted into recommendation
-		// tracking (e.g. the read-only preview card in onboarding) —
-		// emitting position: 0 in that branch would pollute the
-		// recommendation-engine click-through metric, so the event is
-		// skipped entirely.
+		// Fire before dispatch — analytics must survive a downstream throw.
+		// Skip when position is null; emitting 0 there would skew CTR metrics.
 		if (this.position !== null) {
 			this.analytics.capture(Events.ConcertRecommendationClicked, {
 				concert_id: this.event.id,

--- a/src/components/live-highway/event-card.ts
+++ b/src/components/live-highway/event-card.ts
@@ -1,13 +1,29 @@
 import { bindable, INode, resolve } from 'aurelia'
 import { bestLogoUrl } from '../../entities/artist'
+import {
+	Events,
+	IAnalyticsService,
+} from '../../lib/analytics/analytics-service'
 import type { LaneType, LiveEvent } from './live-event'
 
 export class EventCard {
 	@bindable public event!: LiveEvent
 	@bindable public lane: LaneType = 'home'
+	/**
+	 * 0-based position of this card within its lane (`repeat.for` `$index`
+	 * from concert-highway.html). Powers the `position` property on the
+	 * `concert.recommendation.clicked` analytics event so the
+	 * recommendation engine can correlate click-through against the
+	 * backend's `concert.recommendation.served` impression metric. Left
+	 * as `null` for callers that do not yet bind it; the click handler
+	 * skips the analytics emission in that case rather than capturing a
+	 * misleading `0`.
+	 */
+	@bindable public position: number | null = null
 	public logoError = false
 
 	private readonly element = resolve(INode) as HTMLElement
+	private readonly analytics = resolve(IAnalyticsService)
 
 	public get logoUrl(): string | undefined {
 		return bestLogoUrl(this.event.artist)
@@ -40,6 +56,21 @@ export class EventCard {
 
 	public onClick(): void {
 		if (this.readonly) return
+		// Fire concert.recommendation.clicked BEFORE the custom event
+		// dispatch so the analytics signal is captured even if the
+		// downstream bottom-sheet open path throws. `position === null`
+		// indicates a caller that has not opted into recommendation
+		// tracking (e.g. the read-only preview card in onboarding) —
+		// emitting position: 0 in that branch would pollute the
+		// recommendation-engine click-through metric, so the event is
+		// skipped entirely.
+		if (this.position !== null) {
+			this.analytics.capture(Events.ConcertRecommendationClicked, {
+				concert_id: this.event.id,
+				artist_id: this.event.artistId,
+				position: this.position,
+			})
+		}
 		this.element.dispatchEvent(
 			new CustomEvent('event-selected', {
 				detail: { event: this.event },

--- a/src/components/live-highway/event-detail-sheet.ts
+++ b/src/components/live-highway/event-detail-sheet.ts
@@ -70,15 +70,6 @@ export class EventDetailSheet {
 		return `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(e.title)}&dates=${dateStr}T${startStr}/${endDateStr}T${endStr}&location=${encodeURIComponent(e.venueName)}`
 	}
 
-	/**
-	 * Open the sheet for a given event, pushing a history entry for
-	 * deep-link support. The `source` parameter identifies the UI surface
-	 * that triggered the open — currently only the dashboard concert
-	 * highway, which maps to `'recommendation'` because the displayed
-	 * concert list IS the backend's recommendation feed (paired with
-	 * `concert.recommendation.served`). Defaults to `'page'` for callers
-	 * that have not yet been audited; the catalogue allows it.
-	 */
 	public open(event: LiveEvent, source: EventSource = 'page'): void {
 		this.event = event
 		this.isOpen = true
@@ -91,11 +82,7 @@ export class EventDetailSheet {
 		// Listen for browser back navigation (popstate) to close the sheet.
 		window.addEventListener('popstate', this.onPopstate)
 
-		// Fire concert.detail.viewed AFTER the sheet state flips so a
-		// listener (e.g. the dashboard view's `if.bind="detailSheet.isOpen"`
-		// gate) does not see an inconsistent state mid-capture. trace_id is
-		// injected automatically by AnalyticsService from the active OTel
-		// span — no manual plumbing.
+		// Fire after the sheet state flips — listeners observe consistent state.
 		this.analytics.capture(Events.ConcertDetailViewed, {
 			concert_id: event.id,
 			artist_id: event.artistId,

--- a/src/components/live-highway/event-detail-sheet.ts
+++ b/src/components/live-highway/event-detail-sheet.ts
@@ -2,6 +2,11 @@ import { bindable, ILogger, resolve } from 'aurelia'
 import { IHistory } from '../../adapter/browser/history'
 import { displayName } from '../../constants/iso3166'
 import { bestBackgroundUrl } from '../../entities/artist'
+import {
+	Events,
+	IAnalyticsService,
+} from '../../lib/analytics/analytics-service'
+import type { EventSource } from '../../services/analytics-events'
 import { IAuthService } from '../../services/auth-service'
 import { ITicketJourneyService } from '../../services/ticket-journey-service'
 import type { JourneyStatus, LiveEvent } from './live-event'
@@ -16,6 +21,7 @@ export class EventDetailSheet {
 	private readonly journeyService = resolve(ITicketJourneyService)
 	private readonly authService = resolve(IAuthService)
 	private readonly history = resolve(IHistory)
+	private readonly analytics = resolve(IAnalyticsService)
 
 	// Arrow function to allow `removeEventListener` with the same reference
 	private readonly onPopstate = (): void => {
@@ -64,8 +70,16 @@ export class EventDetailSheet {
 		return `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(e.title)}&dates=${dateStr}T${startStr}/${endDateStr}T${endStr}&location=${encodeURIComponent(e.venueName)}`
 	}
 
-	/** Open the sheet for a given event, pushing a history entry for deep-link support */
-	public open(event: LiveEvent): void {
+	/**
+	 * Open the sheet for a given event, pushing a history entry for
+	 * deep-link support. The `source` parameter identifies the UI surface
+	 * that triggered the open — currently only the dashboard concert
+	 * highway, which maps to `'recommendation'` because the displayed
+	 * concert list IS the backend's recommendation feed (paired with
+	 * `concert.recommendation.served`). Defaults to `'page'` for callers
+	 * that have not yet been audited; the catalogue allows it.
+	 */
+	public open(event: LiveEvent, source: EventSource = 'page'): void {
 		this.event = event
 		this.isOpen = true
 
@@ -76,6 +90,17 @@ export class EventDetailSheet {
 
 		// Listen for browser back navigation (popstate) to close the sheet.
 		window.addEventListener('popstate', this.onPopstate)
+
+		// Fire concert.detail.viewed AFTER the sheet state flips so a
+		// listener (e.g. the dashboard view's `if.bind="detailSheet.isOpen"`
+		// gate) does not see an inconsistent state mid-capture. trace_id is
+		// injected automatically by AnalyticsService from the active OTel
+		// span — no manual plumbing.
+		this.analytics.capture(Events.ConcertDetailViewed, {
+			concert_id: event.id,
+			artist_id: event.artistId,
+			source,
+		})
 	}
 
 	/** Programmatic close — replaces current history entry with dashboard URL */

--- a/src/routes/dashboard/dashboard-route.ts
+++ b/src/routes/dashboard/dashboard-route.ts
@@ -226,7 +226,12 @@ export class DashboardRoute {
 	}
 
 	public onEventSelected(event: CustomEvent<{ event: LiveEvent }>): void {
-		this.detailSheet?.open(event.detail.event)
+		// The dashboard concert list IS the backend's recommendation feed
+		// (paired with concert.recommendation.served — see the
+		// introduce-analytics-tool event catalogue). Tag the source
+		// accordingly so the FE analytics events can be joined to the BE
+		// impression-served signal in PostHog.
+		this.detailSheet?.open(event.detail.event, 'recommendation')
 	}
 
 	public onSignupRequested(): void {

--- a/src/routes/dashboard/dashboard-route.ts
+++ b/src/routes/dashboard/dashboard-route.ts
@@ -226,11 +226,8 @@ export class DashboardRoute {
 	}
 
 	public onEventSelected(event: CustomEvent<{ event: LiveEvent }>): void {
-		// The dashboard concert list IS the backend's recommendation feed
-		// (paired with concert.recommendation.served — see the
-		// introduce-analytics-tool event catalogue). Tag the source
-		// accordingly so the FE analytics events can be joined to the BE
-		// impression-served signal in PostHog.
+		// The dashboard concert list IS the recommendation feed — tag the source
+		// so FE click events can be joined to the BE impression signal in PostHog.
 		this.detailSheet?.open(event.detail.event, 'recommendation')
 	}
 

--- a/src/services/analytics-events.ts
+++ b/src/services/analytics-events.ts
@@ -38,7 +38,15 @@
  *   Call sites do not need to plumb trace_id manually.
  */
 
-type EventSource =
+/**
+ * UI surface that triggered an analytics event. Carried as the `source`
+ * property on events whose downstream funnel cares about origin (e.g.
+ * `artist.discovery.viewed` from a bubble tap vs a search result). The
+ * union is exported so call-site helpers (route handlers, sheet open
+ * methods) can accept it as a typed parameter without inlining the
+ * literal union or stringly-typing the value.
+ */
+export type EventSource =
 	| 'page'
 	| 'artist_page'
 	| 'search_result'

--- a/src/services/analytics-events.ts
+++ b/src/services/analytics-events.ts
@@ -38,14 +38,6 @@
  *   Call sites do not need to plumb trace_id manually.
  */
 
-/**
- * UI surface that triggered an analytics event. Carried as the `source`
- * property on events whose downstream funnel cares about origin (e.g.
- * `artist.discovery.viewed` from a bubble tap vs a search result). The
- * union is exported so call-site helpers (route handlers, sheet open
- * methods) can accept it as a typed parameter without inlining the
- * literal union or stringly-typing the value.
- */
 export type EventSource =
 	| 'page'
 	| 'artist_page'

--- a/test/components/live-highway/concert-highway.composition.spec.ts
+++ b/test/components/live-highway/concert-highway.composition.spec.ts
@@ -19,11 +19,9 @@ const sharedDeps = [
 		publish: vi.fn(),
 		subscribe: vi.fn(() => ({ dispose: vi.fn() })),
 	}),
-	// EventCard now resolves IAnalyticsService for the
-	// concert.recommendation.clicked emission added in the
-	// introduce-analytics-tool change. Register a stub so the composition
-	// tests do not transitively pull in the real consent / runtime-config
-	// stack — those have their own dedicated specs.
+	// IAnalyticsService is now required by EventCard. Register a stub so
+	// composition tests do not transitively pull in the real consent /
+	// runtime-config stack — those have their own dedicated specs.
 	Registration.instance(IAnalyticsService, {
 		capture: vi.fn(),
 		identify: vi.fn(),

--- a/test/components/live-highway/concert-highway.composition.spec.ts
+++ b/test/components/live-highway/concert-highway.composition.spec.ts
@@ -6,6 +6,7 @@ import { ConcertHighway } from '../../../src/components/live-highway/concert-hig
 import { EventCard } from '../../../src/components/live-highway/event-card'
 import { BeamVarsCustomAttribute } from '../../../src/custom-attributes/beam-vars'
 import type { DateGroup } from '../../../src/entities/concert'
+import { IAnalyticsService } from '../../../src/lib/analytics/analytics-service'
 import { makeConcert, makeDateGroup } from '../../helpers/mock-date-groups'
 import { createMockI18n } from '../../helpers/mock-i18n'
 
@@ -17,6 +18,17 @@ const sharedDeps = [
 	Registration.instance(IEventAggregator, {
 		publish: vi.fn(),
 		subscribe: vi.fn(() => ({ dispose: vi.fn() })),
+	}),
+	// EventCard now resolves IAnalyticsService for the
+	// concert.recommendation.clicked emission added in the
+	// introduce-analytics-tool change. Register a stub so the composition
+	// tests do not transitively pull in the real consent / runtime-config
+	// stack — those have their own dedicated specs.
+	Registration.instance(IAnalyticsService, {
+		capture: vi.fn(),
+		identify: vi.fn(),
+		reset: vi.fn(),
+		getFeatureFlag: vi.fn((_key: string, fallback: unknown) => fallback),
 	}),
 ]
 

--- a/test/components/live-highway/event-card.spec.ts
+++ b/test/components/live-highway/event-card.spec.ts
@@ -85,12 +85,6 @@ describe('EventCard', () => {
 			expect(customEvent.bubbles).toBe(true)
 		})
 
-		// position-aware recommendation click. When the
-		// dashboard binds position (the repeat.for $index per lane), the
-		// click MUST fire concert.recommendation.clicked with the
-		// (concert_id, artist_id, position) tuple BEFORE the
-		// event-selected dispatch — so a downstream open path that
-		// throws does not eat the analytics signal.
 		it('fires concert.recommendation.clicked when position is bound', () => {
 			component.event = liveEvent
 			component.position = 2
@@ -108,10 +102,6 @@ describe('EventCard', () => {
 			)
 		})
 
-		// Read-only preview cards (e.g. the onboarding preview lane) do
-		// not bind position. Emitting position: 0 there would pollute the
-		// CTR-by-position breakdown with junk samples for a slot that
-		// users could not actually click.
 		it('does NOT fire concert.recommendation.clicked when position is null', () => {
 			component.event = liveEvent
 			component.position = null
@@ -128,8 +118,6 @@ describe('EventCard', () => {
 
 			component.onClick()
 
-			// readonly short-circuits the entire onClick body, including
-			// the analytics emission.
 			expect(mockAnalytics.capture).not.toHaveBeenCalled()
 		})
 	})

--- a/test/components/live-highway/event-card.spec.ts
+++ b/test/components/live-highway/event-card.spec.ts
@@ -2,16 +2,33 @@ import { INode, Registration } from 'aurelia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { EventCard } from '../../../src/components/live-highway/event-card'
 import type { LiveEvent } from '../../../src/components/live-highway/live-event'
+import { IAnalyticsService } from '../../../src/lib/analytics/analytics-service'
 import { createTestContainer } from '../../helpers/create-container'
 
 describe('EventCard', () => {
 	let component: EventCard
 	let mockElement: HTMLElement
+	let mockAnalytics: {
+		capture: ReturnType<typeof vi.fn>
+		identify: ReturnType<typeof vi.fn>
+		reset: ReturnType<typeof vi.fn>
+		getFeatureFlag: ReturnType<typeof vi.fn>
+	}
 
 	beforeEach(() => {
 		mockElement = document.createElement('div')
+		mockAnalytics = {
+			capture: vi.fn(),
+			identify: vi.fn(),
+			reset: vi.fn(),
+			getFeatureFlag: vi.fn((_key: string, fallback: unknown) => fallback),
+		}
 		const container = createTestContainer(
 			Registration.instance(INode, mockElement),
+			// Stub IAnalyticsService so the onClick analytics emission
+			// can be asserted without spinning up the real PostHog
+			// adapter (which would also pull in IConsentService et al.).
+			Registration.instance(IAnalyticsService, mockAnalytics),
 		)
 		container.register(EventCard)
 		component = container.get(EventCard)
@@ -42,32 +59,78 @@ describe('EventCard', () => {
 	})
 
 	describe('onClick', () => {
+		const liveEvent: LiveEvent = {
+			artistName: 'Artist',
+			id: 'event-1',
+			artistId: 'artist-1',
+			venueName: 'Venue',
+			locationLabel: 'Tokyo',
+			date: new Date(2026, 2, 15),
+			startTime: '19:00',
+			title: 'Concert',
+			sourceUrl: 'https://example.com',
+		}
+
 		it('should dispatch event-selected custom event with bubbling', () => {
-			// Arrange
-			const event: LiveEvent = {
-				artistName: 'Artist',
-				id: 'event-1',
-				artistId: 'artist-1',
-				venueName: 'Venue',
-				locationLabel: 'Tokyo',
-				date: new Date(2026, 2, 15),
-				startTime: '19:00',
-				title: 'Concert',
-				sourceUrl: 'https://example.com',
-			}
-			component.event = event
+			component.event = liveEvent
 
 			const eventSpy = vi.fn()
 			mockElement.addEventListener('event-selected', eventSpy)
 
-			// Act
 			component.onClick()
 
-			// Assert
 			expect(eventSpy).toHaveBeenCalled()
 			const customEvent = eventSpy.mock.calls[0][0] as CustomEvent
-			expect(customEvent.detail.event).toBe(event)
+			expect(customEvent.detail.event).toBe(liveEvent)
 			expect(customEvent.bubbles).toBe(true)
+		})
+
+		// Batch 3c-2b: position-aware recommendation click. When the
+		// dashboard binds position (the repeat.for $index per lane), the
+		// click MUST fire concert.recommendation.clicked with the
+		// (concert_id, artist_id, position) tuple BEFORE the
+		// event-selected dispatch — so a downstream open path that
+		// throws does not eat the analytics signal.
+		it('fires concert.recommendation.clicked when position is bound', () => {
+			component.event = liveEvent
+			component.position = 2
+
+			component.onClick()
+
+			expect(mockAnalytics.capture).toHaveBeenCalledTimes(1)
+			expect(mockAnalytics.capture).toHaveBeenCalledWith(
+				'concert.recommendation.clicked',
+				{
+					concert_id: 'event-1',
+					artist_id: 'artist-1',
+					position: 2,
+				},
+			)
+		})
+
+		// Read-only preview cards (e.g. the onboarding preview lane) do
+		// not bind position. Emitting position: 0 there would pollute the
+		// CTR-by-position breakdown with junk samples for a slot that
+		// users could not actually click.
+		it('does NOT fire concert.recommendation.clicked when position is null', () => {
+			component.event = liveEvent
+			component.position = null
+
+			component.onClick()
+
+			expect(mockAnalytics.capture).not.toHaveBeenCalled()
+		})
+
+		it('does NOT fire concert.recommendation.clicked when readonly is true', () => {
+			component.event = liveEvent
+			component.position = 3
+			component.readonly = true
+
+			component.onClick()
+
+			// readonly short-circuits the entire onClick body, including
+			// the analytics emission.
+			expect(mockAnalytics.capture).not.toHaveBeenCalled()
 		})
 	})
 })

--- a/test/components/live-highway/event-card.spec.ts
+++ b/test/components/live-highway/event-card.spec.ts
@@ -85,7 +85,7 @@ describe('EventCard', () => {
 			expect(customEvent.bubbles).toBe(true)
 		})
 
-		// Batch 3c-2b: position-aware recommendation click. When the
+		// position-aware recommendation click. When the
 		// dashboard binds position (the repeat.for $index per lane), the
 		// click MUST fire concert.recommendation.clicked with the
 		// (concert_id, artist_id, position) tuple BEFORE the

--- a/test/components/live-highway/event-detail-sheet.spec.ts
+++ b/test/components/live-highway/event-detail-sheet.spec.ts
@@ -2,6 +2,7 @@ import { Registration } from 'aurelia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { IHistory } from '../../../src/adapter/browser/history'
 import type { LiveEvent } from '../../../src/components/live-highway/live-event'
+import { IAnalyticsService } from '../../../src/lib/analytics/analytics-service'
 import { IAuthService } from '../../../src/services/auth-service'
 import { createTestContainer } from '../../helpers/create-container'
 import { createMockHistory } from '../../helpers/mock-history'
@@ -34,13 +35,26 @@ function createMockAuthService(isAuthenticated = true) {
 describe('EventDetailSheet', () => {
 	let sut: InstanceType<typeof EventDetailSheet>
 	let mockHistory: ReturnType<typeof createMockHistory>
+	let mockAnalytics: {
+		capture: ReturnType<typeof vi.fn>
+		identify: ReturnType<typeof vi.fn>
+		reset: ReturnType<typeof vi.fn>
+		getFeatureFlag: ReturnType<typeof vi.fn>
+	}
 
 	beforeEach(() => {
 		mockHistory = createMockHistory()
+		mockAnalytics = {
+			capture: vi.fn(),
+			identify: vi.fn(),
+			reset: vi.fn(),
+			getFeatureFlag: vi.fn((_key: string, fallback: unknown) => fallback),
+		}
 
 		const container = createTestContainer(
 			Registration.instance(IAuthService, createMockAuthService()),
 			Registration.instance(IHistory, mockHistory),
+			Registration.instance(IAnalyticsService, mockAnalytics),
 		)
 		container.register(EventDetailSheet)
 		sut = container.get(EventDetailSheet)
@@ -138,6 +152,36 @@ describe('EventDetailSheet', () => {
 			sut.close()
 
 			expect(removeSpy).toHaveBeenCalledWith('popstate', expect.any(Function))
+		})
+
+		// Batch 3c-2b: open() fires concert.detail.viewed with the
+		// supplied source so downstream PostHog dashboards can break
+		// detail-view rate by surface.
+		it('fires concert.detail.viewed on open with the supplied source', () => {
+			const event = makeEvent()
+
+			sut.open(event, 'recommendation')
+
+			expect(mockAnalytics.capture).toHaveBeenCalledTimes(1)
+			expect(mockAnalytics.capture).toHaveBeenCalledWith(
+				'concert.detail.viewed',
+				{
+					concert_id: 'c1',
+					artist_id: 'a1',
+					source: 'recommendation',
+				},
+			)
+		})
+
+		it("defaults source to 'page' when omitted", () => {
+			const event = makeEvent()
+
+			sut.open(event)
+
+			expect(mockAnalytics.capture).toHaveBeenCalledWith(
+				'concert.detail.viewed',
+				expect.objectContaining({ source: 'page' }),
+			)
 		})
 	})
 

--- a/test/components/live-highway/event-detail-sheet.spec.ts
+++ b/test/components/live-highway/event-detail-sheet.spec.ts
@@ -154,9 +154,6 @@ describe('EventDetailSheet', () => {
 			expect(removeSpy).toHaveBeenCalledWith('popstate', expect.any(Function))
 		})
 
-		// open() fires concert.detail.viewed with the
-		// supplied source so downstream PostHog dashboards can break
-		// detail-view rate by surface.
 		it('fires concert.detail.viewed on open with the supplied source', () => {
 			const event = makeEvent()
 

--- a/test/components/live-highway/event-detail-sheet.spec.ts
+++ b/test/components/live-highway/event-detail-sheet.spec.ts
@@ -154,7 +154,7 @@ describe('EventDetailSheet', () => {
 			expect(removeSpy).toHaveBeenCalledWith('popstate', expect.any(Function))
 		})
 
-		// Batch 3c-2b: open() fires concert.detail.viewed with the
+		// open() fires concert.detail.viewed with the
 		// supplied source so downstream PostHog dashboards can break
 		// detail-view rate by surface.
 		it('fires concert.detail.viewed on open with the supplied source', () => {


### PR DESCRIPTION
## Summary

Second per-feature instrumentation batch for the [introduce-analytics-tool](https://github.com/liverty-music/specification/tree/main/openspec/changes/introduce-analytics-tool) change. Wires two FE-side events from the catalogue into the dashboard concert flow.

| Event | Where it fires | Properties |
| --- | --- | --- |
| `concert.detail.viewed` | `EventDetailSheet.open` (called by `DashboardRoute.onEventSelected`) | `concert_id`, `artist_id`, `source` (dashboard passes `'recommendation'`) |
| `concert.recommendation.clicked` | `EventCard.onClick` (every dashboard lane card) | `concert_id`, `artist_id`, `position` (0-based `$index` within lane) |

## Design highlights

- **Source is caller-supplied**: `EventDetailSheet.open(event, source?)` takes the surface name as a parameter so today's dashboard caller can tag itself `'recommendation'` (paired with backend's `concert.recommendation.served`), while a future direct-deeplink route could pass `'page'`. Defaults to `'page'` for audit safety — any new caller that omits the argument still produces a well-typed event.

- **`null` position sentinel**: `EventCard.position` is `number | null` with `null` as the default. When `null`, the click handler skips the analytics emission entirely. This protects the recommendation-engine's CTR-by-position metric from spurious `position: 0` samples emitted by read-only preview cards (e.g. onboarding) or future surfaces that don't bind position.

- **Per-lane position**: `concert-highway.html` passes `$index` from each lane's `repeat.for` independently — position is 0-N within HOME / NEAR / AWAY rather than a global running index. Matches the recommendation engine's lane semantics; a global projection would lose the lane signal.

- **`EventSource` now exported**: The union type was module-private inside `analytics-events.ts`. Promoted to a public export so call-site helpers (sheet open methods, route handlers) can accept it as a typed parameter without inlining the literal union.

## Tests

- `event-card.spec.ts` — 3 new cases:
  - Fires `concert.recommendation.clicked` with `(concert_id, artist_id, position)` when position is bound.
  - Does NOT fire when `position` is `null`.
  - Does NOT fire when `readonly` is `true` (existing readonly short-circuit still wins).
- `event-detail-sheet.spec.ts` — 2 new cases:
  - `open(event, source)` fires `concert.detail.viewed` with the supplied source.
  - Source defaults to `'page'` when omitted.
- `concert-highway.composition.spec.ts` — registered an `IAnalyticsService` stub in `sharedDeps` so the composition fixture does not transitively pull in the consent + runtime-config stack (those have their own specs).

## Scope notes

- Out of scope:
  - **Batch 3c-2c**: push subscription / notification instrumentation.
  - **Ticket lottery / purchase / entry**: no FE implementation on `main` yet; these events land with the features.

## Test plan

- [x] `make check` passes locally (biome lint + stylelint + typecheck + 1126 vitest tests + 7 script tests + brand-vocabulary)
- [ ] CI green
- [ ] Manual verification once the cloud-provisioning ConfigMap update lands: open dashboard, tap a concert in any lane, observe `concert.recommendation.clicked` with the correct lane index in PostHog; observe `concert.detail.viewed` fire as the bottom-sheet opens with `source: 'recommendation'`.

Refs: liverty-music/specification#532