### PR TITLE
refactor(analytics): rename push.subscription.requested to notification.requested

### DIFF
--- a/src/components/notification-prompt/notification-prompt.ts
+++ b/src/components/notification-prompt/notification-prompt.ts
@@ -54,9 +54,8 @@ export class NotificationPrompt {
 	public async enable(): Promise<void> {
 		// Fire intent BEFORE the async permission flow so a denied OS
 		// dialog (or a thrown pushService.create) does not eat the signal.
-		// Paired with backend push.subscription.completed for the opt-in
-		// funnel.
-		this.analytics.capture(Events.PushSubscriptionRequested, {
+		// Paired with backend notification.subscribed for the opt-in funnel.
+		this.analytics.capture(Events.NotificationRequested, {
 			source: 'page',
 		})
 		this.isLoading = true

--- a/src/services/analytics-events.ts
+++ b/src/services/analytics-events.ts
@@ -153,19 +153,21 @@ export type EntryCheckinAttemptedProps = {
 
 /**
  * The user opted in to Web Push notifications. Paired with the backend
- * `push.subscription.completed`.
+ * `notification.subscribed`. The underlying transport is the W3C Push API,
+ * but the analytics surface stays scoped under the notification domain to
+ * align with the user-facing concept.
  */
-export type PushSubscriptionRequestedProps = {
+export type NotificationRequestedProps = {
 	source: EventSource
 }
 
-export type PushNotificationOpenedProps = {
+export type NotificationOpenedProps = {
 	notification_id: string
 	concert_id?: string
 	artist_id?: string
 }
 
-export type PushNotificationDismissedProps = {
+export type NotificationDismissedProps = {
 	notification_id: string
 }
 
@@ -193,9 +195,9 @@ export const Events = {
 	TicketLotteryEntrySubmitted: 'ticket.lottery.entry.submitted',
 	TicketPurchaseInitiated: 'ticket.purchase.initiated',
 	EntryCheckinAttempted: 'entry.checkin.attempted',
-	PushSubscriptionRequested: 'push.subscription.requested',
-	PushNotificationOpened: 'push.notification.opened',
-	PushNotificationDismissed: 'push.notification.dismissed',
+	NotificationRequested: 'notification.requested',
+	NotificationOpened: 'notification.opened',
+	NotificationDismissed: 'notification.dismissed',
 } as const satisfies Record<string, string>
 
 /** The union of every valid event-name literal. */
@@ -217,9 +219,9 @@ export type EventPropsMap = {
 	'ticket.lottery.entry.submitted': TicketLotteryEntrySubmittedProps
 	'ticket.purchase.initiated': TicketPurchaseInitiatedProps
 	'entry.checkin.attempted': EntryCheckinAttemptedProps
-	'push.subscription.requested': PushSubscriptionRequestedProps
-	'push.notification.opened': PushNotificationOpenedProps
-	'push.notification.dismissed': PushNotificationDismissedProps
+	'notification.requested': NotificationRequestedProps
+	'notification.opened': NotificationOpenedProps
+	'notification.dismissed': NotificationDismissedProps
 }
 
 /**

--- a/test/components/notification-prompt.spec.ts
+++ b/test/components/notification-prompt.spec.ts
@@ -179,18 +179,18 @@ describe('NotificationPrompt', () => {
 	})
 
 	describe('enable', () => {
-		it('fires push.subscription.requested before the async pushService.create call', async () => {
+		it('fires notification.requested before the async pushService.create call', async () => {
 			sut = create()
 			await sut.enable()
 
 			expect(mockAnalytics.capture).toHaveBeenCalledWith(
-				'push.subscription.requested',
+				'notification.requested',
 				{ source: 'page' },
 			)
 			expect(mockPushService.create).toHaveBeenCalledTimes(1)
 		})
 
-		it('still fires push.subscription.requested when pushService.create throws', async () => {
+		it('still fires notification.requested when pushService.create throws', async () => {
 			sut = create({
 				pushCreate: vi.fn().mockRejectedValue(new Error('denied')),
 			})
@@ -200,7 +200,7 @@ describe('NotificationPrompt', () => {
 			// Intent must be captured regardless of outcome — denied OS
 			// permission dialog is still a meaningful funnel signal.
 			expect(mockAnalytics.capture).toHaveBeenCalledWith(
-				'push.subscription.requested',
+				'notification.requested',
 				{ source: 'page' },
 			)
 		})


### PR DESCRIPTION
## Summary

Aligns frontend with the rename merged in [specification#552](https://github.com/liverty-music/specification/pull/552) and [backend#321](https://github.com/liverty-music/backend/pull/321). The underlying transport is still the W3C Push API (\`notification-prompt\`, \`push-service\` — unchanged), but the analytics surface stays scoped under the **notification** domain to align with the user-facing concept.

## What changes

| Surface | Old | New |
| --- | --- | --- |
| \`Events\` key | \`PushSubscriptionRequested\` | \`NotificationRequested\` |
| \`Events\` key | \`PushNotificationOpened\` | \`NotificationOpened\` |
| \`Events\` key | \`PushNotificationDismissed\` | \`NotificationDismissed\` |
| Wire value | \`push.subscription.requested\` | \`notification.requested\` |
| Wire value | \`push.notification.opened\` | \`notification.opened\` |
| Wire value | \`push.notification.dismissed\` | \`notification.dismissed\` |
| Props type | \`PushSubscriptionRequestedProps\` | \`NotificationRequestedProps\` |
| Props type | \`PushNotificationOpenedProps\` | \`NotificationOpenedProps\` |
| Props type | \`PushNotificationDismissedProps\` | \`NotificationDismissedProps\` |
| Call site | \`Events.PushSubscriptionRequested\` (in \`notification-prompt.ts\`) | \`Events.NotificationRequested\` |

## What does NOT change

The transport-layer Web Push surface stays as is — those names refer to the actual W3C Push API, not the analytics domain:

- \`notification-prompt\` (component, route, service binding)
- \`push-service\`, \`PushSubscriptionService\` (RPC client), service worker registration
- VAPID-key flow, browser permission dialogs

## Production-state notes

- The catalogue event \`push.subscription.requested\` shipped in frontend v1.1.0 (PR #385) but **has never fired in prod** — \`notification-prompt\` only renders for authenticated users who have not yet opted in, and zero users have hit the prompt + clicked Enable since launch. Rename is forward-looking; no PostHog property migration needed.
- \`push.notification.opened\` / \`push.notification.dismissed\` have no call sites yet (task 5.7); the \`Events\`-constant rename is a pure source-of-truth update.

## Verification

- \`npx biome check\` clean on changed files.
- \`make check\` failures observed are pre-existing on main (BSR types pending + \`posthog-js\` not yet installed) and unrelated to this rename. Confirmed by reproducing the same failures on a clean \`main\` checkout.
- This PR is foundational for the frontend v1.3.3 release that pairs with backend v1.3.3.

Refs: liverty-music/specification#532