### PR TITLE
feat(ci): dispatch prod pin-bump after release retag

### DIFF
--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -353,6 +353,54 @@ jobs:
             "${DEV_AR_IMAGE}@${DIGEST}" \
             "${PROD_AR_IMAGE}:${GITHUB_SHA}"
 
+  # =====================================================================
+  # Release path: trigger the automated prod kustomize pin-bump.
+  # =====================================================================
+  # After the retag succeeds, emit a `repository_dispatch` to
+  # cloud-provisioning, which runs `bump-prod-pin.yml` to rewrite the prod
+  # overlay pin (`web-app` newTag) + version label and push to its own main
+  # (ArgoCD then auto-syncs). Per OpenSpec change `automate-prod-pin-bump`:
+  # gated on `build-and-push` succeeding so a failed retag never bumps the
+  # pin to a tag whose prod image is missing.
+  #
+  # The cross-repo trigger uses a GitHub App installation token (short-lived,
+  # auditable) minted at runtime and scoped to cloud-provisioning. The
+  # dispatches API requires `Contents: write` (no narrower scope exists), so
+  # the security boundary is branch protection: cloud-provisioning:main lets
+  # only `github-actions[bot]` bypass, so this token cannot push to the one ref
+  # ArgoCD tracks — its reach is bounded to non-`main` refs.
+  dispatch-prod-pin:
+    needs: [build-and-push]
+    if: github.event_name == 'release' && needs.build-and-push.result == 'success'
+    runs-on: ubuntu-latest
+    # `prod` environment so the dispatch-credential secrets resolve. On a
+    # release event the ref is the `vX.Y.Z` tag, which matches the prod
+    # environment's `v*` deployment-tag policy.
+    environment:
+      name: prod
+    steps:
+      - name: Mint dispatch token (GitHub App, scoped to cloud-provisioning)
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CI_BOT_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: cloud-provisioning
+
+      - name: Dispatch bump-prod-pin to cloud-provisioning
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          OWNER: ${{ github.repository_owner }}
+          TAG: ${{ github.event.release.tag_name }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          payload=$(jq -nc --arg t "$TAG" --arg s "$SHA" \
+            '{event_type:"bump-prod-pin",client_payload:{component:"frontend",tag:$t,sha:$s}}')
+          echo "Dispatching: $payload"
+          echo "$payload" | gh api "repos/${OWNER}/cloud-provisioning/dispatches" --input -
+
   # Post-deploy smoke: hits the live URL and asserts the SPA renders
   # plus /config.json reports the expected environment. Closes the
   # gap left by section 5.5 of OpenSpec archive


### PR DESCRIPTION
## 🔗 Related Issue
Refs liverty-music/specification#553 (kept open — operational verification still pending)

## 📝 Summary of Changes
Adds a `dispatch-prod-pin` job to `push-image.yaml` so a published frontend Release automatically triggers the prod kustomize pin-bump in `cloud-provisioning` (replacing the manual pin-bump PR for the `web-app` overlay).

- Runs only on `release` events, `needs: [build-and-push]`, gated on `needs.build-and-push.result == 'success'` (fires after the retag succeeds).
- Mints a short-lived GitHub App installation token (scoped to `cloud-provisioning`) and POSTs `repository_dispatch` `event_type: bump-prod-pin`, `client_payload: { component: frontend, tag, sha }`. The dispatch is the only cross-repo action the release workflow performs.

## ✅ Self-Checklist
- [x] Linked the related issue.
- [x] Existing build/retag/smoke paths unchanged.
- [x] Workflow YAML validated.

## 📸 Screenshots or Logs
n/a — job fires only on a release once the dispatch GitHub App secrets are provisioned on the frontend `prod` environment.
