### PR TITLE
feat(discovery): reset-to-Top-50 control + raise type-scale minimum font

### DIFF
--- a/src/components/artist-filter-bar/artist-filter-bar.css
+++ b/src/components/artist-filter-bar/artist-filter-bar.css
@@ -76,7 +76,7 @@
 			border: 1px solid var(--color-border-subtle);
 			border-radius: var(--radius-full);
 
-			font-size: var(--step--2);
+			font-size: var(--step--1);
 			color: var(--color-text-muted);
 
 			background: transparent;

--- a/src/components/bottom-nav-bar/bottom-nav-bar.css
+++ b/src/components/bottom-nav-bar/bottom-nav-bar.css
@@ -59,6 +59,7 @@
 		}
 
 		.nav-label {
+			/* Compact-only exception: nav labels stay tight (see tokens.css). */
 			font-size: var(--step--2);
 			font-weight: 500;
 			line-height: var(--leading-none);

--- a/src/components/error-banner/error-banner.css
+++ b/src/components/error-banner/error-banner.css
@@ -48,7 +48,7 @@
 
 		.error-id {
 			font-family: var(--font-body);
-			font-size: var(--step--2);
+			font-size: var(--step--1);
 			color: var(--color-text-muted);
 		}
 
@@ -63,7 +63,7 @@
 			border: 1px solid var(--_border-light);
 			border-radius: var(--radius-button);
 
-			font-size: var(--step--2);
+			font-size: var(--step--1);
 			color: var(--color-text-secondary);
 
 			transition:

--- a/src/components/inline-error/inline-error.css
+++ b/src/components/inline-error/inline-error.css
@@ -26,7 +26,7 @@
 
 		.inline-error-detail {
 			margin-block-end: var(--space-s);
-			font-size: var(--step--2);
+			font-size: var(--step--1);
 			color: var(--color-text-muted);
 		}
 
@@ -35,7 +35,7 @@
 			border: 1px solid var(--color-border-subtle);
 			border-radius: var(--radius-sm);
 
-			font-size: var(--step--2);
+			font-size: var(--step--1);
 			color: var(--color-text-secondary);
 
 			transition:

--- a/src/components/live-highway/concert-highway.css
+++ b/src/components/live-highway/concert-highway.css
@@ -146,7 +146,7 @@
 
 				padding-block: var(--space-s);
 
-				font-size: var(--step--2);
+				font-size: var(--step--1);
 				color: var(--_muted-faint);
 				text-align: center;
 			}

--- a/src/components/live-highway/event-card.css
+++ b/src/components/live-highway/event-card.css
@@ -70,7 +70,7 @@
 
 		.location-label {
 			margin-block-start: var(--space-3xs);
-			font-size: var(--step--2);
+			font-size: var(--step--1);
 			color: var(--_label-color);
 		}
 
@@ -85,7 +85,7 @@
 			padding-inline: var(--space-3xs);
 			border-radius: var(--radius-button);
 
-			font-size: var(--step--2);
+			font-size: var(--step--1);
 			font-weight: 600;
 			line-height: var(--leading-snug);
 			color: var(--_journey-text);

--- a/src/components/live-highway/event-detail-sheet.css
+++ b/src/components/live-highway/event-detail-sheet.css
@@ -126,7 +126,7 @@
 			border: 1px solid var(--_border-light);
 			border-radius: var(--radius-button);
 
-			font-size: var(--step--2);
+			font-size: var(--step--1);
 			font-weight: 500;
 			color: var(--color-text-secondary);
 			text-transform: uppercase;
@@ -186,7 +186,7 @@
 
 		.journey-remove-btn {
 			margin-block-start: var(--space-2xs);
-			font-size: var(--step--2);
+			font-size: var(--step--1);
 			color: var(--color-text-muted);
 			text-decoration: underline;
 

--- a/src/components/page-help/page-help.css
+++ b/src/components/page-help/page-help.css
@@ -130,7 +130,7 @@
 			border-radius: var(--radius-full);
 
 			font-family: var(--font-display);
-			font-size: var(--step--2);
+			font-size: var(--step--1);
 			font-weight: 500;
 			color: var(--_white-70);
 			white-space: nowrap;

--- a/src/components/post-signup-dialog/post-signup-dialog.css
+++ b/src/components/post-signup-dialog/post-signup-dialog.css
@@ -63,7 +63,7 @@
 		}
 
 		.post-signup-error {
-			font-size: var(--step--2);
+			font-size: var(--step--1);
 			color: var(--color-error);
 		}
 

