### PR TITLE
fix(ci): include root index.html in build-vs-inherit trigger regex

### DIFF
--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -163,7 +163,7 @@ jobs:
           echo "Changed files in ${BEFORE}..${SHA}:"
           echo "${changed}"
           # Build glob set (kept in lock-step with the prior `on.push.paths`).
-          if echo "${changed}" | grep -qE '^src/|^public/|^scripts/|^package\.json$|^package-lock\.json$|^vite\.config\.ts$|^Dockerfile$|^Caddyfile$|^\.github/workflows/push-image\.yaml$'; then
+          if echo "${changed}" | grep -qE '^src/|^public/|^scripts/|^index\.html$|^package\.json$|^package-lock\.json$|^vite\.config\.ts$|^Dockerfile$|^Caddyfile$|^\.github/workflows/push-image\.yaml$'; then
             echo "Build-relevant change detected -> build."
             echo "mode=build" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Root cause (this is why prod CSP is still old)

The `push-image.yaml` workflow has a **"Decide build vs inherit"** step that compares the diff between BEFORE..SHA against a regex. When the regex doesn't match, the workflow **skips the docker build** and instead retags the parent commit's existing image:

```yaml
if echo "${changed}" | grep -qE '^src/|^public/|^scripts/|^package\.json$|^package-lock\.json$|^vite\.config\.ts$|^Dockerfile$|^Caddyfile$|^\.github/workflows/push-image\.yaml$'; then
```

**`index.html` is missing from this regex.** But `index.html` is the Vite-served entry template — its content (including the `<meta http-equiv="Content-Security-Policy">` tag) ABSOLUTELY ends up in the built bundle and is what Caddy serves to clients.

## Concrete failure chain we just hit

| PR | Touched | Workflow choice | dev AR result |
|---|---|---|---|
| #388 | `index.html` (CSP fix only) | inherit (no rebuild) | new `14302ed` tag, but digest = parent's `cde432bd` |

When `v1.3.1` was cut from commit `14302ed`, the CI retag picked up the same digest → prod AR has both `v1.3.0` and `v1.3.1` pointing to the same image (CSP fix not included). Verified:

```
prod  v1.3.0 → sha256:80af0bf...
prod  v1.3.1 → sha256:80af0bf...   ← identical
dev   cde432bd → sha256:80af0bf...
dev   14302ed  → sha256:80af0bf...   ← also identical
```

## Change

```diff
- if echo "${changed}" | grep -qE '^src/|^public/|^scripts/|^package\.json$|^package-lock\.json$|^vite\.config\.ts$|^Dockerfile$|^Caddyfile$|^\.github/workflows/push-image\.yaml$'; then
+ if echo "${changed}" | grep -qE '^src/|^public/|^scripts/|^index\.html$|^package\.json$|^package-lock\.json$|^vite\.config\.ts$|^Dockerfile$|^Caddyfile$|^\.github/workflows/push-image\.yaml$'; then
```

One token added: `^index\.html$`.

## Why merging THIS PR fixes prod by itself

Merging this PR changes `.github/workflows/push-image.yaml`, which **is already in the regex**. So the workflow will:

1. See the diff includes `push-image.yaml` → choose `build`.
2. Build a fresh dev AR image from `main` HEAD (which has both this workflow fix AND the CSP fix from #388 still in `index.html`).
3. Push the fresh image with the new commit SHA tag in dev AR.

After this PR merges and the workflow completes, cutting `v1.3.2` from the new HEAD will retag a genuinely-fresh image (with the CSP fix) into prod AR. The subsequent cloud-provisioning pin-bump PR (`v1.3.1 → v1.3.2`) then actually deploys it.

## Test plan

- [x] make check passes locally (no behavioral change to the app itself, just a workflow YAML edit)
- [ ] CI green on this PR
- [ ] After merge: confirm Deploy Frontend `build-and-push` job's "Build and Push Docker Image" step runs (not skipped)
- [ ] After merge: confirm dev AR has a new digest for the new commit SHA
- [ ] Cut v1.3.2 release → prod AR shows a different digest from v1.3.1/v1.3.0
- [ ] After cloud-provisioning bump merge: browser at https://liverty-music.app/ shows CSP including `eu.i.posthog.com` and `eu-assets.i.posthog.com`