### PR TITLE
feat(analytics): push.subscription.requested in notification prompt (Batch 3c-2c)

### DIFF
--- a/src/components/notification-prompt/notification-prompt.ts
+++ b/src/components/notification-prompt/notification-prompt.ts
@@ -1,5 +1,9 @@
 import { ILogger, resolve } from 'aurelia'
 import { StorageKeys } from '../../constants/storage-keys'
+import {
+	Events,
+	IAnalyticsService,
+} from '../../lib/analytics/analytics-service'
 import { IAuthService } from '../../services/auth-service'
 import { INotificationManager } from '../../services/notification-manager'
 import { IOnboardingService } from '../../services/onboarding-service'
@@ -16,6 +20,7 @@ export class NotificationPrompt {
 	private readonly auth = resolve(IAuthService)
 	private readonly onboarding = resolve(IOnboardingService)
 	private readonly promptCoordinator = resolve(IPromptCoordinator)
+	private readonly analytics = resolve(IAnalyticsService)
 
 	public attached(): void {
 		if (!this.auth.isAuthenticated) return
@@ -47,6 +52,13 @@ export class NotificationPrompt {
 	}
 
 	public async enable(): Promise<void> {
+		// Fire intent BEFORE the async permission flow so a denied OS
+		// dialog (or a thrown pushService.create) does not eat the signal.
+		// Paired with backend push.subscription.completed for the opt-in
+		// funnel.
+		this.analytics.capture(Events.PushSubscriptionRequested, {
+			source: 'page',
+		})
 		this.isLoading = true
 		try {
 			await this.pushService.create()

--- a/test/components/notification-prompt.spec.ts
+++ b/test/components/notification-prompt.spec.ts
@@ -1,6 +1,7 @@
 import { DI, ILogger, Registration } from 'aurelia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NotificationPrompt } from '../../src/components/notification-prompt/notification-prompt'
+import { IAnalyticsService } from '../../src/lib/analytics/analytics-service'
 import { IAuthService } from '../../src/services/auth-service'
 import { INotificationManager } from '../../src/services/notification-manager'
 import { IOnboardingService } from '../../src/services/onboarding-service'
@@ -10,6 +11,13 @@ import { createMockLogger } from '../helpers/mock-logger'
 
 describe('NotificationPrompt', () => {
 	let sut: NotificationPrompt
+	let mockAnalytics: {
+		capture: ReturnType<typeof vi.fn>
+		identify: ReturnType<typeof vi.fn>
+		reset: ReturnType<typeof vi.fn>
+		getFeatureFlag: ReturnType<typeof vi.fn>
+	}
+	let mockPushService: { create: ReturnType<typeof vi.fn> }
 
 	function create(
 		overrides: {
@@ -18,6 +26,7 @@ describe('NotificationPrompt', () => {
 			canShowPrompt?: boolean
 			permission?: NotificationPermission
 			dismissed?: boolean
+			pushCreate?: ReturnType<typeof vi.fn>
 		} = {},
 	): NotificationPrompt {
 		const container = DI.createContainer()
@@ -43,11 +52,11 @@ describe('NotificationPrompt', () => {
 				permission: overrides.permission ?? 'default',
 			}),
 		)
-		container.register(
-			Registration.instance(IPushService, {
-				subscribe: vi.fn().mockResolvedValue(undefined),
-			}),
-		)
+		mockPushService = {
+			create: overrides.pushCreate ?? vi.fn().mockResolvedValue(undefined),
+		}
+		container.register(Registration.instance(IPushService, mockPushService))
+		container.register(Registration.instance(IAnalyticsService, mockAnalytics))
 
 		if (overrides.dismissed) {
 			localStorage.setItem('ui.notificationPromptDismissed', 'true')
@@ -59,6 +68,12 @@ describe('NotificationPrompt', () => {
 
 	beforeEach(() => {
 		localStorage.clear()
+		mockAnalytics = {
+			capture: vi.fn(),
+			identify: vi.fn(),
+			reset: vi.fn(),
+			getFeatureFlag: vi.fn((_key: string, fallback: unknown) => fallback),
+		}
 		// jsdom does not provide window.matchMedia
 		window.matchMedia = vi.fn().mockImplementation((query: string) => ({
 			matches: false,
@@ -159,6 +174,34 @@ describe('NotificationPrompt', () => {
 			expect(sut.isVisible).toBe(false)
 			expect(localStorage.getItem('ui.notificationPromptDismissed')).toBe(
 				'true',
+			)
+		})
+	})
+
+	describe('enable', () => {
+		it('fires push.subscription.requested before the async pushService.create call', async () => {
+			sut = create()
+			await sut.enable()
+
+			expect(mockAnalytics.capture).toHaveBeenCalledWith(
+				'push.subscription.requested',
+				{ source: 'page' },
+			)
+			expect(mockPushService.create).toHaveBeenCalledTimes(1)
+		})
+
+		it('still fires push.subscription.requested when pushService.create throws', async () => {
+			sut = create({
+				pushCreate: vi.fn().mockRejectedValue(new Error('denied')),
+			})
+
+			await sut.enable()
+
+			// Intent must be captured regardless of outcome — denied OS
+			// permission dialog is still a meaningful funnel signal.
+			expect(mockAnalytics.capture).toHaveBeenCalledWith(
+				'push.subscription.requested',
+				{ source: 'page' },
 			)
 		})
 	})


### PR DESCRIPTION
## Summary

Third per-feature instrumentation batch for the [introduce-analytics-tool](https://github.com/liverty-music/specification/tree/main/openspec/changes/introduce-analytics-tool) change. Wires `push.subscription.requested` into the notification prompt's `enable()` handler — the entry point where the user opts in to Web Push.

| Event | Where it fires | Properties |
| --- | --- | --- |
| `push.subscription.requested` | `NotificationPrompt.enable()` before `pushService.create()` | `source: 'page'` |

## Design highlights

- **Intent before outcome**: The capture fires BEFORE `pushService.create()` so a denied OS permission dialog or a network failure doesn't eat the intent signal. Pairs with the backend's `push.subscription.completed` event for the opt-in conversion funnel.
- **`source: 'page'`**: The in-app prompt is a page-level overlay; the existing `EventSource` union's `'notification'` value would be semantically wrong (it means "user arrived from a notification deep-link", not "user is being asked to subscribe to notifications").

## Tests

`notification-prompt.spec.ts` — 2 new cases under a new `enable` describe block:
- Happy path: fires `push.subscription.requested` with `source: 'page'` and proceeds to call `pushService.create`.
- Failure path: still fires the event when `pushService.create` rejects — intent survives outcome.

The existing test container gained an `IAnalyticsService` mock alongside the existing service stubs; `pushService` is now also extracted into a per-test mock so the `create` spy is observable in the new cases.

## Scope notes

- Out of scope:
  - `push.notification.opened` / `push.notification.dismissed` — these fire from the service worker / Notification API, a different plumbing surface that warrants its own batch.
  - Backend `push.subscription.completed` publisher — needs `PUSH.*` JetStream provisioning in cloud-provisioning + a publisher in `pushNotificationUseCase.Create`. Deferred to the same batch that adds the new stream.

## Test plan

- [x] `make check` passes locally (biome lint + stylelint + typecheck + 1128 vitest tests + 7 script tests + brand-vocabulary)
- [ ] CI green
- [ ] Manual verification once the cloud-provisioning ConfigMap update lands: tap "Enable" on the notification prompt, observe a single `push.subscription.requested` event in PostHog regardless of whether the OS dialog is accepted or denied.

Refs: liverty-music/specification#532