--- a/src/components/svg-icon/svg-icon.html
+++ b/src/components/svg-icon/svg-icon.html
@@ -93,6 +93,11 @@
     <path d="M5 12h14"></path>
   </svg>
 
+  <svg case="rotate-ccw" class="svg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <polyline points="1 4 1 10 7 10"></polyline>
+    <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"></path>
+  </svg>
+
   <!-- Detail icons -->
   <svg case="map-pin" class="svg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
     <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0118 0z"></path>

--- a/src/components/user-home-selector/user-home-selector.css
+++ b/src/components/user-home-selector/user-home-selector.css
@@ -35,7 +35,7 @@
 		.selector-label {
 			margin-block-end: var(--space-2xs);
 
-			font-size: var(--step--2);
+			font-size: var(--step--1);
 			font-weight: 600;
 			color: var(--color-text-muted);
 			text-transform: uppercase;

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -231,6 +231,7 @@
 		"srSearchResults": "{{count}} search results",
 		"srArtistsAvailable": "{{count}} artists available",
 		"srFollowed": "{{count}} artists followed",
+		"resetBubbles": "Reset to top artists",
 		"resetFailed": "Failed to reset discovery view",
 		"genreLoadFailed": "Couldn't load {{tag}} artists",
 		"searchFailed": "Search couldn't complete — your connection may be unstable. Wait a moment and try again."

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -231,6 +231,7 @@
 		"srSearchResults": "{{count}}件の検索結果",
 		"srArtistsAvailable": "{{count}}件のアーティストが利用可能",
 		"srFollowed": "{{count}}アーティストをフォロー中",
+		"resetBubbles": "トップアーティストにリセット",
 		"resetFailed": "ディスカバリービューのリセットに失敗しました",
 		"genreLoadFailed": "{{tag}}のアーティストを読み込めませんでした",
 		"searchFailed": "検索が完了しませんでした。ネットワークが不安定なようです。少し時間を置いてもう一度お試しください。"

--- a/src/routes/consent/consent-route.css
+++ b/src/routes/consent/consent-route.css
@@ -107,7 +107,7 @@
 		}
 
 		.consent-row-description {
-			font-size: var(--step--2);
+			font-size: var(--step--1);
 			line-height: var(--leading-relaxed);
 			color: var(--color-text-muted);
 
@@ -122,7 +122,7 @@
 		}
 
 		.consent-policy-line {
-			font-size: var(--step--2);
+			font-size: var(--step--1);
 			color: var(--color-text-muted);
 			text-align: center;
 		}

