### PR TITLE
fix(settings): align scroll layout with the house pattern

### DIFF
--- a/src/routes/settings/settings-route.css
+++ b/src/routes/settings/settings-route.css
@@ -16,16 +16,30 @@
 			min-block-size: 0;
 		}
 
+		/* Shell: fixed page-header in the `header` row, this `main` in the
+		   `content` (1fr) track. `min-block-size: 0` lets the grid item shrink
+		   below its content height so the inner `.settings-scroll` can own the
+		   overflow — without it the track grows past the route box and the list
+		   slides under the header. Matches the my-artists / tickets / dashboard
+		   / discovery scroll pattern. */
 		main {
-			overflow-y: auto;
+			overflow: hidden;
 			display: flex;
 			grid-area: content;
 			flex-direction: column;
-			gap: var(--space-m);
 
-			padding: var(--space-m) var(--space-s);
+			min-block-size: 0;
 
 			background: var(--color-surface-base);
+		}
+
+		/* Scroll container. `[ stack ]` (composition layer) supplies the
+		   vertical rhythm between sections; this block only owns the scroll
+		   behaviour and gutters. */
+		.settings-scroll {
+			overflow-y: auto;
+			flex: 1;
+			padding: var(--space-m) var(--space-s);
 		}
 
 		.settings-section-title {
@@ -236,10 +250,10 @@
 			color: var(--color-text-primary);
 		}
 
+		/* Vertical list; layout comes from `[ stack ]` (composition layer).
+		   This exception tightens the default stack gap to the selector rhythm. */
 		.language-list {
-			display: flex;
-			flex-direction: column;
-			gap: var(--space-3xs);
+			--stack-gap: var(--space-3xs);
 		}
 
 		.language-option {

--- a/src/routes/settings/settings-route.html
+++ b/src/routes/settings/settings-route.html
@@ -1,6 +1,7 @@
 <page-header title-key="settings.title"></page-header>
 
 <main>
+  <div class="[ settings-scroll ] [ stack ]">
   <!-- PREFERENCES Section -->
   <section>
     <h2 t="settings.preferences" class="settings-section-title"></h2>
@@ -20,7 +21,7 @@
         </div>
       </button>
 
-      <hr class="[ settings-divider ]">
+      <hr class="settings-divider">
 
       <!-- Language -->
       <button
@@ -37,7 +38,7 @@
         </div>
       </button>
 
-      <hr class="[ settings-divider ]">
+      <hr class="settings-divider">
 
       <!-- Push Notifications -->
       <button
@@ -61,7 +62,7 @@
         </div>
       </button>
 
-      <hr class="[ settings-divider ]">
+      <hr class="settings-divider">
 
       <!-- Sound Effects -->
       <button
@@ -123,7 +124,7 @@
         </div>
       </button>
 
-      <hr class="[ settings-divider ]">
+      <hr class="settings-divider">
 
       <!-- Cross-border marketing measurement toggle -->
       <button
@@ -161,7 +162,7 @@
         <svg-icon name="chevron-right" class="settings-chevron"></svg-icon>
       </a>
 
-      <hr class="[ settings-divider ]">
+      <hr class="settings-divider">
 
       <!-- Privacy Policy -->
       <a
@@ -174,7 +175,7 @@
         <svg-icon name="chevron-right" class="settings-chevron"></svg-icon>
       </a>
 
-      <hr class="[ settings-divider ]">
+      <hr class="settings-divider">
 
       <!-- OSS Licenses -->
       <a
@@ -205,7 +206,7 @@
         <svg-icon name="chevron-right" class="settings-chevron"></svg-icon>
       </button>
 
-      <hr class="[ settings-divider ]">
+      <hr class="settings-divider">
 
       <button click.trigger="signUp()" class="settings-row">
         <div class="settings-row-start">
@@ -245,7 +246,7 @@
         </button>
       </div>
 
-      <hr class="[ settings-divider ]">
+      <hr class="settings-divider">
 
       <button
         click.trigger="signOut()"
@@ -255,6 +256,7 @@
       </button>
     </div>
   </section>
+  </div>
 </main>
 
 <!-- Home Area Selector Bottom Sheet -->
@@ -267,7 +269,7 @@
 <bottom-sheet open.bind="languageSelectorOpen" sheet-closed.trigger="languageSelectorOpen = false" aria-label="Select language">
   <div class="selector-content">
     <h2 t="settings.language" class="selector-title"></h2>
-    <div class="language-list">
+    <div class="[ language-list ] [ stack ]">
       <button
         repeat.for="lang of supportedLanguages"
         click.trigger="selectLanguage(lang)"


### PR DESCRIPTION
## Description

The Settings page rendered with its first preferences card clipped behind the fixed `page-header` — the PREFERENCES section title and the first rows (My Home Area, Language) appeared *under* the header instead of inside the scroll area.

Settings `main` was its own scroll container (`overflow-y: auto`) but lacked `min-block-size: 0`. As a grid item in the `1fr` content track, its default `min-block-size: auto` kept it from shrinking below its content height, so the track grew past the route's `100%` box, the grid overflowed, and the content slid under the header. Settings was the only route that diverged from the shared scroll pattern; that divergence also left CUBE CSS drift behind.

This change re-aligns Settings with the sibling routes and cleans up the CUBE drift. Frontend-only (CSS/HTML); no ViewModel, backend, or dependency changes.

## Type of Change

- [x] fix: A bug fix

## Changes

- `main` becomes an `overflow: hidden` shell with `min-block-size: 0`; a new inner `.settings-scroll` (`flex: 1; overflow-y: auto`) owns the scroll — matching my-artists / tickets / dashboard / discovery.
- The section list and language list derive their vertical rhythm from the existing `[ stack ]` composition primitive instead of hand-rolled `flex`/`gap` in the block layer.
- Removed the meaningless single-block `class="[ settings-divider ]"` bracket grouping.

## Verification

### Automated Tests
- [x] `npm run lint` passed (biome + stylelint + cube-css plugin + typecheck; 0 errors)
- [x] `npm run test` passed (settings-route unit suite: 28 tests)
- [x] `npm run build` passed

### Manual Verification
Pending in-browser confirmation against siblings (first row visible on load, header not overlapped, list scrolls within the content area). The dev environment is currently stopped; the `settings.auth.visual.spec.ts` screenshot baseline will be refreshed when running visually.

## Out of Scope

The guest language-selector reactivity defect (selector highlight not following the active locale) is tracked separately under the GuestService dissolution refactor (#368) — not addressed here.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

close: #390
