### PR TITLE
feat(settings): introduce UserStore, fix guest language-selector reactivity (store-layer Phase 1)

### DIFF
--- a/src/adapter/storage/guest-storage.ts
+++ b/src/adapter/storage/guest-storage.ts
@@ -1,7 +1,16 @@
 import { DEFAULT_HYPE, type FollowedArtist } from '../../entities/follow'
+import { normalizeToSupportedLanguage } from '../../util/change-locale'
 
 const KEY_FOLLOWED = 'guest.followedArtists'
 const KEY_HOME = 'guest.home'
+// Anonymous-period UI language. Dedicated key, DECOUPLED from the i18next
+// detector's own cache key (`StorageKeys.language === 'language'`, configured
+// in main.ts as `lookupLocalStorage`). GuestService is the sole reader/writer
+// of `guest.language`, so `clearAll()` cannot erase the detector's active-locale
+// cache, and a returning guest who never made an explicit choice keeps
+// `guest.language === null` (the detector's auto-written 'language' no longer
+// leaks in) — preserving the "null → reactive i18nLocale fallback" contract.
+const KEY_LANGUAGE = 'guest.language'
 
 export function saveFollows(follows: FollowedArtist[]): void {
 	localStorage.setItem(KEY_FOLLOWED, JSON.stringify(follows))
@@ -32,6 +41,31 @@ export function saveHome(code: string | null): void {
 
 export function loadHome(): string | null {
 	return localStorage.getItem(KEY_HOME)
+}
+
+/**
+ * Persist the guest's anonymous-period language. A `null` clears the key
+ * (used on sign-up/sign-out when the DB or a fresh session takes over).
+ */
+export function saveLanguage(lang: string | null): void {
+	if (lang !== null) {
+		localStorage.setItem(KEY_LANGUAGE, lang)
+	} else {
+		localStorage.removeItem(KEY_LANGUAGE)
+	}
+}
+
+/**
+ * Load the guest's anonymous-period language. Returns `null` when the key is
+ * absent so the store can fall back to the active i18n locale. A stored value
+ * is normalized through `normalizeToSupportedLanguage` so a BCP 47 tag the
+ * i18next detector may have written (e.g. 'en-US') resolves to a supported
+ * code ('en') — otherwise selection-state comparisons against 'en' would fail.
+ */
+export function loadLanguage(): string | null {
+	const raw = localStorage.getItem(KEY_LANGUAGE)
+	if (raw === null) return null
+	return normalizeToSupportedLanguage(raw)
 }
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,6 +80,7 @@ import { ITicketEmailService } from './services/ticket-email-service'
 import { ITicketJourneyService } from './services/ticket-journey-service'
 import { UserHydrationTask } from './services/user-hydration-task'
 import { IUserService } from './services/user-service'
+import { IUserStore } from './services/user-store'
 import { DateValueConverter } from './value-converters/date'
 
 function resolveLogLevel(configLogLevel: AppConfig['logLevel']): LogLevel {
@@ -192,6 +193,10 @@ async function bootstrap(): Promise<void> {
 	au.register(IConcertService)
 	au.register(IOnboardingService)
 	au.register(IGuestService)
+	// UserStore composes IUserService + IGuestService into a single observable
+	// owner of home/language; register after both so its singleton can resolve
+	// them. Callers read the store instead of branching on auth state.
+	au.register(IUserStore)
 	au.register(IGuestDataMergeService)
 	au.register(IAudioEngine)
 	au.register(INotificationManager)

--- a/src/routes/settings/settings-route.ts
+++ b/src/routes/settings/settings-route.ts
@@ -1,7 +1,6 @@
 import { I18N } from '@aurelia/i18n'
 import { Code, ConnectError } from '@connectrpc/connect'
 import { IEventAggregator, ILogger, resolve } from 'aurelia'
-import { ILocalStorage } from '../../adapter/storage/local-storage'
 import { Snack } from '../../components/snack-bar/snack'
 import type { UserHomeSelector } from '../../components/user-home-selector/user-home-selector'
 import { IAppConfig } from '../../config/app-config'
@@ -16,22 +15,19 @@ import { IGuestService } from '../../services/guest-service'
 import { INotificationManager } from '../../services/notification-manager'
 import { IPushService } from '../../services/push-service'
 import { IUserService } from '../../services/user-service'
-import {
-	changeLocale,
-	normalizeToSupportedLanguage,
-	SUPPORTED_LANGUAGES,
-} from '../../util/change-locale'
+import { IUserStore } from '../../services/user-store'
+import { changeLocale, SUPPORTED_LANGUAGES } from '../../util/change-locale'
 
 export class SettingsRoute {
 	public readonly auth = resolve(IAuthService)
 	private readonly guest = resolve(IGuestService)
 	private readonly userService = resolve(IUserService)
+	private readonly userStore = resolve(IUserStore)
 	private readonly notificationManager = resolve(INotificationManager)
 	private readonly pushService = resolve(IPushService)
 	private readonly logger = resolve(ILogger).scopeTo('SettingsRoute')
 	private readonly ea = resolve(IEventAggregator)
 	private readonly i18n = resolve(I18N)
-	private readonly localStorage = resolve(ILocalStorage)
 	private readonly audio = resolve(IAudioEngine)
 	private readonly consent = resolve(IConsentService)
 
@@ -61,59 +57,19 @@ export class SettingsRoute {
 	public isResendingVerification = false
 	public resendSuccess = false
 
-	// View state derived from the single source of truth: UserService.current
-	// (which is @observable and re-notifies on every entity mutation). All
-	// derived display values are exposed as computed getters so Aurelia's
-	// proxy-based observation tracks the access chain and re-evaluates every
-	// dependent binding (settings row text AND in-modal selector check) when
-	// the user entity changes. No component-local mirror state, no manual
-	// write-back in mutation handlers. This eliminates the desync class of
-	// bug where mirror-only updates fail to propagate to method-call
-	// bindings inside repeat.for (which expression observation cannot track
-	// through a method body).
+	// Display values derive from UserStore, the single observable owner of the
+	// current user's home + language. UserStore resolves guest(localStorage)
+	// vs authed(backend) INTERNALLY and exposes only observable state, so these
+	// getters re-evaluate every dependent binding (settings row text AND the
+	// in-modal selector check) without a component-local mirror, an
+	// auth-branch, or a render-time i18n.getLocale() read — the latter was the
+	// root cause of the frozen guest language-selector highlight.
 	public get currentLocale(): string {
-		// Fallback to the active i18n locale only when hydration has not yet
-		// populated `current.preferredLanguage` (e.g., very first render
-		// after signup, or the hydration backfill RPC is still in flight).
-		// MUST NOT read localStorage['language']. The fallback runs through
-		// normalizeToSupportedLanguage so a BCP 47 tag returned by
-		// i18n.getLocale() (e.g. 'en-US' when the detector falls through to
-		// navigator.language) maps to 'en' — otherwise the selector compares
-		// 'en-US' === 'en' and no row is highlighted.
-		return (
-			this.userService.current?.preferredLanguage ??
-			normalizeToSupportedLanguage(this.i18n.getLocale())
-		)
+		return this.userStore.currentLanguage
 	}
 
 	public get currentHome(): string | null {
-		// Settings is now reachable by guests (from the discovery step onward).
-		// For a guest the home lives in guest storage, not the user entity.
-		if (!this.auth.isAuthenticated) {
-			// Read from GuestService (the @observable owner of guest home) rather
-			// than a raw localStorage snapshot, so the row stays reactive if the
-			// guest picks a home from within Settings.
-			const guestCode = this.guest.home
-			return guestCode ? translationKey(guestCode) : null
-		}
-		// Authenticated: the home value MUST come from the user entity. The
-		// guest-flow home storage owned by
-		// UserHomeSelector is consumed at signup time:
-		// auth-callback's ensureUserProvisioned reads guest.home and calls
-		// userService.create(email, locale, codeToHome(guestHome)), which
-		// atomically persists the home into the user row via the Create
-		// RPC's home field. By the time Settings ever renders, user.home
-		// IS the source of truth. (GuestDataMergeService.merge() handles
-		// follows/hypes only — NOT home; home is a Create-time field, not
-		// a post-signup merge target.)
-		//
-		// If a signed-in user lacks user.home (e.g. they completed signup
-		// before the home-prompt step landed, or guest.home was empty at
-		// auth-callback), `currentHome` is null and the UI renders
-		// 'Not set'. The user re-selects via the home-selector sheet,
-		// which calls userService.updateHome — the getter then surfaces
-		// the new value automatically. No localStorage fallback needed.
-		const code = this.userService.current?.home?.level1
+		const code = this.userStore.currentHome
 		return code ? translationKey(code) : null
 	}
 
@@ -252,7 +208,7 @@ export class SettingsRoute {
 					i18n: this.i18n,
 					auth: this.auth,
 					userService: this.userService,
-					localStorage: this.localStorage,
+					guest: this.guest,
 				},
 				lang,
 			)
@@ -277,8 +233,10 @@ export class SettingsRoute {
 			return
 		}
 		// No manual `this.currentLocale = ...` — the getter derives from
-		// userService.current.preferredLanguage, which changeLocale's
-		// updatePreferredLanguage write-through has already updated.
+		// UserStore.currentLanguage, an observable that resolves to the authed
+		// User entity (updated by changeLocale's updatePreferredLanguage
+		// write-through) or the observable guest language (updated by
+		// changeLocale's guest.setLanguage write-through).
 		this.logger.info('Language changed', { from: previous, to: lang })
 	}
 

--- a/src/routes/welcome/welcome-route.ts
+++ b/src/routes/welcome/welcome-route.ts
@@ -5,7 +5,6 @@ import {
 	type NavigationInstruction,
 } from '@aurelia/router'
 import { IEventAggregator, ILogger, INode, observable, resolve } from 'aurelia'
-import { ILocalStorage } from '../../adapter/storage/local-storage'
 import { Snack } from '../../components/snack-bar/snack'
 import {
 	getPreviewArtistIds,
@@ -36,7 +35,6 @@ export class WelcomeRoute implements IRouteViewModel {
 	private readonly i18n = resolve(I18N)
 	private readonly concertService = resolve(IConcertService)
 	private readonly host = resolve(INode) as HTMLElement
-	private readonly localStorage = resolve(ILocalStorage)
 
 	public readonly supportedLanguages = SUPPORTED_LANGUAGES
 	@observable public currentLocale: string = ''
@@ -159,7 +157,7 @@ export class WelcomeRoute implements IRouteViewModel {
 				i18n: this.i18n,
 				auth: this.authService,
 				userService: this.userService,
-				localStorage: this.localStorage,
+				guest: this.guest,
 			},
 			newLocale,
 		)

--- a/src/services/guest-service.ts
+++ b/src/services/guest-service.ts
@@ -2,8 +2,10 @@ import { DI, ILogger, observable, resolve } from 'aurelia'
 import {
 	loadFollows,
 	loadHome,
+	loadLanguage,
 	saveFollows,
 	saveHome,
+	saveLanguage,
 } from '../adapter/storage/guest-storage'
 import { clearAllHelpSeen } from '../adapter/storage/onboarding-storage'
 import type { Artist } from '../entities/artist'
@@ -36,6 +38,13 @@ export class GuestService {
 
 	public follows: FollowedArtist[] = loadFollows()
 	@observable public home: string | null = loadHome()
+	// Anonymous-period UI language. First-class @observable owner, symmetric
+	// with `home`, so any binding that reads the guest language re-evaluates
+	// when it changes (fixes the guest language-selector reactivity bug where
+	// the selector was driven by an unobservable i18n.getLocale() read).
+	// `null` means "no explicit guest choice yet" — UserStore falls back to
+	// the active i18n locale in that case.
+	@observable public language: string | null = loadLanguage()
 
 	public get followedCount(): number {
 		return this.follows.length
@@ -85,6 +94,14 @@ export class GuestService {
 	}
 
 	/**
+	 * Set the guest language (ISO 639-1 code). Persisted via languageChanged().
+	 */
+	public setLanguage(lang: string): void {
+		this.language = lang
+		this.logger.info('Local language set', { language: lang })
+	}
+
+	/**
 	 * Set hype level for a followed artist (persisted to localStorage).
 	 */
 	public setHype(artistId: string, hype: FollowedArtist['hype']): void {
@@ -103,6 +120,7 @@ export class GuestService {
 		this.follows.splice(0)
 		this.persistFollows()
 		this.home = null
+		this.language = null
 		clearAllHelpSeen()
 		this.logger.info('Local data cleared')
 	}
@@ -112,6 +130,13 @@ export class GuestService {
 	 */
 	public homeChanged(newValue: string | null): void {
 		saveHome(newValue)
+	}
+
+	/**
+	 * Persist language to localStorage on change.
+	 */
+	public languageChanged(newValue: string | null): void {
+		saveLanguage(newValue)
 	}
 
 	private persistFollows(): void {

--- a/src/services/user-store.ts
+++ b/src/services/user-store.ts
@@ -1,0 +1,105 @@
+import { I18N, Signals } from '@aurelia/i18n'
+import { DI, IEventAggregator, observable, resolve } from 'aurelia'
+import { normalizeToSupportedLanguage } from '../util/change-locale'
+import { IAuthService } from './auth-service'
+import { IGuestService } from './guest-service'
+import { IUserService } from './user-service'
+
+export const IUserStore = DI.createInterface<IUserStore>('IUserStore', (x) =>
+	x.singleton(UserStore),
+)
+
+export interface IUserStore extends UserStore {}
+
+/**
+ * Observable owner of the current user's `home` and `preferredLanguage`,
+ * resolving guest (localStorage) vs authenticated (backend) sources
+ * INTERNALLY so callers never branch on `auth.isAuthenticated`.
+ *
+ * This is the Phase 1 scaffold of the entity-store layer: it COMPOSES the
+ * existing `IUserService` (the authenticated `User` entity, with its
+ * cache→Get→Create + write-through logic intact) and `IGuestService` (the
+ * observable guest preference source). Full absorption / deletion of
+ * `UserService` and `GuestService` is deferred to later phases.
+ *
+ * Every exposed value depends ONLY on observable state:
+ *   - `userService.current` is @observable.
+ *   - `guest.home` / `guest.language` are @observable.
+ *   - `i18nLocale` mirrors the active i18n locale, kept in sync via the
+ *     i18n locale-changed event, so even the authed-NULL fallback is
+ *     reactive (a render-time `i18n.getLocale()` read is not observable and
+ *     would freeze the binding).
+ */
+export class UserStore {
+	private readonly userService = resolve(IUserService)
+	private readonly guest = resolve(IGuestService)
+	private readonly auth = resolve(IAuthService)
+	private readonly i18n = resolve(I18N)
+	private readonly ea = resolve(IEventAggregator)
+
+	/**
+	 * Reactive mirror of the active i18n locale, normalized to a supported
+	 * code. Seeded from the current locale and updated whenever i18n publishes
+	 * a locale change. Used as the observable fallback for the authed-NULL and
+	 * guest-unset paths — replacing the unobservable `i18n.getLocale()` read
+	 * that froze the guest selector highlight.
+	 */
+	@observable private i18nLocale: string = normalizeToSupportedLanguage(
+		this.i18n.getLocale(),
+	)
+
+	constructor() {
+		// The i18n subsystem publishes `{ oldLocale, newLocale }` on this EA
+		// channel after every successful setLocale. Mirroring it into an
+		// @observable is what makes `currentLanguage` re-evaluate for the
+		// guest/authed-NULL paths without a render-time getLocale() read.
+		this.ea.subscribe(
+			Signals.I18N_EA_CHANNEL,
+			(payload: { oldLocale: string; newLocale: string }) => {
+				this.i18nLocale = normalizeToSupportedLanguage(payload.newLocale)
+			},
+		)
+	}
+
+	/**
+	 * The current user's home area (ISO 3166-2 level1 code), or `null` when
+	 * unset. Authenticated: the backend `User.home.level1`. Guest: the
+	 * observable guest home. Resolved internally — callers must NOT branch on
+	 * auth state.
+	 */
+	public get currentHome(): string | null {
+		if (this.auth.isAuthenticated) {
+			return this.userService.current?.home?.level1 ?? null
+		}
+		return this.guest.home
+	}
+
+	/**
+	 * The current user's effective preferred language (ISO 639-1 code).
+	 *
+	 * Authenticated: `User.preferredLanguage`, normalized to a SUPPORTED code
+	 * so a non-supported backend tag ('en-US') still maps to a value the
+	 * selector can highlight ('en'). When the row's preference is NULL/undefined
+	 * (historical rows pending backfill), falls back to the observable
+	 * `i18nLocale` mirror. Persisting that NULL → backfill is owned solely by
+	 * `user-hydration-task` (an activating AppTask); this getter is a PURE
+	 * projection of observable state and never issues an RPC.
+	 *
+	 * Guest: the observable guest language, or the i18n locale mirror when the
+	 * guest has not made an explicit choice yet.
+	 *
+	 * NEVER reads a render-time `i18n.getLocale()`; every branch resolves to
+	 * observable state so dependent bindings re-evaluate on change.
+	 */
+	public get currentLanguage(): string {
+		if (this.auth.isAuthenticated) {
+			const preferred = this.userService.current?.preferredLanguage
+			if (preferred) return normalizeToSupportedLanguage(preferred)
+			// NULL server preferred_language: surface the active locale. The
+			// hydration task owns the one-shot backfill RPC, so this getter
+			// stays side-effect-free and safe to re-evaluate on every pass.
+			return this.i18nLocale
+		}
+		return this.guest.language ?? this.i18nLocale
+	}
+}

--- a/src/util/change-locale.spec.ts
+++ b/src/util/change-locale.spec.ts
@@ -1,8 +1,7 @@
 import type { I18N } from '@aurelia/i18n'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { ILocalStorage } from '../adapter/storage/local-storage'
-import { StorageKeys } from '../constants/storage-keys'
 import type { IAuthService } from '../services/auth-service'
+import type { IGuestService } from '../services/guest-service'
 import type { IUserService } from '../services/user-service'
 import { changeLocale } from './change-locale'
 
@@ -30,25 +29,18 @@ function makeUserService(behavior?: {
 	} as unknown as IUserService
 }
 
-function makeLocalStorage() {
-	const map = new Map<string, string>()
-	const impl: ILocalStorage = {
-		getItem: vi.fn((k: string) => map.get(k) ?? null),
-		setItem: vi.fn((k: string, v: string) => {
-			map.set(k, v)
-		}),
-		removeItem: vi.fn((k: string) => {
-			map.delete(k)
-		}),
-	}
-	return { map, impl }
+function makeGuest(): IGuestService {
+	return {
+		language: null,
+		setLanguage: vi.fn(),
+	} as unknown as IGuestService
 }
 
 describe('changeLocale', () => {
-	let storage: ReturnType<typeof makeLocalStorage>
+	let guest: IGuestService
 
 	beforeEach(() => {
-		storage = makeLocalStorage()
+		guest = makeGuest()
 	})
 
 	describe('validation', () => {
@@ -58,39 +50,32 @@ describe('changeLocale', () => {
 			const userService = makeUserService()
 
 			await expect(
-				changeLocale(
-					{ i18n, auth, userService, localStorage: storage.impl },
-					'fr',
-				),
+				changeLocale({ i18n, auth, userService, guest }, 'fr'),
 			).rejects.toBeInstanceOf(TypeError)
 			expect(i18n.setLocale).not.toHaveBeenCalled()
-			expect(storage.impl.setItem).not.toHaveBeenCalled()
+			expect(guest.setLanguage).not.toHaveBeenCalled()
 			expect(userService.updatePreferredLanguage).not.toHaveBeenCalled()
 		})
 	})
 
 	describe('unauthenticated path', () => {
-		it('calls i18n.setLocale and writes localStorage; no RPC', async () => {
+		it('calls i18n.setLocale and writes through the observable guest source; no RPC', async () => {
 			const i18n = makeI18n()
 			const auth = makeAuth(false)
 			const userService = makeUserService()
 
-			await changeLocale(
-				{ i18n, auth, userService, localStorage: storage.impl },
-				'en',
-			)
+			await changeLocale({ i18n, auth, userService, guest }, 'en')
 
 			expect(i18n.setLocale).toHaveBeenCalledWith('en')
-			expect(storage.impl.setItem).toHaveBeenCalledWith(
-				StorageKeys.language,
-				'en',
-			)
+			// Write through the @observable guest language owner (not raw
+			// localStorage) so UserStore.currentLanguage stays reactive.
+			expect(guest.setLanguage).toHaveBeenCalledWith('en')
 			expect(userService.updatePreferredLanguage).not.toHaveBeenCalled()
 		})
 	})
 
 	describe('authenticated path', () => {
-		it('calls RPC first, then setLocale; NEVER writes localStorage', async () => {
+		it('calls RPC first, then setLocale; NEVER touches the guest source', async () => {
 			const callOrder: string[] = []
 			const i18n = makeI18n({
 				setLocale: async () => {
@@ -105,15 +90,12 @@ describe('changeLocale', () => {
 				},
 			})
 
-			await changeLocale(
-				{ i18n, auth, userService, localStorage: storage.impl },
-				'en',
-			)
+			await changeLocale({ i18n, auth, userService, guest }, 'en')
 
 			expect(userService.updatePreferredLanguage).toHaveBeenCalledWith('en')
 			expect(i18n.setLocale).toHaveBeenCalledWith('en')
 			expect(callOrder).toEqual(['rpc', 'setLocale'])
-			expect(storage.impl.setItem).not.toHaveBeenCalled()
+			expect(guest.setLanguage).not.toHaveBeenCalled()
 		})
 
 		it('rethrows when RPC fails so the caller can surface a Snack', async () => {
@@ -126,13 +108,10 @@ describe('changeLocale', () => {
 			})
 
 			await expect(
-				changeLocale(
-					{ i18n, auth, userService, localStorage: storage.impl },
-					'en',
-				),
+				changeLocale({ i18n, auth, userService, guest }, 'en'),
 			).rejects.toThrow('network')
 			expect(i18n.setLocale).not.toHaveBeenCalled()
-			expect(storage.impl.setItem).not.toHaveBeenCalled()
+			expect(guest.setLanguage).not.toHaveBeenCalled()
 		})
 	})
 })

--- a/src/util/change-locale.ts
+++ b/src/util/change-locale.ts
@@ -1,7 +1,6 @@
 import type { I18N } from '@aurelia/i18n'
-import type { ILocalStorage } from '../adapter/storage/local-storage'
-import { StorageKeys } from '../constants/storage-keys'
 import type { IAuthService } from '../services/auth-service'
+import type { IGuestService } from '../services/guest-service'
 import type { IUserService } from '../services/user-service'
 
 export const SUPPORTED_LANGUAGES = ['ja', 'en'] as const
@@ -43,7 +42,7 @@ export interface ChangeLocaleDeps {
 	readonly i18n: I18N
 	readonly auth: IAuthService
 	readonly userService: IUserService
-	readonly localStorage: ILocalStorage
+	readonly guest: IGuestService
 }
 
 /**
@@ -51,8 +50,12 @@ export interface ChangeLocaleDeps {
  *
  * Routes persistence based on the caller's auth state:
  *
- * - **Unauthenticated** (Welcome page): write through to
- *   `localStorage['language']` after `i18n.setLocale`. No backend call.
+ * - **Unauthenticated** (Welcome / guest Settings): write through to the
+ *   observable guest language source (`GuestService.setLanguage`, which
+ *   persists to `localStorage['language']` via its `languageChanged` hook)
+ *   after `i18n.setLocale`. Writing through the @observable owner — not raw
+ *   localStorage — keeps `UserStore.currentLanguage` reactive so the language
+ *   selector highlight follows the active locale. No backend call.
  *
  * - **Authenticated** (Settings page): call `UpdatePreferredLanguage` first,
  *   apply `i18n.setLocale` after success. The backend row is the source
@@ -66,7 +69,7 @@ export async function changeLocale(
 	deps: ChangeLocaleDeps,
 	lang: string,
 ): Promise<void> {
-	const { i18n, auth, userService, localStorage } = deps
+	const { i18n, auth, userService, guest } = deps
 
 	if (!isSupportedLanguage(lang)) {
 		throw new TypeError(
@@ -76,7 +79,7 @@ export async function changeLocale(
 
 	if (!auth.isAuthenticated) {
 		await i18n.setLocale(lang)
-		localStorage.setItem(StorageKeys.language, lang)
+		guest.setLanguage(lang)
 		return
 	}
 

--- a/test/routes/settings-route.spec.ts
+++ b/test/routes/settings-route.spec.ts
@@ -5,6 +5,8 @@ import { createTestContainer } from '../helpers/create-container'
 
 const mockIAuthService = DI.createInterface('IAuthService')
 const mockIUserService = DI.createInterface('IUserService')
+const mockIUserStore = DI.createInterface('IUserStore')
+const mockIGuestService = DI.createInterface('IGuestService')
 const mockINotificationManager = DI.createInterface('INotificationManager')
 const mockIPushService = DI.createInterface('IPushService')
 
@@ -13,6 +15,12 @@ vi.mock('../../src/services/auth-service', () => ({
 }))
 vi.mock('../../src/services/user-service', () => ({
 	IUserService: mockIUserService,
+}))
+vi.mock('../../src/services/user-store', () => ({
+	IUserStore: mockIUserStore,
+}))
+vi.mock('../../src/services/guest-service', () => ({
+	IGuestService: mockIGuestService,
 }))
 vi.mock('../../src/services/notification-manager', () => ({
 	INotificationManager: mockINotificationManager,
@@ -52,6 +60,20 @@ describe('SettingsRoute', () => {
 		clear: ReturnType<typeof vi.fn>
 		updatePreferredLanguage: ReturnType<typeof vi.fn>
 	}
+	// Lightweight stand-in for the real UserStore: its getters resolve the
+	// same observable sources (mockUser / mockGuest / mockAuth) the production
+	// store composes, so the SettingsRoute getters that now delegate to the
+	// store exercise the same resolution logic under test.
+	let mockUserStore: {
+		readonly currentHome: string | null
+		readonly currentLanguage: string
+	}
+	let mockGuest: {
+		home: string | null
+		language: string | null
+		setLanguage: ReturnType<typeof vi.fn>
+		setHome: ReturnType<typeof vi.fn>
+	}
 	let mockNotification: { permission: string }
 	let mockPush: {
 		getBrowserSubscription: ReturnType<typeof vi.fn>
@@ -81,6 +103,29 @@ describe('SettingsRoute', () => {
 				return mockUser.current
 			}),
 		}
+		mockGuest = {
+			home: null,
+			language: null,
+			setLanguage: vi.fn((lang: string) => {
+				mockGuest.language = lang
+			}),
+			setHome: vi.fn((code: string) => {
+				mockGuest.home = code
+			}),
+		}
+		mockUserStore = {
+			get currentHome(): string | null {
+				return mockAuth.isAuthenticated
+					? (mockUser.current?.home?.level1 ?? null)
+					: mockGuest.home
+			},
+			get currentLanguage(): string {
+				if (mockAuth.isAuthenticated) {
+					return mockUser.current?.preferredLanguage ?? 'ja'
+				}
+				return mockGuest.language ?? 'ja'
+			},
+		}
 		mockNotification = { permission: 'default' }
 		mockPush = {
 			getBrowserSubscription: vi.fn().mockResolvedValue(null),
@@ -94,6 +139,8 @@ describe('SettingsRoute', () => {
 		const container = createTestContainer(
 			Registration.instance(mockIAuthService, mockAuth),
 			Registration.instance(mockIUserService, mockUser),
+			Registration.instance(mockIUserStore, mockUserStore),
+			Registration.instance(mockIGuestService, mockGuest),
 			Registration.instance(mockINotificationManager, mockNotification),
 			Registration.instance(mockIPushService, mockPush),
 			Registration.instance(IEventAggregator, mockEa),
@@ -370,6 +417,8 @@ describe('SettingsRoute', () => {
 			const container = createTestContainer(
 				Registration.instance(mockIAuthService, mockAuth),
 				Registration.instance(mockIUserService, mockUser),
+				Registration.instance(mockIUserStore, mockUserStore),
+				Registration.instance(mockIGuestService, mockGuest),
 				Registration.instance(mockINotificationManager, mockNotification),
 				Registration.instance(mockIPushService, mockPush),
 				Registration.instance(IEventAggregator, mockEa),
@@ -394,6 +443,23 @@ describe('SettingsRoute', () => {
 			const guestSut = buildGuestSut()
 			await guestSut.selectLanguage('en')
 			expect(mockUser.updatePreferredLanguage).not.toHaveBeenCalled()
+		})
+
+		it('guest language change writes through the observable guest source and the selector reflects it (reactive)', async () => {
+			const guestSut = buildGuestSut()
+			// Before the change the guest has made no explicit choice; the
+			// selector highlight falls back to the active i18n locale ('ja').
+			expect(guestSut.currentLocale).toBe('ja')
+
+			await guestSut.selectLanguage('en')
+
+			// changeLocale writes through GuestService.setLanguage (the
+			// @observable owner) rather than raw localStorage, so the store —
+			// and therefore the Settings selector binding — reflects the new
+			// language immediately. This is the guest language-selector
+			// reactivity fix.
+			expect(mockGuest.setLanguage).toHaveBeenCalledWith('en')
+			expect(guestSut.currentLocale).toBe('en')
 		})
 	})
 })

--- a/test/services/guest-service.spec.ts
+++ b/test/services/guest-service.spec.ts
@@ -9,9 +9,11 @@ vi.mock('../../src/adapter/storage/guest-storage', () => ({
 	saveFollows: vi.fn(),
 	loadHome: vi.fn().mockReturnValue(null),
 	saveHome: vi.fn(),
+	loadLanguage: vi.fn().mockReturnValue(null),
+	saveLanguage: vi.fn(),
 }))
 
-const { loadFollows, loadHome } = await import(
+const { loadFollows, loadHome, loadLanguage, saveLanguage } = await import(
 	'../../src/adapter/storage/guest-storage'
 )
 
@@ -30,12 +32,17 @@ function makeFollow(
 }
 
 function createService(
-	overrides: { follows?: FollowedArtist[]; home?: string | null } = {},
+	overrides: {
+		follows?: FollowedArtist[]
+		home?: string | null
+		language?: string | null
+	} = {},
 ): InstanceType<typeof GuestService> {
 	vi.mocked(loadFollows).mockReturnValue(
 		overrides.follows ? [...overrides.follows] : [],
 	)
 	vi.mocked(loadHome).mockReturnValue(overrides.home ?? null)
+	vi.mocked(loadLanguage).mockReturnValue(overrides.language ?? null)
 
 	const container = DI.createContainer()
 	container.register(Registration.instance(ILogger, createMockLogger()))
@@ -137,17 +144,36 @@ describe('GuestService', () => {
 		})
 	})
 
+	describe('setLanguage', () => {
+		it('should set and persist the language code', () => {
+			const sut = createService()
+
+			sut.setLanguage('en')
+
+			expect(sut.language).toBe('en')
+			// languageChanged persists via the storage adapter.
+			expect(saveLanguage).toHaveBeenCalledWith('en')
+		})
+
+		it('hydrates the initial language from storage', () => {
+			const sut = createService({ language: 'en' })
+			expect(sut.language).toBe('en')
+		})
+	})
+
 	describe('clearAll', () => {
-		it('should empty follows and null home', () => {
+		it('should empty follows and null home and language', () => {
 			const sut = createService({
 				follows: [makeFollow('a1', 'One'), makeFollow('a2', 'Two')],
 				home: 'JP-13',
+				language: 'en',
 			})
 
 			sut.clearAll()
 
 			expect(sut.follows).toHaveLength(0)
 			expect(sut.home).toBeNull()
+			expect(sut.language).toBeNull()
 		})
 	})
 

--- a/test/services/user-store.spec.ts
+++ b/test/services/user-store.spec.ts
@@ -1,0 +1,285 @@
+import { Signals } from '@aurelia/i18n'
+import { IEventAggregator, Registration } from 'aurelia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { IAuthService } from '../../src/services/auth-service'
+import { GuestService, IGuestService } from '../../src/services/guest-service'
+import { IUserService } from '../../src/services/user-service'
+import { IUserStore, UserStore } from '../../src/services/user-store'
+import { createTestContainer } from '../helpers/create-container'
+
+// Dedicated guest-language key (decoupled from the i18next detector's
+// 'language' cache). Kept in sync with guest-storage.ts.
+const GUEST_LANGUAGE_KEY = 'guest.language'
+// The i18next-browser-languagedetector's own active-locale cache key.
+const DETECTOR_LANGUAGE_KEY = 'language'
+
+type LocaleSubscriber = (payload: {
+	oldLocale: string
+	newLocale: string
+}) => void
+
+function makeEa() {
+	let localeSubscriber: LocaleSubscriber | undefined
+	const ea = {
+		subscribe: vi.fn((channel: string, cb: LocaleSubscriber) => {
+			if (channel === Signals.I18N_EA_CHANNEL) localeSubscriber = cb
+			return { dispose: vi.fn() }
+		}),
+		publish: vi.fn(),
+	}
+	return {
+		ea,
+		// Simulate i18n publishing a locale change on its EA channel.
+		emitLocaleChange(newLocale: string): void {
+			localeSubscriber?.({ oldLocale: 'ja', newLocale })
+		},
+	}
+}
+
+function makeAuth(isAuthenticated: boolean): IAuthService {
+	return { isAuthenticated } as unknown as IAuthService
+}
+
+function makeUserService(behavior?: {
+	current?: {
+		id: string
+		home?: { level1: string }
+		preferredLanguage?: string
+	}
+	updatePreferredLanguage?: (lang: string) => Promise<unknown>
+	updateHome?: (home: unknown) => Promise<unknown>
+}): IUserService {
+	return {
+		current: behavior?.current,
+		updatePreferredLanguage: vi.fn(
+			behavior?.updatePreferredLanguage ?? (async () => behavior?.current),
+		),
+		updateHome: vi.fn(behavior?.updateHome ?? (async () => behavior?.current)),
+	} as unknown as IUserService
+}
+
+function makeGuest(overrides?: {
+	home?: string | null
+	language?: string | null
+}): IGuestService {
+	const guest = {
+		home: overrides?.home ?? null,
+		language: overrides?.language ?? null,
+		setHome: vi.fn((code: string) => {
+			guest.home = code
+		}),
+		setLanguage: vi.fn((lang: string) => {
+			guest.language = lang
+		}),
+	}
+	return guest as unknown as IGuestService
+}
+
+function build(opts: {
+	auth: IAuthService
+	userService: IUserService
+	guest: IGuestService
+}) {
+	const { ea, emitLocaleChange } = makeEa()
+	const container = createTestContainer(
+		Registration.instance(IAuthService, opts.auth),
+		Registration.instance(IUserService, opts.userService),
+		Registration.instance(IGuestService, opts.guest),
+		Registration.instance(IEventAggregator, ea as never),
+	)
+	container.register(Registration.singleton(IUserStore, UserStore))
+	const store = container.get(IUserStore)
+	return { store, emitLocaleChange, ea }
+}
+
+describe('UserStore', () => {
+	afterEach(() => {
+		vi.restoreAllMocks()
+		sessionStorage.clear()
+		localStorage.clear()
+	})
+
+	describe('currentLanguage — guest', () => {
+		let guest: IGuestService
+
+		beforeEach(() => {
+			guest = makeGuest()
+		})
+
+		it('falls back to the active i18n locale when the guest made no explicit choice', () => {
+			const { store } = build({
+				auth: makeAuth(false),
+				userService: makeUserService(),
+				guest,
+			})
+			// createTestContainer's mock i18n.getLocale() defaults to 'ja'.
+			expect(store.currentLanguage).toBe('ja')
+		})
+
+		it('reflects an explicit guest language choice from the observable source', () => {
+			guest = makeGuest({ language: 'en' })
+			const { store } = build({
+				auth: makeAuth(false),
+				userService: makeUserService(),
+				guest,
+			})
+			expect(store.currentLanguage).toBe('en')
+		})
+
+		it('updates reactively when the guest language changes', () => {
+			const { store } = build({
+				auth: makeAuth(false),
+				userService: makeUserService(),
+				guest,
+			})
+			expect(store.currentLanguage).toBe('ja')
+
+			// Mutating the @observable guest source re-resolves the getter with
+			// no manual mirror — language changes route through changeLocale, not
+			// the store (the store no longer exposes a setter).
+			guest.setLanguage('en')
+			expect(store.currentLanguage).toBe('en')
+		})
+	})
+
+	describe('currentLanguage — authenticated', () => {
+		it('reads preferredLanguage from userService.current', () => {
+			const { store } = build({
+				auth: makeAuth(true),
+				userService: makeUserService({
+					current: { id: 'u', preferredLanguage: 'en' },
+				}),
+				guest: makeGuest(),
+			})
+			expect(store.currentLanguage).toBe('en')
+		})
+
+		it('normalizes a non-supported backend tag to a supported code', () => {
+			const { store } = build({
+				auth: makeAuth(true),
+				userService: makeUserService({
+					current: { id: 'u', preferredLanguage: 'en-US' },
+				}),
+				guest: makeGuest(),
+			})
+			// 'en-US' is not in SUPPORTED_LANGUAGES; normalize so the selector
+			// still highlights the 'en' option.
+			expect(store.currentLanguage).toBe('en')
+		})
+
+		it('falls back to the i18n mirror and does NOT backfill when preferredLanguage is NULL', () => {
+			const userService = makeUserService({
+				current: { id: 'u' }, // no preferredLanguage
+			})
+			const { store } = build({
+				auth: makeAuth(true),
+				userService,
+				guest: makeGuest(),
+			})
+
+			// Surfaces the active locale ('ja' from the mock i18n) ...
+			expect(store.currentLanguage).toBe('ja')
+			// ... and is a PURE projection: the backfill RPC is owned by
+			// user-hydration-task, never the getter (no retry storm, no
+			// requireUserId throw before a user is loaded).
+			store.currentLanguage
+			expect(userService.updatePreferredLanguage).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('currentLanguage — reactive i18n mirror', () => {
+		it('re-resolves the guest fallback when the i18n locale changes', () => {
+			const { store, emitLocaleChange } = build({
+				auth: makeAuth(false),
+				userService: makeUserService(),
+				guest: makeGuest(),
+			})
+			expect(store.currentLanguage).toBe('ja')
+
+			// Guest never set an explicit language, so the store tracks the
+			// active locale via the observable i18n mirror (not a render-time
+			// getLocale() read).
+			emitLocaleChange('en')
+			expect(store.currentLanguage).toBe('en')
+		})
+	})
+
+	describe('currentHome', () => {
+		it('reads from the authenticated user entity', () => {
+			const { store } = build({
+				auth: makeAuth(true),
+				userService: makeUserService({
+					current: { id: 'u', home: { level1: 'JP-13' } },
+				}),
+				guest: makeGuest(),
+			})
+			expect(store.currentHome).toBe('JP-13')
+		})
+
+		it('reads from the observable guest source for a guest', () => {
+			const { store } = build({
+				auth: makeAuth(false),
+				userService: makeUserService(),
+				guest: makeGuest({ home: 'JP-27' }),
+			})
+			expect(store.currentHome).toBe('JP-27')
+		})
+	})
+
+	// Round-trip against the REAL guest-storage key + a REAL GuestService,
+	// exercising the dedicated 'guest.language' key (decoupled from the i18next
+	// detector's 'language' cache).
+	describe('currentLanguage — real guest round-trip', () => {
+		function buildWithRealGuest() {
+			const { ea, emitLocaleChange } = makeEa()
+			const container = createTestContainer(
+				Registration.instance(IAuthService, makeAuth(false)),
+				Registration.instance(IUserService, makeUserService()),
+				Registration.instance(IEventAggregator, ea as never),
+			)
+			container.register(Registration.singleton(IGuestService, GuestService))
+			container.register(Registration.singleton(IUserStore, UserStore))
+			const guest = container.get(IGuestService)
+			const store = container.get(IUserStore)
+			return { store, guest, emitLocaleChange }
+		}
+
+		it('falls back to the i18n mirror when no explicit choice was stored', () => {
+			// No 'guest.language' key written → loadLanguage() returns null.
+			const { store, guest } = buildWithRealGuest()
+			expect(guest.language).toBeNull()
+			expect(localStorage.getItem(GUEST_LANGUAGE_KEY)).toBeNull()
+			expect(store.currentLanguage).toBe('ja')
+		})
+
+		it('persists and reflects an explicit guest choice via the dedicated key', () => {
+			const { store, guest } = buildWithRealGuest()
+
+			guest.setLanguage('ja')
+			// languageChanged() write-through hits the real saveLanguage.
+			expect(localStorage.getItem(GUEST_LANGUAGE_KEY)).toBe('ja')
+
+			guest.setLanguage('en')
+			expect(guest.language).toBe('en')
+			expect(localStorage.getItem(GUEST_LANGUAGE_KEY)).toBe('en')
+			expect(store.currentLanguage).toBe('en')
+		})
+
+		it('clearAll() removes only the guest key, never the detector cache', () => {
+			// Seed the detector's own active-locale cache (written by
+			// i18next-browser-languagedetector, NOT GuestService).
+			localStorage.setItem(DETECTOR_LANGUAGE_KEY, 'en')
+
+			const { guest } = buildWithRealGuest()
+			guest.setLanguage('en')
+			expect(localStorage.getItem(GUEST_LANGUAGE_KEY)).toBe('en')
+
+			guest.clearAll()
+			// guest.language cleared (its dedicated key removed) ...
+			expect(localStorage.getItem(GUEST_LANGUAGE_KEY)).toBeNull()
+			// ... but the detector's 'language' cache survives, so a cancelled
+			// login does not lose the chosen UI language.
+			expect(localStorage.getItem(DETECTOR_LANGUAGE_KEY)).toBe('en')
+		})
+	})
+})


### PR DESCRIPTION
## Description

**Phase 1 of the entity-store-layer refactor** (OpenSpec `introduce-entity-store-layer`). Introduces `UserStore` and fixes a guest language-selector reactivity bug.

On Settings, a guest who changed the language saw the selector keep highlighting the *previous* language — the `currentLocale` getter fell back to an unobservable `i18n.getLocale()` read, so the `data-selected` binding never re-evaluated (guest home was reactive, guest language was not).

`UserStore` is now the single **observable** owner of the current user's home and preferred language, resolving guest(localStorage) vs authed(backend) internally so callers stop branching on `auth.isAuthenticated`. It **composes** the existing `UserService` + `GuestService` — no auth-logic rewrite; full absorption is a later phase.

Frontend-only (TS); no backend/proto/DB changes.

## Type of Change

- [x] fix: A bug fix
- [x] refactor: introduces the store layer (Phase 1 scaffold)

## Changes

- New `UserStore` (`src/services/user-store.ts`): observable `currentHome` / `currentLanguage`, source-resolved internally; an i18n locale-changed event mirror keeps the guest-unset / authed-NULL fallback reactive; authed language is normalized.
- Guest language is a first-class `@observable` on `GuestService`, persisted to a **dedicated** `guest.language` key (decoupled from the i18next detector's `language` key).
- `SettingsRoute` reads home/language from `UserStore` (removed auth-branching + render-time `getLocale()`).
- Backfill of a NULL server `preferred_language` stays owned solely by the hydration task (the getter is side-effect-free).

## Verification

### Automated Tests
- [x] `npm run lint` passed (0 errors)
- [x] `npm run test` passed (1160 tests; new `user-store.spec` covers guest reactivity, authed normalization, NULL fallback, real `guest.language` round-trip incl. `clearAll()` not touching the detector key)
- [x] `npm run build` passes

### Manual Verification
Reactivity verified via tests; in-browser smoke pending (dev env stopped).

## Out of scope (later phases)
- `FollowStore` + `UserCreated`/`SignedOut` events + boot reconciliation (Phase 2)
- Cache-only `ConcertStore`/`ArtistStore` (Phase 3)
- Remaining consumer migration + `GuestService` removal + welcome-route mirror removal (Phase 4)

## Checklist
- [x] Follows project style; self-reviewed; commented; docs (OpenSpec) updated; no new warnings

Refs: #368