--- a/src/routes/discovery/bubble-manager.spec.ts
+++ b/src/routes/discovery/bubble-manager.spec.ts
@@ -1,0 +1,141 @@
+import type { ILogger } from 'aurelia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Artist } from '../../entities/artist'
+import { BubbleManager } from './bubble-manager'
+
+const logger = {
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+} as unknown as ILogger
+
+function artist(id: string, name = id): Artist {
+	return { id, name, mbid: '' } as Artist
+}
+
+describe('BubbleManager.reset', () => {
+	let listTop: ReturnType<typeof vi.fn>
+	let listSimilar: ReturnType<typeof vi.fn>
+	let followed: Set<string>
+
+	beforeEach(() => {
+		listTop = vi.fn()
+		listSimilar = vi.fn(async () => [])
+		followed = new Set<string>()
+	})
+
+	function makeManager(): BubbleManager {
+		return new BubbleManager({ listTop, listSimilar }, logger, () => followed)
+	}
+
+	it('replaces the pool with the global top artists', async () => {
+		listTop.mockResolvedValue([artist('a'), artist('b'), artist('c')])
+		const mgr = makeManager()
+
+		await mgr.reset([])
+
+		// Always the global top path: empty tag, full cap, never similar-seeded.
+		expect(listTop).toHaveBeenCalledWith(expect.any(String), '', 50)
+		expect(listSimilar).not.toHaveBeenCalled()
+		expect(mgr.poolBubbles.map((a) => a.id)).toEqual(['a', 'b', 'c'])
+	})
+
+	it('excludes followed artists from the reset pool', async () => {
+		listTop.mockResolvedValue([artist('a'), artist('b'), artist('c')])
+		followed = new Set(['b'])
+		const mgr = makeManager()
+
+		await mgr.reset([artist('b')])
+
+		expect(mgr.poolBubbles.map((a) => a.id)).toEqual(['a', 'c'])
+	})
+
+	it('clears seen-sets so a previously seen artist can reappear', async () => {
+		// Initial load tracks old1/old2 as seen.
+		listTop.mockResolvedValueOnce([artist('old1'), artist('old2')])
+		const mgr = makeManager()
+		await mgr.loadInitialArtists([], 'US', '')
+		expect(mgr.poolBubbles).toHaveLength(2)
+
+		// Reset fetches a fresh list that re-includes old1. If seen-sets were NOT
+		// cleared, dedup would drop old1; clearing them lets it reappear.
+		listTop.mockResolvedValueOnce([
+			artist('new1'),
+			artist('new2'),
+			artist('old1'),
+		])
+		await mgr.reset([])
+
+		expect(mgr.poolBubbles.map((a) => a.id)).toEqual(['new1', 'new2', 'old1'])
+	})
+})
+
+describe('BubbleManager.loadInitialArtists', () => {
+	let listTop: ReturnType<typeof vi.fn>
+	let listSimilar: ReturnType<typeof vi.fn>
+	let followed: Set<string>
+
+	beforeEach(() => {
+		listTop = vi.fn()
+		listSimilar = vi.fn(async () => [])
+		followed = new Set<string>()
+	})
+
+	function makeManager(): BubbleManager {
+		return new BubbleManager({ listTop, listSimilar }, logger, () => followed)
+	}
+
+	it('tops up with top artists when seed-similar resolves to nothing', async () => {
+		// User follows an artist, so the similar-seed path is taken — but every
+		// similar lookup returns empty (e.g. no Last.fm match), which would leave
+		// the field blank without the top-up.
+		followed = new Set(['seed'])
+		listSimilar.mockResolvedValue([])
+		listTop.mockResolvedValue([artist('top1'), artist('top2')])
+		const mgr = makeManager()
+
+		await mgr.loadInitialArtists([artist('seed')], 'US', '')
+
+		expect(listSimilar).toHaveBeenCalled()
+		expect(listTop).toHaveBeenCalledWith('US', '', 50)
+		expect(mgr.poolBubbles.map((a) => a.id)).toEqual(['top1', 'top2'])
+	})
+
+	it('tops up sparse seed-similar with top artists, similar first', async () => {
+		// 3 similar artists resolve (< target 30) → field is topped up with
+		// global top artists, but the similar artists keep priority.
+		followed = new Set(['seed'])
+		listSimilar.mockResolvedValue([artist('s1'), artist('s2'), artist('s3')])
+		listTop.mockResolvedValue([
+			artist('t1'),
+			artist('t2'),
+			artist('s2'), // duplicate of a similar result — must be deduped out
+		])
+		const mgr = makeManager()
+
+		await mgr.loadInitialArtists([artist('seed')], 'US', '')
+
+		expect(listTop).toHaveBeenCalledWith('US', '', 50)
+		expect(mgr.poolBubbles.map((a) => a.id)).toEqual([
+			's1',
+			's2',
+			's3',
+			't1',
+			't2',
+		])
+	})
+
+	it('does not top up when seed-similar already meets the target', async () => {
+		// 30+ similar artists resolve → no need to dilute with top artists.
+		followed = new Set(['seed'])
+		const many = Array.from({ length: 35 }, (_, i) => artist(`s${i}`))
+		listSimilar.mockResolvedValue(many)
+		listTop.mockResolvedValue([artist('t1')])
+		const mgr = makeManager()
+
+		await mgr.loadInitialArtists([artist('seed')], 'US', '')
+
+		expect(listTop).not.toHaveBeenCalled()
+		expect(mgr.poolBubbles).toHaveLength(35)
+	})
+})

