### PR TITLE
fix(analytics): allow PostHog Cloud EU domains in CSP

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,11 +8,11 @@
   <meta name="theme-color" content="#1a1a3a">
   <meta http-equiv="Content-Security-Policy" content="
     default-src 'self';
-    script-src 'self' 'wasm-unsafe-eval' blob:;
+    script-src 'self' 'wasm-unsafe-eval' blob: https://eu-assets.i.posthog.com;
     style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
     font-src 'self' https://fonts.gstatic.com;
-    connect-src 'self' https://*.zitadel.cloud https://*.liverty-music.app;
-    img-src 'self' data: blob: https://assets.fanart.tv;
+    connect-src 'self' https://*.zitadel.cloud https://*.liverty-music.app https://eu.i.posthog.com https://eu-assets.i.posthog.com;
+    img-src 'self' data: blob: https://assets.fanart.tv https://eu.i.posthog.com;
     frame-src https://*.zitadel.cloud;
     worker-src 'self' blob:;
   ">


### PR DESCRIPTION
## Summary

Browser console on https://liverty-music.app/my-artists confirms the PostHog SDK is fully booted in production — it reads `posthogProjectKey` from `/config.json`, AnalyticsService initialises, and SDK starts attempting to reach PostHog Cloud EU. **Every request is then blocked by the existing Content-Security-Policy.**

| Blocked | Directive violated |
| --- | --- |
| `GET https://eu-assets.i.posthog.com/array/phc_.../config.js` | `script-src` |
| `POST https://eu-assets.i.posthog.com/array/.../config?...` | `connect-src` |
| `GET https://eu.i.posthog.com/flags?v=2&...` | `connect-src` |
| `POST https://eu.i.posthog.com/e/?...` | `connect-src` |

The analytics integration is otherwise correctly wired (token in `/config.json`, AnalyticsService DI registered, `page.viewed` capture call sites firing in app-shell, deferred init via `requestIdleCallback`). CSP was the only thing standing between event capture and PostHog ingestion.

## Change

```diff
- script-src 'self' 'wasm-unsafe-eval' blob:;
- connect-src 'self' https://*.zitadel.cloud https://*.liverty-music.app;
- img-src 'self' data: blob: https://assets.fanart.tv;
+ script-src 'self' 'wasm-unsafe-eval' blob: https://eu-assets.i.posthog.com;
+ connect-src 'self' https://*.zitadel.cloud https://*.liverty-music.app https://eu.i.posthog.com https://eu-assets.i.posthog.com;
+ img-src 'self' data: blob: https://assets.fanart.tv https://eu.i.posthog.com;
```

## Why only EU domains

The region (EU vs US) is fixed for the lifetime of the PostHog organisation and we are on **EU** per the APPI Article 28 adequacy posture documented in the [introduce-analytics-tool change](https://github.com/liverty-music/specification/tree/main/openspec/changes/introduce-analytics-tool). Whitelisting US Cloud hosts would silently allow events to cross-border to a region we never use — net-negative.

## Per-directive rationale

- **`connect-src eu.i.posthog.com`** — event capture (`/e/`), feature flag evaluation (`/flags`), remote config refresh
- **`connect-src eu-assets.i.posthog.com`** — initial remote config POST (`/array/<key>/config`)
- **`script-src eu-assets.i.posthog.com`** — the `/array/<key>/config.js` bootstrap script that posthog-js fetches BEFORE init completes (this is how PostHog disables features remotely without an SDK upgrade)
- **`img-src eu.i.posthog.com`** — defensive. PostHog can emit tracking pixels even with autocapture off; allowing it costs nothing since data:+blob:+fanart.tv are already allowed.

## Verification

After this PR is released and the cloud-provisioning prod image tag bumps to the new frontend version, a fresh visit to https://liverty-music.app/my-artists should:

- Show **no CSP violations** in browser console for `posthog` domains
- Produce a `$pageview` (page.viewed) event in the PostHog `liverty-music-prod` project's Activity within ~1 minute

This is **independent of the parallel Zitadel signup incident**: even without signup working, the frontend will fire `page.viewed` / `concert.detail.viewed` etc. on existing logged-out / cached-session paths.

Refs: liverty-music/specification#532