--- a/src/routes/discovery/bubble-manager.ts
+++ b/src/routes/discovery/bubble-manager.ts
@@ -12,6 +12,9 @@ export interface BubbleArtistClient {
 export class BubbleManager {
 	private static readonly SIMILAR_LIMIT_ON_TAP = 30
 	private static readonly MAX_SEED_ARTISTS = 5
+	// Below this many seed-similar results, top up the initial field with
+	// global top artists so it stays full regardless of follow count.
+	private static readonly SEED_SIMILAR_TARGET = 30
 
 	public readonly pool = new BubblePool()
 	private isLoadingBubbles = false
@@ -37,21 +40,72 @@ export class BubbleManager {
 		this.pool.clearSeenSets()
 		this.pool.trackAllSeen(followedArtists)
 
-		let artists: Artist[]
-
-		if (followedArtists.length === 0) {
-			artists = await this.client.listTop(country, tag, BubblePool.MAX_BUBBLES)
-		} else {
-			artists = await this.fetchSeedSimilarArtists(followedArtists)
-		}
+		let artists =
+			followedArtists.length === 0
+				? await this.client.listTop(country, tag, BubblePool.MAX_BUBBLES)
+				: await this.fetchSeedSimilarArtists(followedArtists)
 
 		artists = this.pool
 			.dedup(artists, this.getFollowedIds())
 			.slice(0, BubblePool.MAX_BUBBLES)
+
+		// Top up sparse seed-similar results with global top artists so the
+		// field stays full regardless of how many artists the user follows
+		// (more follows → fewer/narrower similar lists, heavier dedup). Similar
+		// artists keep priority; popular artists fill the remainder. This also
+		// covers the case where the similar lookups resolve to nothing.
+		if (
+			followedArtists.length > 0 &&
+			artists.length < BubbleManager.SEED_SIMILAR_TARGET
+		) {
+			this.logger.info('Seed similar sparse, topping up with top artists', {
+				similarCount: artists.length,
+			})
+			this.pool.trackAllSeen(artists)
+			const top = await this.client.listTop(
+				country,
+				tag,
+				BubblePool.MAX_BUBBLES,
+			)
+			const fillers = this.pool.dedup(top, this.getFollowedIds())
+			artists = [...artists, ...fillers].slice(0, BubblePool.MAX_BUBBLES)
+		}
+
 		this.pool.replace(artists)
 		this.pool.trackAllSeen(artists)
 
 		this.logger.info('Loaded initial artists', {
+			count: this.pool.availableBubbles.length,
+		})
+	}
+
+	/**
+	 * Reset the bubble field to the global top artists, independent of follows.
+	 *
+	 * Unlike loadInitialArtists, this never takes the follow-seeded similar-artist
+	 * path — it always fetches listTop(country, '', MAX) so the user lands on a
+	 * stable, predictable baseline. Clears the seen-sets and replaces the entire
+	 * pool, discarding any accumulated similar bubbles and prior eviction history.
+	 */
+	public async reset(followedArtists: Artist[]): Promise<void> {
+		this.logger.info('Resetting bubbles to global top artists', {
+			country: this.country,
+		})
+		this.pool.clearSeenSets()
+		this.pool.trackAllSeen(followedArtists)
+
+		const rawArtists = await this.client.listTop(
+			this.country,
+			'',
+			BubblePool.MAX_BUBBLES,
+		)
+		const artists = this.pool
+			.dedup(rawArtists, this.getFollowedIds())
+			.slice(0, BubblePool.MAX_BUBBLES)
+		this.pool.replace(artists)
+		this.pool.trackAllSeen(artists)
+
+		this.logger.info('Reset complete', {
 			count: this.pool.availableBubbles.length,
 		})
 	}

--- a/src/routes/discovery/discovery-route.css
+++ b/src/routes/discovery/discovery-route.css
@@ -81,9 +81,10 @@
 				);
 
 			display: grid;
-			grid-template-areas: "header" "content";
-			grid-template-rows: auto 1fr;
-
+			grid-template:
+				"header" auto
+				"content" 1fr
+				/ minmax(0, 1fr);
 			block-size: 100%;
 			min-block-size: 0;
 		}
@@ -95,7 +96,11 @@
 			overflow: hidden;
 			display: grid;
 			grid-area: content;
-			grid-template-rows: auto auto 1fr;
+			grid-template:
+				"search" auto
+				"genre" auto
+				"bubbles" 1fr
+				/ minmax(0, 1fr);
 
 			inline-size: 100%;
 			block-size: 100%;
@@ -142,6 +147,7 @@
 			position: relative;
 
 			display: flex;
+			grid-area: search;
 			align-items: center;
 
 			margin: var(--space-xs) var(--space-s) 0;
@@ -207,14 +213,68 @@
 			}
 		}
 
+		.genre-bar {
+			display: flex;
+			grid-area: genre;
+			gap: var(--space-2xs);
+			align-items: center;
+
+			/* Vertical padding lives here (not the fieldset) so the reset chip
+			   and the scrollable chips share one centered baseline. */
+			padding-block: var(--space-xs) var(--space-3xs);
+			padding-inline-start: var(--space-s);
+		}
+
 		fieldset {
 			scrollbar-width: none;
 
 			overflow-inline: auto;
 			display: flex;
+			flex: 1;
 			gap: var(--space-2xs);
 
-			padding: var(--space-xs) var(--space-s) var(--space-3xs);
+			min-inline-size: 0;
+			padding-block: 0;
+			padding-inline: 0 var(--space-s);
+		}
+
+		.reset-chip {
+			cursor: pointer;
+
+			display: grid;
+			grid-auto-columns: 1lh;
+			grid-auto-rows: 1lh;
+			flex-shrink: 0;
+			place-items: center;
+
+			padding: var(--space-3xs);
+			border: 1px solid var(--_white-15);
+			border-radius: var(--radius-full);
+
+			/* Match the genre chips' fluid height: 1lh + padding + border,
+			   derived from the same font step so the row stays aligned. */
+			font-size: var(--step--1);
+			color: var(--_white-70);
+
+			background: var(--_white-8);
+
+			transition:
+				border-color var(--transition-normal),
+				color var(--transition-normal);
+
+			& svg {
+				inline-size: 1rem;
+				block-size: 1rem;
+			}
+
+			&:hover {
+				border-color: var(--_white-25);
+				color: var(--color-white);
+			}
+
+			&:disabled {
+				opacity: 0.5;
+			}
 		}
 
 		.genre-chip {
@@ -225,7 +285,7 @@
 			border-radius: var(--radius-full);
 
 			font-family: var(--font-display);
-			font-size: var(--step--2);
+			font-size: var(--step--1);
 			font-weight: 500;
 			color: var(--_white-70);
 			white-space: nowrap;
@@ -259,7 +319,7 @@
 			container-name: bubble-area;
 			container-type: size;
 			overflow: hidden;
-			grid-row: -2 / -1;
+			grid-area: bubbles;
 
 			min-block-size: 0;
 		}
@@ -268,7 +328,7 @@
 			container-name: search-results;
 			container-type: inline-size;
 			overflow-block: auto;
-			grid-row: -2 / -1;
+			grid-area: bubbles;
 
 			min-block-size: 0;
 			padding: var(--space-xs) var(--space-s);
@@ -360,7 +420,7 @@
 		}
 
 		/* State-driven visibility (after base selectors to avoid descending specificity) */
-		.discovery-layout[data-search-mode="true"] :is(fieldset, .bubble-area) {
+		.discovery-layout[data-search-mode="true"] :is(.genre-bar, .bubble-area) {
 			display: none;
 		}
 

--- a/src/routes/discovery/discovery-route.html
+++ b/src/routes/discovery/discovery-route.html
@@ -28,18 +28,29 @@
       </button>
     </search>
 
-    <!-- Genre chips (hidden during search) -->
-    <fieldset class="genre-chips">
+    <!-- Genre row: pinned reset + scrollable chips (hidden during search) -->
+    <div class="genre-bar">
       <button
-        repeat.for="tag of genre.genreTags; key.bind: tag"
-        class="genre-chip" data-active.bind="genre.activeTag === tag"
-        click.trigger="onGenreSelected(tag)"
+        type="button"
+        class="reset-chip"
+        click.trigger="onReset()"
         disabled.bind="genre.isLoadingTag"
-        aria-pressed.bind="genre.activeTag === tag"
+        aria-label.bind="$this.i18n?.tr('discovery.resetBubbles') ?? ''"
       >
-        ${tag}
+        <svg-icon name="rotate-ccw"></svg-icon>
       </button>
-    </fieldset>
+      <fieldset class="genre-chips">
+        <button
+          repeat.for="tag of genre.genreTags; key.bind: tag"
+          class="genre-chip" data-active.bind="genre.activeTag === tag"
+          click.trigger="onGenreSelected(tag)"
+          disabled.bind="genre.isLoadingTag"
+          aria-pressed.bind="genre.activeTag === tag"
+        >
+          ${tag}
+        </button>
+      </fieldset>
+    </div>
 
     <!-- Bubble UI (hidden during search) -->
     <div class="bubble-area">

--- a/src/routes/discovery/discovery-route.ts
+++ b/src/routes/discovery/discovery-route.ts
@@ -222,6 +222,30 @@ export class DiscoveryRoute {
 		await this.genre.onGenreSelected(tag)
 	}
 
+	/**
+	 * Reset the bubble field to the global Top 50, clearing any active genre
+	 * filter and the accumulated similar-artist bubbles. Reuses the genre
+	 * loading flag as the shared pool-reload guard so genre chips and the reset
+	 * control disable together and concurrent reloads are prevented.
+	 */
+	public async onReset(): Promise<void> {
+		if (this.genre.isLoadingTag) return
+		this.logger.info('Resetting discovery bubbles to top artists')
+
+		this.genre.clearActiveTag()
+		this.genre.isLoadingTag = true
+		try {
+			await this.bubbles.reset(this.followService.followedArtists)
+			if (this.abortController.signal.aborted) return
+			this.dnaOrbCanvas.reloadBubbles(this.poolBubbles)
+		} catch (err) {
+			this.logger.error('Failed to reset discovery bubbles', err)
+			this.ea.publish(new Snack(this.i18n.tr('discovery.resetFailed'), 'error'))
+		} finally {
+			this.genre.isLoadingTag = false
+		}
+	}
+
 	public async onArtistSelected(
 		event: CustomEvent<{
 			artist: Artist

--- a/src/routes/discovery/genre-filter-controller.ts
+++ b/src/routes/discovery/genre-filter-controller.ts
@@ -39,6 +39,14 @@ export class GenreFilterController {
 		private readonly abortSignal: () => AbortSignal,
 	) {}
 
+	/**
+	 * Clear the active genre selection without reloading. The caller is
+	 * responsible for re-seeding the pool (e.g. the discovery reset flow).
+	 */
+	public clearActiveTag(): void {
+		this.activeTag = ''
+	}
+
 	public async onGenreSelected(tag: string): Promise<void> {
 		if (this.isLoadingTag) return
 

--- a/src/routes/my-artists/my-artists-route.css
+++ b/src/routes/my-artists/my-artists-route.css
@@ -120,6 +120,7 @@
 
 			min-inline-size: 44px;
 
+			/* Compact-only exception: dense hype table headers (see tokens.css). */
 			font-size: var(--step--2);
 			font-weight: normal;
 			color: var(--color-text-muted);

--- a/src/routes/settings/settings-route.css
+++ b/src/routes/settings/settings-route.css
@@ -46,7 +46,7 @@
 			margin-block-end: var(--space-2xs);
 			padding-inline: var(--space-3xs);
 
-			font-size: var(--step--2);
+			font-size: var(--step--1);
 			font-weight: 600;
 			color: var(--color-text-muted);
 			text-transform: uppercase;
@@ -119,7 +119,7 @@
 
 			& .settings-row-hint {
 				margin-inline-start: var(--space-l);
-				font-size: var(--step--2);
+				font-size: var(--step--1);
 				color: var(--color-text-muted);
 			}
 		}
@@ -191,7 +191,7 @@
 		}
 
 		.settings-verification-badge {
-			font-size: var(--step--2);
+			font-size: var(--step--1);
 
 			&[data-verified="true"] {
 				color: var(--color-success);
@@ -207,7 +207,7 @@
 			border: 1px solid color-mix(in oklch, var(--color-white) 15%, transparent);
 			border-radius: var(--radius-button);
 
-			font-size: var(--step--2);
+			font-size: var(--step--1);
 			color: var(--color-text-primary);
 			white-space: nowrap;
 

--- a/src/routes/tickets/tickets-route.css
+++ b/src/routes/tickets/tickets-route.css
@@ -6,7 +6,7 @@
 			--_pad-btn: var(--space-2xs);
 			--_pad-tiny: 0.125rem;
 			--_font-mono: monospace;
-			--_size-hint: var(--step--2);
+			--_size-hint: var(--step--1);
 
 			display: grid;
 			grid-template-areas:

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -35,7 +35,11 @@
 		--font-body: "Poppins", system-ui, -apple-system, sans-serif;
 
 		/* Fluid type scale (generated via utopia.fyi) */
-		--step--2: clamp(0.625rem, calc(0.6rem + 0.13vi), 0.7rem);
+
+		/* Compact-only floor (11px min, on the modular curve: 16 ÷ 1.2²).
+		   Reserved for intentionally dense UI (bottom-nav labels, hype-col
+		   headers); general text rests on --step--1 or larger. */
+		--step--2: clamp(0.6875rem, calc(0.6rem + 0.13vi), 0.7rem);
 		--step--1: clamp(0.83rem, calc(0.78rem + 0.29vi), 1rem);
 		--step-0: clamp(1rem, calc(0.91rem + 0.43vi), 1.25rem);
 		--step-1: clamp(1.2rem, calc(1.07rem + 0.63vi), 1.56rem);


### PR DESCRIPTION
## Description

Discovery-page improvements (frontend-only; no proto/backend changes), from the OpenSpec change `reset-discovery-bubbles`.

**1. Reset-to-Top-50 control** — an icon-only (⟳) button pinned as the leading, sticky item of the genre-chips row. Tapping it clears any active genre filter and the accumulated similar-artist bubbles, then reloads the global Top 50 (`listTop(country,'',50)`) independent of the user's follows. Reset is semantically a sibling of genre filtering, so it lives in the bubble-field control strip rather than a FAB (which would fight the physics canvas) or the header.

**2. Type-scale minimum font** — `--step--2` was hand-shrunk below the modular curve to 10px, putting chips/labels under the legibility floor. Raise its floor to 11px (on-curve, min-only) and migrate ~22 consumers to `--step--1` (13.3–16px), so the app-wide visible floor is legible. `--step--2` is now a documented compact-only exception, kept only on `bottom-nav-bar` and the `my-artists` hype-column headers.

### QA-discovered fixes (same area)
- **Resilient bubble loading**: `loadInitialArtists` now tops up the seed-similar path with global top artists when results fall below a target (30), keeping similar artists first. Following *more* artists no longer yields *fewer* bubbles (11 follows: 14 → 35), and the field is never empty on load.
- **Grid blowout**: `.discovery-layout` now uses explicit named `grid-template` areas (`"search"/"genre"/"bubbles"`) + a `minmax(0,1fr)` column, per the app-shell-layout grid-area rule. Fixes the search bar and DNA orb overflowing off-screen.
- **Reset-chip alignment**: chip height derived from the same fluid line metrics (`1lh` + padding + border) as the genre chips, so it stays aligned and circular at every viewport width.

## Type of Change

- [x] feat: A new feature

## Verification

### Automated Tests
- [x] `npm run lint` passed (`make lint` — biome + stylelint + typecheck + brand-vocabulary)
- [x] `npm run test` passed (discovery unit tests +6; full suite green)
- [ ] `npm run build` passed

### Manual Verification
Verified locally against the full stack (backend `:8080` + frontend `:9000`) via Playwright:
- Apply a genre filter → tap ⟳ → genre cleared and field restored to global Top 50.
- Genre chips legible at the new `--step--1`; bottom-nav labels stay compact at the kept `--step--2` (11px).
- Reset chip aligned and circular at 412px and 900px viewports.
- Seed-similar top-up: 11 follows → field fills to 35 (was 14); empty seed result fills rather than blanking.
- Layout contained within the viewport (no search-bar/orb overflow).

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

close: #393
