### PR TITLE
feat(follow): FollowStore + event-driven guest migration (store-layer Phase 2)

### DIFF
--- a/src/adapter/storage/local-storage.ts
+++ b/src/adapter/storage/local-storage.ts
@@ -4,9 +4,48 @@ export interface ILocalStorage {
 	getItem(key: string): string | null
 	setItem(key: string, value: string): void
 	removeItem(key: string): void
+	/**
+	 * Remove every key whose name starts with `prefix`. Used to clear all
+	 * per-account namespaced entries (e.g. the guest-merge receipts) on sign-out
+	 * without knowing the exact account id — the signed-out user's id is already
+	 * cleared from the in-memory + cached state by the time SignedOut fires.
+	 */
+	removeByPrefix(prefix: string): void
+}
+
+/**
+ * `window.localStorage` does not expose `removeByPrefix`, so wrap it in a thin
+ * adapter that implements the enumeration-based bulk removal on top of the
+ * native getItem/setItem/removeItem/key/length API.
+ */
+class LocalStorageAdapter implements ILocalStorage {
+	constructor(private readonly store: Storage) {}
+
+	public getItem(key: string): string | null {
+		return this.store.getItem(key)
+	}
+
+	public setItem(key: string, value: string): void {
+		this.store.setItem(key, value)
+	}
+
+	public removeItem(key: string): void {
+		this.store.removeItem(key)
+	}
+
+	public removeByPrefix(prefix: string): void {
+		// Collect first, delete after: removing while iterating by index shifts
+		// the remaining keys and would skip entries.
+		const toRemove: string[] = []
+		for (let i = 0; i < this.store.length; i++) {
+			const key = this.store.key(i)
+			if (key?.startsWith(prefix)) toRemove.push(key)
+		}
+		for (const key of toRemove) this.store.removeItem(key)
+	}
 }
 
 export const ILocalStorage = DI.createInterface<ILocalStorage>(
 	'ILocalStorage',
-	(x) => x.instance(window.localStorage),
+	(x) => x.instance(new LocalStorageAdapter(window.localStorage)),
 )

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -30,6 +30,12 @@ export const SessionKeys = {
 	// lifetime — acceptable since the RPC is idempotent on a non-NULL row
 	// (server returns the existing value unchanged).
 	languageBackfillAttempted: 'liverty:lang:backfillAttempted',
+	// Set after the follow-reconcile task runs in the current tab so the
+	// receipt-keyed reconcile fires at most once per tab. Cleared again if the
+	// reconcile defers (no user id yet) so the next start retries. Per-tab
+	// scoping is acceptable because the backend Follow/SetHype calls are
+	// idempotent and the receipt makes queue-level migration exactly-once.
+	followReconcileAttempted: 'liverty:follow:reconcileAttempted',
 } as const
 
 // Per-external_id namespaced key holding the internal user_id resolved from
@@ -39,6 +45,22 @@ export const SessionKeys = {
 export function userIdStorageKey(externalID: string): string {
 	return `liverty:userId:${externalID}`
 }
+
+// Per-account guest-merge receipt. Written once a follow migration completes
+// for an account; its PRESENCE — not the presence of guest follow data —
+// decides whether boot reconciliation re-migrates. This makes follow migration
+// exactly-once per account and prevents resurrecting state the user reverted
+// after sign-up (migrate-then-clear-failed → reboot would otherwise re-follow).
+export function guestMergedReceiptKey(userId: string): string {
+	return `${GUEST_MERGED_RECEIPT_PREFIX}${userId}`
+}
+
+// Shared prefix for the per-account guest-merge receipt keys. The receipt's
+// lifetime is ONE authenticated session: it prevents resurrecting reverted
+// state WITHIN a session, but on sign-out every receipt is removed (by prefix,
+// since the signed-out user's id is already cleared from in-memory + cached
+// state by then) so a fresh post-sign-out guest session can migrate again.
+export const GUEST_MERGED_RECEIPT_PREFIX = 'liverty:guestMerged:'
 
 /**
  * Migrate legacy localStorage keys from the old admin area format.

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,7 +64,9 @@ import { IAudioEngine } from './services/audio-engine'
 import { IAuthService } from './services/auth-service'
 import { IConcertService } from './services/concert-service'
 import { IErrorBoundaryService } from './services/error-boundary-service'
+import { FollowReconcileTask } from './services/follow-reconcile-task'
 import { IFollowServiceClient } from './services/follow-service-client'
+import { IFollowStore } from './services/follow-store'
 import { GlobalErrorHandlingTask } from './services/global-error-handler'
 import { IGuestDataMergeService } from './services/guest-data-merge-service'
 import { IGuestService } from './services/guest-service'
@@ -197,6 +199,20 @@ async function bootstrap(): Promise<void> {
 	// owner of home/language; register after both so its singleton can resolve
 	// them. Callers read the store instead of branching on auth state.
 	au.register(IUserStore)
+	// FollowStore owns the follow slice's auth-boundary transitions
+	// (GuestMigrationRequested → migrate, SignedOut → self-clear + cache eviction) by
+	// composing IFollowServiceClient. Registered after IGuestService /
+	// IFollowServiceClient so its singleton can resolve them.
+	au.register(IFollowStore)
+	// FollowReconcileTask is an activating AppTask that heals partial follow
+	// migrations on boot, keyed on the per-account guest-merge receipt. Same-slot
+	// AppTasks (this and UserHydrationTask) run CONCURRENTLY via Promise.all, NOT
+	// sequentially in registration order, so this task does NOT depend on
+	// UserHydrationTask having populated `UserService.current` first — it calls
+	// the idempotent `ensureLoaded` itself before reading `current.id`. It also
+	// eagerly resolves IFollowStore so its event subscriptions are live before
+	// any sign-up / sign-out fires.
+	au.register(FollowReconcileTask)
 	au.register(IGuestDataMergeService)
 	au.register(IAudioEngine)
 	au.register(INotificationManager)

--- a/src/routes/auth-callback/auth-callback-route.ts
+++ b/src/routes/auth-callback/auth-callback-route.ts
@@ -1,12 +1,13 @@
 import { I18N } from '@aurelia/i18n'
 import type { NavigationInstruction, Params, RouteNode } from '@aurelia/router'
-import { ILogger, resolve } from 'aurelia'
+import { IEventAggregator, ILogger, resolve } from 'aurelia'
 import { codeToHome } from '../../constants/iso3166'
 import { StorageKeys } from '../../constants/storage-keys'
 import { IAuthService } from '../../services/auth-service'
+import { GuestMigrationRequested } from '../../services/events/guest-migration-requested'
 import { IGuestDataMergeService } from '../../services/guest-data-merge-service'
 import { IGuestService } from '../../services/guest-service'
-import { IUserService } from '../../services/user-service'
+import { IUserService, type ProvisionResult } from '../../services/user-service'
 import {
 	isSupportedLanguage,
 	normalizeToSupportedLanguage,
@@ -29,6 +30,7 @@ export class AuthCallbackRoute {
 	private readonly mergeService = resolve(IGuestDataMergeService)
 	private readonly guest = resolve(IGuestService)
 	private readonly i18n = resolve(I18N)
+	private readonly ea = resolve(IEventAggregator)
 	private readonly logger = resolve(ILogger).scopeTo('AuthCallbackRoute')
 
 	public async canLoad(
@@ -40,7 +42,30 @@ export class AuthCallbackRoute {
 			const user = await this.authService.handleCallback()
 			this.logger.info('handleCallback success!')
 
-			const isNewUser = await this.ensureUserProvisioned(user.profile.email)
+			const { user: provisioned, created } = await this.ensureUserProvisioned(
+				user.profile.email,
+			)
+
+			// Request guest-follow migration on EVERY successful authenticated
+			// callback (sign-up AND returning sign-in), not only on sign-up. A
+			// returning user who browsed anonymously (accumulating guest follows)
+			// and then signs in via Settings / auth-status — paths that do NOT
+			// clearAll — would otherwise lose those follows in-session until a
+			// cold-boot reconcile healed them. FollowStore.migrateGuestFollows is
+			// receipt-guarded, idempotent, and a no-op on an empty queue, so firing
+			// unconditionally is safe (empty queue → nothing; already-migrated →
+			// not re-migrated).
+			//
+			// migrateGuestFollows needs the internal user_id; ensureUserProvisioned
+			// guarantees `userService.current` is hydrated before we read it.
+			const userId = provisioned?.id ?? this.userService.current?.id
+			if (userId) {
+				this.ea.publish(new GuestMigrationRequested(userId))
+			} else {
+				this.logger.warn(
+					'Authenticated callback but no user id available; skipping follow migration trigger',
+				)
+			}
 
 			// Apply the DB-stored preferred language to i18n for the
 			// current session. UserHydrationTask normally owns this, but
@@ -88,8 +113,13 @@ export class AuthCallbackRoute {
 			// Merge any guest data accumulated during onboarding
 			await this.mergeService.merge()
 
-			// On first-time signup: set flag so dashboard shows PostSignupDialog
-			if (isNewUser) {
+			// On a GENUINELY NEW account: set flag so dashboard shows
+			// PostSignupDialog. Keyed on the new-account signal from provisioning
+			// (backend minted a fresh row, not an idempotent ALREADY_EXISTS
+			// return), NOT on the OIDC sign-up FLOW — a returning user who taps
+			// "Sign up" (settings / auth-status have no guard) must not get the
+			// new-user dialog.
+			if (created) {
 				localStorage.setItem(StorageKeys.postSignupShown, 'pending')
 			}
 
@@ -120,12 +150,13 @@ export class AuthCallbackRoute {
 	// Otherwise UserService.ensureLoaded() handles everything: cache hit →
 	// Get, cache miss → idempotent Create using the JWT email.
 	//
-	// Returns true when this session looks like a first-time signup. The
-	// presence of guestHome (set only during the onboarding flow before
-	// account creation) is a reliable proxy.
+	// Returns the provisioned/loaded user (so the caller has the internal
+	// user_id for the migration trigger) plus `created`, which is true only when
+	// a GENUINELY NEW backend account was minted — the caller keys the
+	// post-signup dialog on that, NOT on the OIDC sign-up flow.
 	private async ensureUserProvisioned(
 		email: string | undefined,
-	): Promise<boolean> {
+	): Promise<ProvisionResult> {
 		const guestHome = this.guest.home
 		if (guestHome && email) {
 			// Capture the effective locale at signup so the new user row carries
@@ -153,17 +184,15 @@ export class AuthCallbackRoute {
 			// If "cleanup before first authenticated read" ever becomes a
 			// hard requirement, the right fix is to call the cleanup
 			// imperatively here, not to rely on AppTask.activating.
-			await this.userService.create(
+			return this.userService.create(
 				email,
 				normalizeToSupportedLanguage(this.i18n.getLocale()),
 				codeToHome(guestHome),
 			)
-			return true
 		}
 
-		await this.userService.ensureLoaded(
+		return this.userService.ensureLoaded(
 			normalizeToSupportedLanguage(this.i18n.getLocale()),
 		)
-		return false
 	}
 }

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -1,4 +1,4 @@
-import { DI, ILogger, resolve } from 'aurelia'
+import { DI, IEventAggregator, ILogger, resolve } from 'aurelia'
 import {
 	type User,
 	UserManager,
@@ -6,6 +6,7 @@ import {
 	WebStorageStateStore,
 } from 'oidc-client-ts'
 import { type AppConfig, IAppConfig } from '../config/app-config'
+import { SignedOut } from './events/signed-out'
 
 function createSettings(config: AppConfig): UserManagerSettings {
 	return {
@@ -44,6 +45,7 @@ export interface IAuthService extends AuthService {}
 export class AuthService {
 	private userManager: UserManager
 	private readonly logger = resolve(ILogger).scopeTo('AuthService')
+	private readonly ea = resolve(IEventAggregator)
 	private readyResolve?: () => void
 	public readonly ready: Promise<void>
 
@@ -90,8 +92,11 @@ export class AuthService {
 
 	public async signUp(): Promise<void> {
 		this.logger.info('Starting sign-up flow')
-		// Zitadel supports prompt=create to default to sign-up form
-		// Onboarding vs login detection is handled via onboardingStep in localStorage
+		// Zitadel supports prompt=create to default to sign-up form. No custom
+		// `state` round-trip: the callback no longer keys behavior on the sign-up
+		// FLOW. Guest-follow migration fires on every authenticated callback, and
+		// the post-signup dialog keys on the backend new-account signal — neither
+		// needs an isSignUp flag, so plumbing one through OIDC state would be dead.
 		await this.userManager.signinRedirect({
 			prompt: 'create',
 		})
@@ -99,6 +104,12 @@ export class AuthService {
 
 	public async signOut(): Promise<void> {
 		this.logger.info('Starting sign-out flow')
+		// Publish BEFORE the redirect so every store can self-clear (guest
+		// follows, user-specific caches) while the app is still alive. This is
+		// the single publish point for the two sign-out call sites
+		// (settings-route, auth-status); each store subscribes and clears
+		// idempotently, replacing the old GuestService.clearAll() responsibility.
+		this.ea.publish(new SignedOut())
 		await this.userManager.signoutRedirect()
 	}
 
@@ -106,6 +117,9 @@ export class AuthService {
 		this.logger.info('Processing auth callback')
 		try {
 			const user = await this.userManager.signinCallback()
+			if (!user) {
+				throw new Error('signinCallback returned no user')
+			}
 			this.logger.info('Auth callback processed successfully', {
 				user: user.profile.preferred_username,
 			})

--- a/src/services/events/guest-migration-requested.ts
+++ b/src/services/events/guest-migration-requested.ts
@@ -1,0 +1,30 @@
+/**
+ * Requests migration of the guest follow queue into the authenticated account.
+ *
+ * Published by `AuthCallbackRoute` on EVERY successful authenticated callback
+ * (sign-up AND sign-in) once the user has been provisioned and the internal
+ * `userId` is available. The single ordering edge in the auth-boundary
+ * transition is "provision before migrate" (migration needs a `userId`), which
+ * the publisher guarantees.
+ *
+ * Fires on any authentication — not only sign-up — because a returning user who
+ * browsed anonymously (accumulating guest follows) and then SIGNS IN via
+ * Settings / auth-status (paths that do NOT clearAll) would otherwise lose those
+ * follows in-session until a cold-boot reconcile healed them. `FollowStore`'s
+ * `migrateGuestFollows` is receipt-guarded, idempotent, and a no-op on an empty
+ * queue, so publishing unconditionally on a successful callback is safe: an
+ * empty-queue callback does nothing and already-migrated state is not
+ * re-migrated (the per-account receipt makes the queue-level migration
+ * exactly-once).
+ *
+ * NOT published from `UserService.create()`: that method is also reached on the
+ * idempotent cache-miss recovery, so owning the publish in the callback keeps
+ * the trigger at the single auth-boundary site with the resolved `userId`.
+ *
+ * Subscribers run best-effort and are NOT awaited by the publisher — follow
+ * migration is background work; a partial failure is healed by boot
+ * reconciliation rather than blocking navigation.
+ */
+export class GuestMigrationRequested {
+	constructor(public readonly userId: string) {}
+}

--- a/src/services/events/signed-out.ts
+++ b/src/services/events/signed-out.ts
@@ -1,0 +1,13 @@
+/**
+ * Published on the sign-out path, before the OIDC sign-out redirect, so every
+ * store can self-clear while the app is still alive.
+ *
+ * Each store subscribes and clears its own state independently — clearing is
+ * idempotent and order-independent, so there is no orchestrator and no
+ * completion barrier. Stores that cache user-specific data (e.g. the follow
+ * store's followed-artist projections) MUST also evict that cache here so a
+ * subsequent visitor on a shared browser never sees the previous user's data.
+ *
+ * Replaces the old `GuestService.clearAll()` sign-out responsibility.
+ */
+export class SignedOut {}

--- a/src/services/follow-reconcile-task.spec.ts
+++ b/src/services/follow-reconcile-task.spec.ts
@@ -1,0 +1,226 @@
+import type { IContainer } from 'aurelia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SessionKeys } from '../constants/storage-keys'
+import type { Artist } from '../entities/artist'
+import { DEFAULT_HYPE, type FollowedArtist } from '../entities/follow'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockLogger = {
+	scopeTo: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}
+
+const mockAuth: { ready: Promise<void>; isAuthenticated: boolean } = {
+	ready: Promise.resolve(),
+	isAuthenticated: true,
+}
+
+// ensureLoaded is the idempotent hydration call the reconcile awaits itself so
+// it does NOT depend on UserHydrationTask ordering. By default it resolves a
+// user into `current` (simulating the Get/Create chain); individual tests
+// override it to model a not-yet-hydrated or failing hydration.
+const mockUserService = {
+	current: undefined as { id: string } | undefined,
+	ensureLoaded: vi.fn(async (_locale: string) => {
+		mockUserService.current ??= { id: 'user-1' }
+		return mockUserService.current
+	}),
+}
+
+const mockI18n = {
+	getLocale: vi.fn(() => 'en'),
+}
+
+const mockGuest = {
+	follows: [] as FollowedArtist[],
+	clearFollows: vi.fn(() => {
+		mockGuest.follows.splice(0)
+	}),
+}
+
+const mockFollowStore = {
+	hasReceipt: vi.fn(() => false),
+	migrateGuestFollows: vi.fn(async () => undefined),
+}
+
+vi.mock('aurelia', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('aurelia')>()
+	return {
+		...actual,
+		ILogger: { friendlyName: 'ILogger' },
+		IContainer: { friendlyName: 'IContainer' },
+		AppTask: { activating: (_key: unknown, fn: unknown) => fn },
+	}
+})
+
+vi.mock('@aurelia/i18n', () => ({
+	I18N: { friendlyName: 'I18N' },
+}))
+
+vi.mock('../util/change-locale', () => ({
+	// Identity-ish normalize: the reconcile only needs SOME effective locale
+	// string to pass to ensureLoaded; the exact value is irrelevant here.
+	normalizeToSupportedLanguage: (l: string) => l,
+}))
+
+vi.mock('./auth-service', () => ({
+	IAuthService: { friendlyName: 'IAuthService' },
+}))
+vi.mock('./user-service', () => ({
+	IUserService: { friendlyName: 'IUserService' },
+}))
+vi.mock('./guest-service', () => ({
+	IGuestService: { friendlyName: 'IGuestService' },
+}))
+vi.mock('./follow-store', () => ({
+	IFollowStore: { friendlyName: 'IFollowStore' },
+}))
+
+import { runFollowReconcile } from './follow-reconcile-task'
+
+const container = {
+	get: vi.fn((token: { friendlyName?: string }) => {
+		const map: Record<string, unknown> = {
+			ILogger: mockLogger,
+			IAuthService: mockAuth,
+			IUserService: mockUserService,
+			IGuestService: mockGuest,
+			IFollowStore: mockFollowStore,
+			I18N: mockI18n,
+		}
+		return map[token.friendlyName ?? '']
+	}),
+} as unknown as IContainer
+
+function makeFollow(id: string): FollowedArtist {
+	return { artist: { id, name: `Artist ${id}` } as Artist, hype: DEFAULT_HYPE }
+}
+
+describe('runFollowReconcile', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		sessionStorage.clear()
+		mockAuth.isAuthenticated = true
+		mockUserService.current = { id: 'user-1' }
+		// Default ensureLoaded: idempotent hydration that ensures `current`.
+		mockUserService.ensureLoaded.mockImplementation(async () => {
+			mockUserService.current ??= { id: 'user-1' }
+			return mockUserService.current
+		})
+		mockGuest.follows = []
+		mockFollowStore.hasReceipt.mockReturnValue(false)
+		// hasReceipt becomes true after a successful migrate (write-through).
+		mockFollowStore.migrateGuestFollows.mockImplementation(async () => {
+			mockFollowStore.hasReceipt.mockReturnValue(true)
+		})
+	})
+
+	it('skips when unauthenticated', async () => {
+		mockAuth.isAuthenticated = false
+		mockGuest.follows = [makeFollow('a1')]
+
+		await runFollowReconcile(container)
+
+		expect(mockFollowStore.migrateGuestFollows).not.toHaveBeenCalled()
+	})
+
+	it('no-ops when the guest queue is empty', async () => {
+		mockGuest.follows = []
+
+		await runFollowReconcile(container)
+
+		expect(mockFollowStore.migrateGuestFollows).not.toHaveBeenCalled()
+		expect(mockGuest.clearFollows).not.toHaveBeenCalled()
+	})
+
+	it('migrates then clears when there is no receipt and a leftover queue', async () => {
+		mockGuest.follows = [makeFollow('a1')]
+
+		await runFollowReconcile(container)
+
+		expect(mockFollowStore.migrateGuestFollows).toHaveBeenCalledWith('user-1')
+		expect(mockGuest.clearFollows).toHaveBeenCalledOnce()
+	})
+
+	it('clears WITHOUT migrating when the receipt already exists (no resurrection)', async () => {
+		mockGuest.follows = [makeFollow('a1')]
+		mockFollowStore.hasReceipt.mockReturnValue(true)
+
+		await runFollowReconcile(container)
+
+		expect(mockFollowStore.migrateGuestFollows).not.toHaveBeenCalled()
+		expect(mockGuest.clearFollows).toHaveBeenCalledOnce()
+	})
+
+	it('is session-guarded: a second run in the same tab is a no-op', async () => {
+		mockGuest.follows = [makeFollow('a1')]
+
+		await runFollowReconcile(container)
+		expect(mockFollowStore.migrateGuestFollows).toHaveBeenCalledOnce()
+
+		// Re-arm a queue; the session flag must short-circuit the second run.
+		mockGuest.follows = [makeFollow('a2')]
+		await runFollowReconcile(container)
+		expect(mockFollowStore.migrateGuestFollows).toHaveBeenCalledOnce()
+	})
+
+	it('self-hydrates via ensureLoaded (does NOT rely on UserHydrationTask ordering)', async () => {
+		// `current` starts undefined — simulating the race where UserHydrationTask
+		// has not populated it yet. The reconcile must call ensureLoaded itself.
+		mockUserService.current = undefined
+		mockGuest.follows = [makeFollow('a1')]
+		mockUserService.ensureLoaded.mockImplementation(async () => {
+			mockUserService.current = { id: 'user-1' }
+			return mockUserService.current
+		})
+
+		await runFollowReconcile(container)
+
+		expect(mockUserService.ensureLoaded).toHaveBeenCalledOnce()
+		// Migration ran because ensureLoaded produced a user id without depending
+		// on the hydration task running first.
+		expect(mockFollowStore.migrateGuestFollows).toHaveBeenCalledWith('user-1')
+		expect(mockGuest.clearFollows).toHaveBeenCalledOnce()
+	})
+
+	it('defers (re-arms the session flag) when no user id is available even after ensureLoaded', async () => {
+		mockGuest.follows = [makeFollow('a1')]
+		mockUserService.current = undefined
+		// ensureLoaded cannot bootstrap a user (e.g. no cached id and no email).
+		mockUserService.ensureLoaded.mockResolvedValue(undefined)
+
+		await runFollowReconcile(container)
+
+		expect(mockFollowStore.migrateGuestFollows).not.toHaveBeenCalled()
+		// Flag cleared so the next start retries once a user id exists.
+		expect(
+			sessionStorage.getItem(SessionKeys.followReconcileAttempted),
+		).toBeNull()
+	})
+
+	it('re-arms the session flag when ensureLoaded throws', async () => {
+		mockGuest.follows = [makeFollow('a1')]
+		mockUserService.current = undefined
+		mockUserService.ensureLoaded.mockRejectedValue(new Error('rpc down'))
+
+		await runFollowReconcile(container)
+
+		expect(mockFollowStore.migrateGuestFollows).not.toHaveBeenCalled()
+		expect(
+			sessionStorage.getItem(SessionKeys.followReconcileAttempted),
+		).toBeNull()
+	})
+
+	it('does NOT clear when migration left failed items (no receipt written)', async () => {
+		mockGuest.follows = [makeFollow('a1')]
+		// Simulate a partial failure: migrate runs but does not write the receipt.
+		mockFollowStore.migrateGuestFollows.mockImplementation(async () => {
+			mockFollowStore.hasReceipt.mockReturnValue(false)
+		})
+
+		await runFollowReconcile(container)
+
+		expect(mockFollowStore.migrateGuestFollows).toHaveBeenCalledOnce()
+		expect(mockGuest.clearFollows).not.toHaveBeenCalled()
+	})
+})

--- a/src/services/follow-reconcile-task.ts
+++ b/src/services/follow-reconcile-task.ts
@@ -1,0 +1,117 @@
+import { I18N } from '@aurelia/i18n'
+import { AppTask, IContainer, ILogger } from 'aurelia'
+import { SessionKeys } from '../constants/storage-keys'
+import { normalizeToSupportedLanguage } from '../util/change-locale'
+import { IAuthService } from './auth-service'
+import { IFollowStore } from './follow-store'
+import { IGuestService } from './guest-service'
+import { IUserService } from './user-service'
+
+/**
+ * Boot reconciliation of leftover guest follows, keyed on the per-account
+ * guest-merge receipt (NOT the mere presence of guest data) so reverted state
+ * is never resurrected:
+ *
+ *   - authenticated + leftover queue + NO receipt → migrate (idempotent,
+ *     per-item drain), write receipt, clear.
+ *   - authenticated + residual queue + receipt ALREADY present → clear WITHOUT
+ *     re-migrating (a prior clear failed; the user may have reverted state, so
+ *     re-following would resurrect it).
+ *
+ * Runs early (activating AppTask) and session-guarded so the reconcile fires at
+ * most once per tab. Mirrors the `user-hydration-task` boot pattern, and is
+ * exported separately from its `AppTask` wrapper so tests can drive it with
+ * stubbed services.
+ */
+export async function runFollowReconcile(container: IContainer): Promise<void> {
+	// Eagerly resolve FollowStore FIRST so its constructor's GuestMigrationRequested /
+	// SignedOut subscriptions are live before any sign-up or sign-out can fire
+	// (a plain DI singleton is otherwise lazy and would miss early events).
+	const followStore = container.get(IFollowStore)
+
+	const auth = container.get(IAuthService)
+	await auth.ready
+
+	if (!auth.isAuthenticated) return
+
+	// Session guard: one reconcile attempt per tab. Idempotent backend calls
+	// make a missed attempt harmless (the next cold start retries).
+	if (sessionStorage.getItem(SessionKeys.followReconcileAttempted)) return
+	sessionStorage.setItem(SessionKeys.followReconcileAttempted, '1')
+
+	const logger = container.get(ILogger).scopeTo('FollowReconcileTask')
+	const guest = container.get(IGuestService)
+
+	// Nothing left in the guest queue → nothing to reconcile.
+	if (guest.follows.length === 0) return
+
+	const userService = container.get(IUserService)
+
+	// Self-sufficient hydration: same-slot AppTasks (UserHydrationTask and this
+	// task) run CONCURRENTLY via Promise.all (onResolveAll), NOT sequentially in
+	// registration order — so we cannot assume `current` is populated by the
+	// time we read it. ensureLoaded is idempotent (the same call hydration uses):
+	// it returns the in-memory user if already loaded, otherwise resolves the
+	// Get/idempotent-Create chain. Awaiting it here guarantees `current.id` is
+	// available without racing UserHydrationTask. Pass the effective locale for
+	// the cache-miss Create path, mirroring UserHydrationTask.
+	const clientLocale = normalizeToSupportedLanguage(
+		container.get(I18N).getLocale(),
+	)
+	try {
+		await userService.ensureLoaded(clientLocale)
+	} catch (err) {
+		logger.warn('Failed to hydrate user for follow reconcile; deferring', {
+			error: err,
+		})
+		sessionStorage.removeItem(SessionKeys.followReconcileAttempted)
+		return
+	}
+
+	const userId = userService.current?.id
+	if (!userId) {
+		// No user id even after ensureLoaded (e.g. no cached id AND no email in
+		// the JWT claims). Leave the session flag cleared so the next start can
+		// retry once a user id exists.
+		sessionStorage.removeItem(SessionKeys.followReconcileAttempted)
+		logger.warn(
+			'No user id available; deferring follow reconcile to next start',
+		)
+		return
+	}
+
+	if (followStore.hasReceipt(userId)) {
+		// Receipt present → this account already migrated. The residual queue is
+		// stale (a prior clear failed); clear WITHOUT re-migrating so reverted
+		// state is not resurrected.
+		logger.info(
+			'Receipt present; clearing residual guest follows without migrating',
+			{
+				userId,
+				residual: guest.follows.length,
+			},
+		)
+		guest.clearFollows()
+		return
+	}
+
+	// No receipt → first authenticated reconcile for this account. Migrate
+	// (idempotent, per-item drain), which writes the receipt on success.
+	logger.info('Reconciling leftover guest follows', {
+		userId,
+		queued: guest.follows.length,
+	})
+	await followStore.migrateGuestFollows(userId)
+
+	// Clear whatever fully migrated. The per-item drain already removed
+	// succeeded items; any survivors are genuine failures left for the next
+	// reconcile (the receipt was NOT written, so they will be retried).
+	if (followStore.hasReceipt(userId)) {
+		guest.clearFollows()
+	}
+}
+
+export const FollowReconcileTask = AppTask.activating(
+	IContainer,
+	runFollowReconcile,
+)

--- a/src/services/follow-service-client.ts
+++ b/src/services/follow-service-client.ts
@@ -38,6 +38,16 @@ export class FollowServiceClient {
 	}
 
 	/**
+	 * Evict the followed-artist projection cache. Owned by this client (the
+	 * @observable field's owner) so any cache invalidation tied to the
+	 * projection runs through the owner rather than an external cross-object
+	 * write. Called by FollowStore on sign-out.
+	 */
+	public clear(): void {
+		this.followedArtists = []
+	}
+
+	/**
 	 * Follow an artist with optimistic UI update.
 	 * Guest users delegate to GuestService for localStorage persistence.
 	 * Authenticated users call backend RPC with rollback on failure.

--- a/src/services/follow-store.spec.ts
+++ b/src/services/follow-store.spec.ts
@@ -1,0 +1,287 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ILocalStorage } from '../adapter/storage/local-storage'
+import { guestMergedReceiptKey } from '../constants/storage-keys'
+import type { Artist } from '../entities/artist'
+import {
+	DEFAULT_HYPE,
+	type FollowedArtist,
+	type Hype,
+} from '../entities/follow'
+import { GuestMigrationRequested } from './events/guest-migration-requested'
+import { SignedOut } from './events/signed-out'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockLogger = {
+	scopeTo: () => ({
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	}),
+}
+
+// Guest follow source backed by a mutable array so per-item drain is observable.
+const mockGuest = {
+	follows: [] as FollowedArtist[],
+	removeFollow: vi.fn((id: string) => {
+		const idx = mockGuest.follows.findIndex((f) => f.artist.id === id)
+		if (idx >= 0) mockGuest.follows.splice(idx, 1)
+	}),
+	// Counts calls so a test can assert the drain persisted ONCE for the batch.
+	removeFollows: vi.fn((ids: readonly string[]) => {
+		const remove = new Set(ids)
+		mockGuest.follows = mockGuest.follows.filter(
+			(f) => !remove.has(f.artist.id),
+		)
+	}),
+	clearFollows: vi.fn(() => {
+		mockGuest.follows.splice(0)
+	}),
+}
+
+const mockRpcClient = {
+	follow: vi.fn(async (_id: string) => undefined),
+	setHype: vi.fn(async (_id: string, _hype: Hype) => undefined),
+}
+
+const mockDelegate = {
+	followedArtists: [] as Artist[],
+	followedIds: new Set<string>(),
+	followedCount: 0,
+	hydrate: vi.fn(),
+	clear: vi.fn(() => {
+		mockDelegate.followedArtists = []
+	}),
+	follow: vi.fn(async () => undefined),
+	unfollow: vi.fn(async () => undefined),
+	listFollowed: vi.fn(async () => [] as FollowedArtist[]),
+	setHype: vi.fn(async () => undefined),
+	getFollowedArtistMap: vi.fn(async () => new Map()),
+}
+
+const lsMap = new Map<string, string>()
+const mockStorage: ILocalStorage = {
+	getItem: vi.fn((k: string) => lsMap.get(k) ?? null),
+	setItem: vi.fn((k: string, v: string) => {
+		lsMap.set(k, v)
+	}),
+	removeItem: vi.fn((k: string) => {
+		lsMap.delete(k)
+	}),
+	removeByPrefix: vi.fn((prefix: string) => {
+		for (const k of [...lsMap.keys()]) {
+			if (k.startsWith(prefix)) lsMap.delete(k)
+		}
+	}),
+}
+
+// Capture EA subscriptions so the test can fire GuestMigrationRequested / SignedOut.
+type Handler = (event: unknown) => void
+const subscriptions = new Map<unknown, Handler>()
+const mockEa = {
+	subscribe: vi.fn((channel: unknown, handler: Handler) => {
+		subscriptions.set(channel, handler)
+		return { dispose: vi.fn() }
+	}),
+	publish: vi.fn(),
+}
+
+vi.mock('aurelia', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('aurelia')>()
+	return {
+		...actual,
+		resolve: vi.fn((token: unknown) => {
+			const map: Record<string, unknown> = {
+				ILogger: mockLogger,
+				IGuestService: mockGuest,
+				IFollowRpcClient: mockRpcClient,
+				IFollowServiceClient: mockDelegate,
+				ILocalStorage: mockStorage,
+				IEventAggregator: mockEa,
+			}
+			const tokenAny = token as { friendlyName?: string }
+			return map[tokenAny.friendlyName ?? ''] ?? {}
+		}),
+	}
+})
+
+import { FollowStore } from './follow-store'
+
+function makeArtist(id: string, name: string): Artist {
+	return { id, name } as Artist
+}
+
+function makeFollow(id: string, hype: Hype = DEFAULT_HYPE): FollowedArtist {
+	return { artist: makeArtist(id, `Artist ${id}`), hype }
+}
+
+describe('FollowStore', () => {
+	let sut: FollowStore
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		subscriptions.clear()
+		lsMap.clear()
+		mockGuest.follows = []
+		mockDelegate.followedArtists = []
+		// clearAllMocks keeps per-test mockImplementation overrides, so restore
+		// the happy-path RPC defaults to prevent one test's failure-injection
+		// (e.g. follow throwing) from leaking into the next.
+		mockRpcClient.follow.mockImplementation(async (_id: string) => undefined)
+		mockRpcClient.setHype.mockImplementation(
+			async (_id: string, _hype: Hype) => undefined,
+		)
+		sut = new FollowStore()
+	})
+
+	function fireMigrationRequested(userId: string): Promise<void> {
+		const handler = subscriptions.get(GuestMigrationRequested)
+		handler?.(new GuestMigrationRequested(userId))
+		// Migration runs as a fire-and-forget promise inside the handler; flush
+		// the microtask queue so its awaits settle before assertions.
+		return Promise.resolve()
+	}
+
+	describe('GuestMigrationRequested → migrate', () => {
+		it('follows each guest artist, drains the batch, and writes the receipt', async () => {
+			mockGuest.follows = [makeFollow('a1'), makeFollow('a2')]
+
+			await sut.migrateGuestFollows('user-1')
+
+			expect(mockRpcClient.follow).toHaveBeenCalledTimes(2)
+			expect(mockRpcClient.follow).toHaveBeenCalledWith('a1')
+			expect(mockRpcClient.follow).toHaveBeenCalledWith('a2')
+			// Batched drain emptied the queue.
+			expect(mockGuest.follows).toHaveLength(0)
+			// Receipt written for the account.
+			expect(lsMap.get(guestMergedReceiptKey('user-1'))).toBe('1')
+		})
+
+		it('drains the fully-migrated batch with a SINGLE persist (no O(n^2) write storm)', async () => {
+			mockGuest.follows = [makeFollow('a1'), makeFollow('a2'), makeFollow('a3')]
+
+			await sut.migrateGuestFollows('user-1')
+
+			// One batched removeFollows call rather than one removeFollow per item.
+			expect(mockGuest.removeFollows).toHaveBeenCalledOnce()
+			expect(mockGuest.removeFollows).toHaveBeenCalledWith(['a1', 'a2', 'a3'])
+			expect(mockGuest.removeFollow).not.toHaveBeenCalled()
+		})
+
+		it('migrates non-default hype only for successfully followed artists', async () => {
+			mockGuest.follows = [makeFollow('a1', 'away'), makeFollow('a2')]
+
+			await sut.migrateGuestFollows('user-1')
+
+			expect(mockRpcClient.setHype).toHaveBeenCalledOnce()
+			expect(mockRpcClient.setHype).toHaveBeenCalledWith('a1', 'away')
+		})
+
+		it('leaves only the failed item in the queue and DEFERS the receipt', async () => {
+			mockGuest.follows = [makeFollow('a1'), makeFollow('a2')]
+			mockRpcClient.follow.mockImplementation(async (id: string) => {
+				if (id === 'a2') throw new Error('network')
+			})
+
+			await sut.migrateGuestFollows('user-1')
+
+			// a1 drained, a2 failed → remains.
+			expect(mockGuest.follows.map((f) => f.artist.id)).toEqual(['a2'])
+			// No receipt: the next reconcile must retry the failed item.
+			expect(lsMap.has(guestMergedReceiptKey('user-1'))).toBe(false)
+		})
+
+		it('does NOT drain an item whose SetHype fails, and DEFERS the receipt', async () => {
+			// a1 has a non-default hype; its Follow succeeds but SetHype throws.
+			mockGuest.follows = [makeFollow('a1', 'away'), makeFollow('a2')]
+			mockRpcClient.setHype.mockImplementation(async (id: string) => {
+				if (id === 'a1') throw new Error('hype rpc failed')
+			})
+
+			await sut.migrateGuestFollows('user-1')
+
+			// a1 Follow succeeded but its hype did not migrate → keep it for retry
+			// so the non-default hype is not lost; a2 (default hype) drains.
+			expect(mockGuest.follows.map((f) => f.artist.id)).toEqual(['a1'])
+			expect(mockGuest.removeFollows).toHaveBeenCalledWith(['a2'])
+			// Receipt deferred so reconcile re-issues SetHype for a1.
+			expect(lsMap.has(guestMergedReceiptKey('user-1'))).toBe(false)
+		})
+
+		it('writes the receipt even when the guest queue is empty', async () => {
+			mockGuest.follows = []
+
+			await sut.migrateGuestFollows('user-1')
+
+			expect(mockRpcClient.follow).not.toHaveBeenCalled()
+			expect(lsMap.get(guestMergedReceiptKey('user-1'))).toBe('1')
+		})
+
+		it('is triggered by the GuestMigrationRequested event subscription', async () => {
+			const migrateSpy = vi
+				.spyOn(sut, 'migrateGuestFollows')
+				.mockResolvedValue()
+
+			await fireMigrationRequested('user-evt')
+
+			expect(migrateSpy).toHaveBeenCalledWith('user-evt')
+		})
+
+		it('does not double-migrate: a second pass with an empty queue re-asserts the receipt only', async () => {
+			mockGuest.follows = [makeFollow('a1')]
+			await sut.migrateGuestFollows('user-1')
+			expect(mockRpcClient.follow).toHaveBeenCalledTimes(1)
+
+			// Queue already drained → second pass issues no new Follow calls.
+			await sut.migrateGuestFollows('user-1')
+			expect(mockRpcClient.follow).toHaveBeenCalledTimes(1)
+			expect(lsMap.get(guestMergedReceiptKey('user-1'))).toBe('1')
+		})
+	})
+
+	describe('SignedOut → self-clear + cache eviction', () => {
+		it('clears the guest follow queue and evicts the projection cache via the delegate', () => {
+			mockGuest.follows = [makeFollow('a1')]
+			mockDelegate.followedArtists = [makeArtist('a1', 'Artist a1')]
+
+			const handler = subscriptions.get(SignedOut)
+			handler?.(new SignedOut())
+
+			expect(mockGuest.clearFollows).toHaveBeenCalledOnce()
+			// Eviction routes through the delegate's own clear(), not a direct
+			// cross-object field write.
+			expect(mockDelegate.clear).toHaveBeenCalledOnce()
+			expect(mockDelegate.followedArtists).toEqual([])
+		})
+
+		it('clears the guest-merge receipts so a fresh post-sign-out guest session can migrate again', () => {
+			// Two accounts previously migrated in this browser.
+			lsMap.set(guestMergedReceiptKey('user-1'), '1')
+			lsMap.set(guestMergedReceiptKey('user-2'), '1')
+
+			const handler = subscriptions.get(SignedOut)
+			handler?.(new SignedOut())
+
+			expect(mockStorage.removeByPrefix).toHaveBeenCalledOnce()
+			expect(sut.hasReceipt('user-1')).toBe(false)
+			expect(sut.hasReceipt('user-2')).toBe(false)
+		})
+
+		it('clear() is idempotent and routes eviction through the delegate', () => {
+			sut.clear()
+			sut.clear()
+			expect(mockGuest.clearFollows).toHaveBeenCalledTimes(2)
+			expect(mockDelegate.clear).toHaveBeenCalledTimes(2)
+			expect(mockDelegate.followedArtists).toEqual([])
+		})
+	})
+
+	describe('hasReceipt', () => {
+		it('reflects the persisted per-account receipt key', () => {
+			expect(sut.hasReceipt('user-1')).toBe(false)
+			lsMap.set(guestMergedReceiptKey('user-1'), '1')
+			expect(sut.hasReceipt('user-1')).toBe(true)
+		})
+	})
+})

--- a/src/services/follow-store.ts
+++ b/src/services/follow-store.ts
@@ -1,0 +1,268 @@
+import { DI, IEventAggregator, ILogger, resolve } from 'aurelia'
+import { IFollowRpcClient } from '../adapter/rpc/client/follow-client'
+import { ILocalStorage } from '../adapter/storage/local-storage'
+import {
+	GUEST_MERGED_RECEIPT_PREFIX,
+	guestMergedReceiptKey,
+} from '../constants/storage-keys'
+import type { Artist } from '../entities/artist'
+import {
+	DEFAULT_HYPE,
+	type FollowedArtist,
+	type Hype,
+} from '../entities/follow'
+import { GuestMigrationRequested } from './events/guest-migration-requested'
+import { SignedOut } from './events/signed-out'
+import { IFollowServiceClient } from './follow-service-client'
+import { IGuestService } from './guest-service'
+
+export const IFollowStore = DI.createInterface<IFollowStore>(
+	'IFollowStore',
+	(x) => x.singleton(FollowStore),
+)
+
+export interface IFollowStore extends FollowStore {}
+
+/**
+ * Observable owner of the follow set + hype, resolving guest (localStorage) vs
+ * authenticated (backend) sources INTERNALLY so callers never branch on
+ * `auth.isAuthenticated`.
+ *
+ * Phase 2 of the entity-store layer. It COMPOSES the existing
+ * `IFollowServiceClient` (which still owns the optimistic follow/unfollow/
+ * setHype facade + its `followedArtists` projection cache and the guest-vs-
+ * authed branching) as a thin delegate — fully absorbing it is deferred to a
+ * later phase to keep this change focused and low-risk. On top of that delegate
+ * FollowStore adds the auth-boundary responsibilities that used to live in
+ * `GuestDataMergeService`:
+ *
+ *   - `GuestMigrationRequested` → migrate the guest follow queue + hype to the
+ *     backend with idempotent calls, draining each artist from the guest queue once it FULLY
+ *     migrates (Follow + any non-default SetHype → only not-fully-migrated items
+ *     survive) in a single batched localStorage write, then write the
+ *     per-account guest-merge receipt.
+ *   - `SignedOut` → clear the guest follow state AND evict the followed-artist
+ *     projection cache so a next visitor on a shared browser sees nothing.
+ *
+ * `migrateGuestFollows` is also reused by the boot-reconcile task to heal a
+ * crash/network partial migration on the next authenticated start.
+ */
+export class FollowStore {
+	private readonly logger = resolve(ILogger).scopeTo('FollowStore')
+	private readonly delegate = resolve(IFollowServiceClient)
+	private readonly guest = resolve(IGuestService)
+	private readonly rpcClient = resolve(IFollowRpcClient)
+	private readonly storage = resolve(ILocalStorage)
+	private readonly ea = resolve(IEventAggregator)
+
+	constructor() {
+		// GuestMigrationRequested fires on every successful authenticated callback
+		// (sign-up AND returning sign-in) after the user id exists. Migration is
+		// best-effort background work: a failure must not surface to the publisher
+		// (auth-callback navigation), so swallow + log here. The receipt guard +
+		// empty-queue no-op inside migrateGuestFollows make a redundant fire safe.
+		this.ea.subscribe(
+			GuestMigrationRequested,
+			(event: GuestMigrationRequested) => {
+				void this.migrateGuestFollows(event.userId).catch((err) => {
+					this.logger.error('Guest follow migration failed', { error: err })
+				})
+			},
+		)
+
+		// SignedOut fires before the OIDC sign-out redirect. Self-clear is
+		// synchronous and idempotent. Also drop the guest-merge receipts so a
+		// fresh post-sign-out guest session can migrate NEW follows again — the
+		// receipt's lifetime is one authenticated session, not forever.
+		this.ea.subscribe(SignedOut, () => {
+			this.clear()
+			this.clearReceipts()
+		})
+	}
+
+	/** Observable follow projection — delegates to the composed facade. */
+	public get followedArtists(): Artist[] {
+		return this.delegate.followedArtists
+	}
+
+	public get followedIds(): ReadonlySet<string> {
+		return this.delegate.followedIds
+	}
+
+	public get followedCount(): number {
+		return this.delegate.followedCount
+	}
+
+	/**
+	 * Hydrate the observable follow projection from persisted guest follows
+	 * (onboarding page-load). Thin delegate.
+	 */
+	public hydrate(artists: Artist[]): void {
+		this.delegate.hydrate(artists)
+	}
+
+	/**
+	 * Follow an artist. Routes to guest storage or the backend RPC internally —
+	 * callers do not branch on auth state.
+	 */
+	public follow(artist: Artist): Promise<void> {
+		return this.delegate.follow(artist)
+	}
+
+	/** Unfollow an artist (guest or authed, resolved internally). */
+	public unfollow(artistId: string): Promise<void> {
+		return this.delegate.unfollow(artistId)
+	}
+
+	/** List followed artists (guest or authed, resolved internally). */
+	public listFollowed(signal?: AbortSignal): Promise<FollowedArtist[]> {
+		return this.delegate.listFollowed(signal)
+	}
+
+	/** Set the hype level for a followed artist. */
+	public setHype(artistId: string, hype: Hype): Promise<void> {
+		return this.delegate.setHype(artistId, hype)
+	}
+
+	/**
+	 * Build a lookup map of followed artists keyed by artist id (delegate).
+	 */
+	public getFollowedArtistMap(
+		signal?: AbortSignal,
+	): Promise<Map<string, { artist: Artist; hype: Hype }>> {
+		return this.delegate.getFollowedArtistMap(signal)
+	}
+
+	/**
+	 * Migrate the guest follow queue + non-default hype to the backend with
+	 * idempotent calls. An item counts as FULLY migrated — and is drained from
+	 * the queue — only when BOTH its `Follow` AND (when hype != DEFAULT) its
+	 * `SetHype` succeed. The leftover queue holds only items that did not fully
+	 * migrate, which a later reconcile retries without re-following already-merged
+	 * artists. On full success (every item fully migrated) writes the per-account
+	 * guest-merge receipt.
+	 *
+	 * Why SetHype gates the drain: once the receipt exists no later reconcile
+	 * re-issues SetHype, so draining an item whose Follow succeeded but whose
+	 * SetHype threw would lose a non-default hype forever. Keeping such an item in
+	 * the queue (and deferring the receipt) lets reconcile retry it; the backend
+	 * Follow is idempotent, so the retried Follow is a no-op and the SetHype runs
+	 * again.
+	 *
+	 * Best-effort: a single failed item is logged and does NOT abort the rest.
+	 * The drain is applied in a SINGLE localStorage write at the end (not per
+	 * item) to avoid an O(n^2) write storm on the post-signup hot path. Safe to
+	 * call multiple times for the same account (backend Follow/SetHype are
+	 * idempotent; the receipt makes the queue-level migration exactly-once).
+	 */
+	public async migrateGuestFollows(userId: string): Promise<void> {
+		// Snapshot the queue up-front; the drain is applied once at the end.
+		const queue = [...this.guest.follows]
+		if (queue.length === 0) {
+			// Nothing to migrate, but still record that this account has been
+			// reconciled so a later residual-queue reconcile clears without
+			// re-migrating.
+			this.writeReceipt(userId)
+			return
+		}
+
+		this.logger.info('Migrating guest follows', {
+			userId,
+			artistCount: queue.length,
+		})
+
+		// Ids of items that FULLY migrated (Follow + any required SetHype). Only
+		// these are drained; everything else is left for reconcile to retry.
+		const migratedIds: string[] = []
+		let allMigrated = true
+		for (const follow of queue) {
+			const { id, name } = follow.artist
+			try {
+				await this.rpcClient.follow(id)
+			} catch (err) {
+				allMigrated = false
+				this.logger.warn('Failed to follow artist during migration', {
+					id,
+					name,
+					error: err,
+				})
+				continue
+			}
+
+			// Merge non-default hype before counting the item as migrated. A
+			// SetHype failure means the item is NOT fully migrated: leave it in
+			// the queue (do not drain) and defer the receipt so reconcile retries
+			// it — otherwise the non-default hype would be lost forever once the
+			// receipt suppresses re-migration.
+			if (follow.hype !== DEFAULT_HYPE) {
+				try {
+					await this.rpcClient.setHype(id, follow.hype)
+				} catch (err) {
+					allMigrated = false
+					this.logger.warn('Failed to set hype during migration', {
+						artistId: id,
+						hype: follow.hype,
+						error: err,
+					})
+					continue
+				}
+			}
+
+			migratedIds.push(id)
+		}
+
+		// Single batched drain: remove only the fully-migrated items, one write.
+		this.guest.removeFollows(migratedIds)
+
+		// Write the receipt only when every item fully migrated — a residual queue
+		// means genuine failures remain, and the next reconcile should retry them
+		// (no receipt yet) rather than clear them away.
+		if (allMigrated) {
+			this.writeReceipt(userId)
+			this.logger.info('Guest follow migration completed', { userId })
+		} else {
+			this.logger.warn(
+				'Guest follow migration left failed items; receipt deferred to reconcile',
+				{ userId, remaining: this.guest.follows.length },
+			)
+		}
+	}
+
+	/**
+	 * Clear the guest follow state AND evict the followed-artist projection
+	 * cache. Idempotent and order-independent — safe to call on `SignedOut`
+	 * regardless of other stores' clear order. Preserves the privacy guarantee
+	 * of the old `GuestService.clearAll()` sign-out path: a next visitor on a
+	 * shared browser sees no follows.
+	 */
+	public clear(): void {
+		this.guest.clearFollows()
+		// Route the projection eviction through the delegate's own method so any
+		// cache invalidation tied to the @observable owner runs, rather than a
+		// cross-object write that bypasses it.
+		this.delegate.clear()
+		this.logger.info('Follow state cleared')
+	}
+
+	/** Whether the per-account guest-merge receipt exists. */
+	public hasReceipt(userId: string): boolean {
+		return this.storage.getItem(guestMergedReceiptKey(userId)) !== null
+	}
+
+	private writeReceipt(userId: string): void {
+		this.storage.setItem(guestMergedReceiptKey(userId), '1')
+	}
+
+	/**
+	 * Remove every per-account guest-merge receipt on sign-out. Cleared by prefix
+	 * because the signed-out user's id is already gone from in-memory + cached
+	 * state by the time `SignedOut` fires (the sign-out call sites run
+	 * `userService.clear()` first). This bounds the receipt's lifetime to a
+	 * single authenticated session: the within-session no-resurrection guarantee
+	 * stays intact (the receipt still blocks re-migrating reverted state WHILE
+	 * signed in), but a fresh guest session after sign-out can migrate again.
+	 */
+	private clearReceipts(): void {
+		this.storage.removeByPrefix(GUEST_MERGED_RECEIPT_PREFIX)
+	}
+}

--- a/src/services/guest-data-merge-service.spec.ts
+++ b/src/services/guest-data-merge-service.spec.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockLogger = {
+	scopeTo: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}
+
+const mockGuest = {
+	clearOnboardingExceptFollows: vi.fn(),
+	clearFollows: vi.fn(),
+	clearAll: vi.fn(),
+}
+
+const mockOnboarding = {
+	complete: vi.fn(),
+}
+
+vi.mock('aurelia', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('aurelia')>()
+	return {
+		...actual,
+		resolve: vi.fn((token: unknown) => {
+			const map: Record<string, unknown> = {
+				ILogger: mockLogger,
+				IGuestService: mockGuest,
+				IOnboardingService: mockOnboarding,
+			}
+			const tokenAny = token as { friendlyName?: string }
+			return map[tokenAny.friendlyName ?? ''] ?? {}
+		}),
+	}
+})
+
+import { GuestDataMergeService } from './guest-data-merge-service'
+
+describe('GuestDataMergeService (Phase 2 hand-over)', () => {
+	let sut: GuestDataMergeService
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		sut = new GuestDataMergeService()
+	})
+
+	it('completes onboarding on the sign-up hand-off', async () => {
+		await sut.merge()
+		expect(mockOnboarding.complete).toHaveBeenCalledOnce()
+	})
+
+	it('clears non-follow guest preferences (home/language/help-seen)', async () => {
+		await sut.merge()
+		expect(mockGuest.clearOnboardingExceptFollows).toHaveBeenCalledOnce()
+	})
+
+	it('does NOT clear the guest follow queue (FollowStore drains it per-item)', async () => {
+		await sut.merge()
+		expect(mockGuest.clearFollows).not.toHaveBeenCalled()
+		expect(mockGuest.clearAll).not.toHaveBeenCalled()
+	})
+})

--- a/src/services/guest-data-merge-service.ts
+++ b/src/services/guest-data-merge-service.ts
@@ -1,6 +1,4 @@
 import { DI, ILogger, resolve } from 'aurelia'
-import { IFollowRpcClient } from '../adapter/rpc/client/follow-client'
-import { DEFAULT_HYPE } from '../entities/follow'
 import { IGuestService } from './guest-service'
 import { IOnboardingService } from './onboarding-service'
 
@@ -13,59 +11,34 @@ export interface IGuestDataMergeService extends GuestDataMergeService {}
 
 export class GuestDataMergeService {
 	private readonly logger = resolve(ILogger).scopeTo('GuestDataMergeService')
-	private readonly rpcClient = resolve(IFollowRpcClient)
 	private readonly guest = resolve(IGuestService)
 	private readonly onboarding = resolve(IOnboardingService)
 
 	/**
-	 * Merge all guest data into the authenticated user's account.
-	 * Follows and hypes are best-effort: individual failures are logged but do not abort the merge.
-	 * After merge, onboardingStep is set to COMPLETED and guest data is cleared.
+	 * Complete the sign-up onboarding hand-off.
+	 *
+	 * Phase 2 hand-over: the follow + hype migration that used to live here is
+	 * now owned SOLELY by `FollowStore`, triggered by the
+	 * `GuestMigrationRequested` event that `AuthCallbackRoute` publishes on every
+	 * successful authenticated callback. This method
+	 * is reduced to its
+	 * remaining non-follow orchestration so migration happens exactly once via
+	 * a single path (the receipt + idempotent backend calls are only a safety
+	 * net). Deleting this service entirely (and the onboarding-completion
+	 * orchestration) is deferred to Phase 4.
+	 *
+	 * It MUST NOT clear the guest follow queue: FollowStore drains it per-item
+	 * in the background as each `Follow` succeeds, and wiping it here would
+	 * strand the in-flight migration. Home/language (UserStore's slice) ARE
+	 * cleared here to preserve the existing sign-up behavior until UserStore
+	 * absorbs `create()` in a later phase.
 	 */
 	public async merge(): Promise<void> {
-		const { follows } = this.guest
-		const hypeCount = follows.filter((f) => f.hype !== DEFAULT_HYPE).length
-		this.logger.info('Starting guest data merge', {
-			artistCount: follows.length,
-			hypeCount,
-		})
-
-		for (const follow of follows) {
-			const artistId = follow.artist.id
-			const artistName = follow.artist.name
-			try {
-				await this.rpcClient.follow(artistId)
-				this.logger.debug('Followed artist', {
-					id: artistId,
-					name: artistName,
-				})
-			} catch (err) {
-				this.logger.warn('Failed to follow artist during merge, continuing', {
-					id: artistId,
-					name: artistName,
-					error: err,
-				})
-			}
-		}
-
-		// Merge non-default hype levels (best-effort)
-		for (const follow of follows) {
-			if (follow.hype === DEFAULT_HYPE) continue
-			const artistId = follow.artist.id
-			try {
-				await this.rpcClient.setHype(artistId, follow.hype)
-				this.logger.debug('Hype merged', { artistId, hype: follow.hype })
-			} catch (err) {
-				this.logger.warn('Failed to set hype during merge, continuing', {
-					artistId,
-					hype: follow.hype,
-					error: err,
-				})
-			}
-		}
-
-		this.guest.clearAll()
+		this.logger.info('Completing guest onboarding hand-off')
+		// Clear only the home/language/help-seen guest preferences. Follows are
+		// intentionally retained for FollowStore's GuestMigrationRequested-driven drain.
+		this.guest.clearOnboardingExceptFollows()
 		this.onboarding.complete()
-		this.logger.info('Guest data merge completed')
+		this.logger.info('Guest onboarding hand-off completed')
 	}
 }

--- a/src/services/guest-service.ts
+++ b/src/services/guest-service.ts
@@ -114,6 +114,43 @@ export class GuestService {
 	}
 
 	/**
+	 * Remove a single followed artist from the guest queue, persisting the
+	 * shrunk list. Distinct from `unfollow()` only in intent/logging — both
+	 * splice + persist. FollowStore's migration drain uses the batched
+	 * `removeFollows` instead (single write); this single-item variant is kept
+	 * for callers that drain exactly one entry.
+	 */
+	public removeFollow(id: string): void {
+		const idx = this.follows.findIndex((f) => f.artist.id === id)
+		if (idx >= 0) {
+			this.follows.splice(idx, 1)
+			this.persistFollows()
+		}
+	}
+
+	/**
+	 * Remove a batch of followed artists from the guest queue in a SINGLE
+	 * localStorage write. Used by FollowStore's migration drain: per-item
+	 * `removeFollow` persisted once per artist, an O(n^2) byte cost (full
+	 * JSON.stringify + setItem per item) on the latency-sensitive post-signup
+	 * path. This drains in memory and persists once. Per-item correctness is
+	 * preserved: callers pass ONLY the ids that fully migrated, so failed items
+	 * remain in the queue for boot reconciliation to retry. No-op for ids absent
+	 * from the queue.
+	 */
+	public removeFollows(ids: readonly string[]): void {
+		if (ids.length === 0) return
+		const remove = new Set(ids)
+		const before = this.follows.length
+		// Mutate in place (filter into a fresh array, then splice-replace) so
+		// Aurelia's array observation still sees the change.
+		const remaining = this.follows.filter((f) => !remove.has(f.artist.id))
+		if (remaining.length === before) return
+		this.follows.splice(0, this.follows.length, ...remaining)
+		this.persistFollows()
+	}
+
+	/**
 	 * Clear all guest data.
 	 */
 	public clearAll(): void {
@@ -123,6 +160,32 @@ export class GuestService {
 		this.language = null
 		clearAllHelpSeen()
 		this.logger.info('Local data cleared')
+	}
+
+	/**
+	 * Clear only the guest follow set (queue + cleared persisted list). Used by
+	 * FollowStore's `SignedOut` self-clear: the follow store owns ONLY the
+	 * follow slice, so it must not wipe home/language (owned by UserStore) when
+	 * it clears. Idempotent — a no-op on an already-empty queue.
+	 */
+	public clearFollows(): void {
+		this.follows.splice(0)
+		this.persistFollows()
+	}
+
+	/**
+	 * Clear the guest onboarding preferences that are NOT follows: home,
+	 * anonymous-period language and per-page help-seen flags. Used on the
+	 * sign-up path so the home/language slice is cleared at user-create time
+	 * while the follow queue is left intact for FollowStore to drain
+	 * per-item on `GuestMigrationRequested` (clearing follows here would race the in-flight
+	 * background migration and strand them).
+	 */
+	public clearOnboardingExceptFollows(): void {
+		this.home = null
+		this.language = null
+		clearAllHelpSeen()
+		this.logger.info('Local onboarding preferences cleared (follows retained)')
 	}
 
 	/**

--- a/src/services/user-hydration-task.spec.ts
+++ b/src/services/user-hydration-task.spec.ts
@@ -51,6 +51,11 @@ const mockLocalStorage: ILocalStorage = {
 	removeItem: vi.fn((k: string) => {
 		lsMap.delete(k)
 	}),
+	removeByPrefix: vi.fn((prefix: string) => {
+		for (const k of [...lsMap.keys()]) {
+			if (k.startsWith(prefix)) lsMap.delete(k)
+		}
+	}),
 }
 
 vi.mock('aurelia', async (importOriginal) => {

--- a/src/services/user-service.ts
+++ b/src/services/user-service.ts
@@ -11,6 +11,26 @@ export const IUserService = DI.createInterface<IUserService>(
 	(x) => x.singleton(UserServiceClient),
 )
 
+/**
+ * Outcome of a provisioning call (`ensureLoaded` / `create`).
+ *
+ * `created` reports whether this call provisioned a GENUINELY NEW backend
+ * account, as opposed to resolving a pre-existing one. The backend `Create`
+ * RPC is idempotent — on a duplicate identity it returns the EXISTING user with
+ * a wire-identical response — so the new-vs-existing distinction is not on the
+ * response. The available frontend signal is the cache: a returning identity
+ * already has a cached `user_id` (it signed in before on this device, or its id
+ * was minted earlier this session), whereas a genuinely new account has none
+ * and reaches the Create path with an empty cache. Callers key new-account-only
+ * behavior (e.g. the post-signup dialog) on this flag rather than on the OIDC
+ * sign-up FLOW, so a returning user who taps "Sign up" is not treated as new.
+ */
+export interface ProvisionResult {
+	user: User | undefined
+	/** True only when this call minted a brand-new backend account. */
+	created: boolean
+}
+
 export interface IUserService {
 	readonly current: User | undefined
 	/**
@@ -21,6 +41,10 @@ export interface IUserService {
 	 * I18N inside the service) avoids coupling UserService to the i18n
 	 * subsystem.
 	 *
+	 * Returns a `ProvisionResult` so the auth-callback can tell a brand-new
+	 * account (cache-miss → Create) from a returning one (cache hit → Get)
+	 * without re-deriving the cache state itself.
+	 *
 	 * BREAKING (since persist-user-language): the `preferredLanguage`
 	 * parameter is required. Previously `ensureLoaded()` took no arguments.
 	 * Any external implementer of this interface (test doubles, manual
@@ -28,13 +52,13 @@ export interface IUserService {
 	 * typing will catch typed implementations, but loose `as` casts in
 	 * test fixtures could silently pass the wrong value.
 	 */
-	ensureLoaded(preferredLanguage: string): Promise<User | undefined>
+	ensureLoaded(preferredLanguage: string): Promise<ProvisionResult>
 	clear(): void
 	create(
 		email: string,
 		preferredLanguage: string,
 		home?: { countryCode: string; level1: string; level2?: string },
-	): Promise<User | undefined>
+	): Promise<ProvisionResult>
 	updateHome(home: {
 		countryCode: string
 		level1: string
@@ -91,8 +115,10 @@ export class UserServiceClient implements IUserService {
 	// runs so the app self-heals instead of locking the user out.
 	public async ensureLoaded(
 		preferredLanguage: string,
-	): Promise<User | undefined> {
-		if (this.current) return this.current
+	): Promise<ProvisionResult> {
+		// An in-memory or persisted user_id means this identity was already
+		// resolved before — never a brand-new account, so `created` is false.
+		if (this.current) return { user: this.current, created: false }
 
 		const userId = this.readCachedUserId()
 		if (userId) {
@@ -100,7 +126,7 @@ export class UserServiceClient implements IUserService {
 				this.logger.info('Loading user profile from backend (cache hit)')
 				this.current = await this.rpcClient.get(userId)
 				if (this.current) this.writeCachedUserId(this.current.id)
-				return this.current
+				return { user: this.current, created: false }
 			} catch (err) {
 				if (err instanceof ConnectError && err.code === Code.PermissionDenied) {
 					this.logger.warn(
@@ -120,16 +146,23 @@ export class UserServiceClient implements IUserService {
 			this.logger.warn(
 				'No cached user_id and no email in auth claims; cannot bootstrap user',
 			)
-			return undefined
+			return { user: undefined, created: false }
 		}
 
 		this.logger.info('Bootstrapping via idempotent Create (cache miss)')
 		// Create requires preferred_language; on the idempotent-return path the
 		// existing row's language is preserved, so passing the current effective
 		// locale is safe even for returning users.
+		//
+		// `created` is true here: we reached Create with no cached user_id, which
+		// is the new-account path (a returning identity would have hit the Get
+		// branch above). A cleared cache on an existing identity also lands here,
+		// but the cache is the only new-vs-existing signal the idempotent backend
+		// exposes, so this is the best available approximation and matches the
+		// post-signup-dialog contract (fresh-cache identity → treat as new).
 		this.current = await this.rpcClient.create(email, preferredLanguage)
 		if (this.current) this.writeCachedUserId(this.current.id)
-		return this.current
+		return { user: this.current, created: true }
 	}
 
 	public clear(): void {
@@ -142,11 +175,24 @@ export class UserServiceClient implements IUserService {
 		email: string,
 		preferredLanguage: string,
 		home?: { countryCode: string; level1: string; level2?: string },
-	): Promise<User | undefined> {
+	): Promise<ProvisionResult> {
+		// New-account signal: no user_id cached for this identity before the call.
+		// The backend Create is idempotent (a returning identity gets its existing
+		// row back, wire-identical), so the pre-call cache is the only available
+		// new-vs-existing signal — a returning user tapping "Sign up" already has a
+		// cached id and is therefore NOT treated as new.
+		const created = this.readCachedUserId() === undefined
 		const user = await this.rpcClient.create(email, preferredLanguage, home)
 		this.current = user
-		if (user) this.writeCachedUserId(user.id)
-		return user
+		if (user) {
+			this.writeCachedUserId(user.id)
+		}
+		// NOTE: the guest-follow migration trigger (GuestMigrationRequested) is
+		// published by AuthCallbackRoute on every successful authenticated
+		// callback, NOT here. create() is also reached on the idempotent cache-miss
+		// recovery, so keeping the publish at the auth-callback boundary keeps the
+		// trigger at a single site with the resolved userId.
+		return { user, created }
 	}
 
 	public async updateHome(home: {

--- a/test/auth-service.spec.ts
+++ b/test/auth-service.spec.ts
@@ -103,10 +103,17 @@ describe('AuthService', () => {
 		expect(userManagerMock.signoutRedirect).toHaveBeenCalled()
 	})
 
-	it('handleCallback calls signinCallback and updates state', async () => {
-		await sut.handleCallback()
+	it('handleCallback calls signinCallback, updates state, and returns the user', async () => {
+		const result = await sut.handleCallback()
 		expect(userManagerMock.signinCallback).toHaveBeenCalled()
 		expect(sut.isAuthenticated).toBe(true)
 		expect(sut.user?.profile.preferred_username).toBe('test-user')
+		expect(result.profile.preferred_username).toBe('test-user')
+	})
+
+	it('handleCallback throws when signinCallback returns no user', async () => {
+		userManagerMock.signinCallback.mockResolvedValue(null)
+
+		await expect(sut.handleCallback()).rejects.toThrow(/no user/)
 	})
 })

--- a/test/routes/auth-callback-route.spec.ts
+++ b/test/routes/auth-callback-route.spec.ts
@@ -1,9 +1,10 @@
 import { I18N } from '@aurelia/i18n'
 import type { RouteNode } from '@aurelia/router'
-import { Registration } from 'aurelia'
+import { IEventAggregator, Registration } from 'aurelia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { AuthCallbackRoute } from '../../src/routes/auth-callback/auth-callback-route'
 import { IAuthService } from '../../src/services/auth-service'
+import { GuestMigrationRequested } from '../../src/services/events/guest-migration-requested'
 import { IGuestDataMergeService } from '../../src/services/guest-data-merge-service'
 import { IGuestService } from '../../src/services/guest-service'
 import { IUserService } from '../../src/services/user-service'
@@ -11,17 +12,28 @@ import { createTestContainer } from '../helpers/create-container'
 import { createMockAuth } from '../helpers/mock-auth'
 import type { createMockI18n } from '../helpers/mock-i18n'
 
+/**
+ * Build the handleCallback result: the OIDC User. handleCallback no longer
+ * round-trips a sign-up flag — the callback keys behavior on the backend
+ * new-account signal (ProvisionResult.created), not the sign-up FLOW.
+ */
+function authUser(email: string | undefined): { profile: { email?: string } } {
+	return { profile: email ? { email } : {} }
+}
+
 function createMockUserService() {
 	const stub = { id: 'u1', externalId: 'ext', email: 'u@test.com', name: 'U' }
 	// Mirrors UserServiceClient's public @observable `current` field shape.
 	// Tests assign to `current` directly to simulate the post-RPC entity
-	// state the production service write-throughs would produce.
+	// state the production service write-throughs would produce. create /
+	// ensureLoaded resolve a ProvisionResult { user, created }; per-test
+	// overrides set `created` to drive the post-signup-dialog assertions.
 	const svc = {
 		current: stub as unknown as
 			| import('../../src/entities/user').User
 			| undefined,
-		create: vi.fn().mockResolvedValue(stub),
-		ensureLoaded: vi.fn().mockResolvedValue(stub),
+		create: vi.fn().mockResolvedValue({ user: stub, created: true }),
+		ensureLoaded: vi.fn().mockResolvedValue({ user: stub, created: false }),
 	}
 	return svc
 }
@@ -51,6 +63,10 @@ describe('AuthCallbackRoute', () => {
 	let mockUserService: ReturnType<typeof createMockUserService>
 	let mockMergeService: ReturnType<typeof createMockMergeService>
 	let mockI18n: ReturnType<typeof createMockI18n>
+	let mockEa: {
+		publish: ReturnType<typeof vi.fn>
+		subscribe: ReturnType<typeof vi.fn>
+	}
 
 	function setup(guestHome: string | null = null) {
 		const container = createTestContainer(
@@ -61,6 +77,10 @@ describe('AuthCallbackRoute', () => {
 				mockMergeService as IGuestDataMergeService,
 			),
 			Registration.instance(IGuestService, createMockGuestService(guestHome)),
+			Registration.instance(
+				IEventAggregator,
+				mockEa as unknown as IEventAggregator,
+			),
 		)
 		container.register(AuthCallbackRoute)
 		sut = container.get(AuthCallbackRoute)
@@ -77,14 +97,15 @@ describe('AuthCallbackRoute', () => {
 		})
 		mockUserService = createMockUserService()
 		mockMergeService = createMockMergeService()
+		mockEa = { publish: vi.fn(), subscribe: vi.fn() }
 		setup()
 	})
 
 	describe('canLoad', () => {
 		it('redirects to dashboard for returning user (cache hit → ensureLoaded resolves a user, Create not called)', async () => {
-			mockAuth.handleCallback = vi.fn().mockResolvedValue({
-				profile: { email: 'existing@example.com' },
-			})
+			mockAuth.handleCallback = vi
+				.fn()
+				.mockResolvedValue(authUser('existing@example.com'))
 
 			const result = await sut.canLoad({}, {} as RouteNode)
 
@@ -101,13 +122,15 @@ describe('AuthCallbackRoute', () => {
 		})
 
 		it('delegates cache-miss recovery to UserService.ensureLoaded — Create is NOT called from auth-callback when there is no guest home', async () => {
-			mockAuth.handleCallback = vi.fn().mockResolvedValue({
-				profile: { email: 'new@example.com' },
-			})
+			mockAuth.handleCallback = vi
+				.fn()
+				.mockResolvedValue(authUser('new@example.com'))
 			// ensureLoaded internally handles cache hit/miss (calls Get or Create
 			// depending on cache state). Auth-callback only invokes Create
 			// explicitly when there is a guestHome to persist atomically.
-			mockUserService.ensureLoaded = vi.fn().mockResolvedValue(undefined)
+			mockUserService.ensureLoaded = vi
+				.fn()
+				.mockResolvedValue({ user: undefined, created: false })
 
 			const result = await sut.canLoad({}, {} as RouteNode)
 
@@ -117,11 +140,15 @@ describe('AuthCallbackRoute', () => {
 			expect(result).toBe('/dashboard')
 		})
 
-		it('explicitly calls Create with home when guest selected one — sets postSignupShown flag', async () => {
-			mockAuth.handleCallback = vi.fn().mockResolvedValue({
-				profile: { email: 'new@example.com' },
-			})
+		it('explicitly calls Create with home when guest selected one — created=true sets postSignupShown flag', async () => {
+			mockAuth.handleCallback = vi
+				.fn()
+				.mockResolvedValue(authUser('new@example.com'))
 			setup('JP-13')
+			// Genuinely new account: Create minted a fresh row.
+			mockUserService.create = vi
+				.fn()
+				.mockResolvedValue({ user: mockUserService.current, created: true })
 
 			localStorage.removeItem('liverty:postSignup:shown')
 			const result = await sut.canLoad({}, {} as RouteNode)
@@ -141,17 +168,55 @@ describe('AuthCallbackRoute', () => {
 			expect(localStorage.getItem('liverty:postSignup:shown')).toBe('pending')
 		})
 
-		it('does NOT set postSignupShown when guest home is absent — relies on ensureLoaded only', async () => {
-			mockAuth.handleCallback = vi.fn().mockResolvedValue({
-				profile: { email: 'returning@example.com' },
-			})
+		it('a NEW no-home account still migrates and shows postSignup (migration fires regardless of home; created=true)', async () => {
+			// New account where the visitor skipped home selection: guestHome is
+			// null so provisioning goes through ensureLoaded (not Create), which
+			// reports created=true (cache-miss Create path). The migration trigger
+			// and the postSignup flag MUST still fire.
+			mockAuth.handleCallback = vi
+				.fn()
+				.mockResolvedValue(authUser('new@example.com'))
 			setup(null)
+			mockUserService.ensureLoaded = vi
+				.fn()
+				.mockResolvedValue({ user: mockUserService.current, created: true })
 
 			localStorage.removeItem('liverty:postSignup:shown')
 			const result = await sut.canLoad({}, {} as RouteNode)
 
 			expect(mockUserService.ensureLoaded).toHaveBeenCalled()
 			expect(mockUserService.create).not.toHaveBeenCalled()
+			// Migration published with the provisioned user id → migration runs.
+			expect(mockEa.publish).toHaveBeenCalledWith(
+				new GuestMigrationRequested('u1'),
+			)
+			expect(localStorage.getItem('liverty:postSignup:shown')).toBe('pending')
+			expect(result).toBe('/dashboard')
+		})
+
+		it('a RETURNING sign-in DOES migrate (guest follows heal in-session) but does NOT set postSignup', async () => {
+			// created=false → no postSignup flag, even though ensureLoaded hydrates
+			// a user. Migration STILL fires: a returning user who browsed
+			// anonymously and signed in must not lose their guest follows in-session
+			// (FollowStore is receipt-guarded + idempotent, so this is safe).
+			mockAuth.handleCallback = vi
+				.fn()
+				.mockResolvedValue(authUser('returning@example.com'))
+			setup(null)
+			mockUserService.ensureLoaded = vi
+				.fn()
+				.mockResolvedValue({ user: mockUserService.current, created: false })
+
+			localStorage.removeItem('liverty:postSignup:shown')
+			const result = await sut.canLoad({}, {} as RouteNode)
+
+			expect(mockUserService.ensureLoaded).toHaveBeenCalled()
+			expect(mockUserService.create).not.toHaveBeenCalled()
+			// Migration fires on sign-in too (Correction 1).
+			expect(mockEa.publish).toHaveBeenCalledWith(
+				new GuestMigrationRequested('u1'),
+			)
+			// But no new-account dialog (Correction 2).
 			expect(result).toBe('/dashboard')
 			expect(localStorage.getItem('liverty:postSignup:shown')).toBeNull()
 		})
@@ -181,11 +246,11 @@ describe('AuthCallbackRoute', () => {
 		})
 
 		it('does not invoke explicit Create when email is missing even with guest home', async () => {
-			mockAuth.handleCallback = vi.fn().mockResolvedValue({
-				profile: {},
-			})
+			mockAuth.handleCallback = vi.fn().mockResolvedValue(authUser(undefined))
 			setup('JP-13')
-			mockUserService.ensureLoaded = vi.fn().mockResolvedValue(undefined)
+			mockUserService.ensureLoaded = vi
+				.fn()
+				.mockResolvedValue({ user: undefined, created: false })
 
 			const result = await sut.canLoad({}, {} as RouteNode)
 
@@ -195,9 +260,9 @@ describe('AuthCallbackRoute', () => {
 		})
 
 		it('surfaces ensureLoaded errors as a login failure', async () => {
-			mockAuth.handleCallback = vi.fn().mockResolvedValue({
-				profile: { email: 'new@example.com' },
-			})
+			mockAuth.handleCallback = vi
+				.fn()
+				.mockResolvedValue(authUser('new@example.com'))
 			mockUserService.ensureLoaded = vi
 				.fn()
 				.mockRejectedValue(new Error('server error'))
@@ -209,9 +274,9 @@ describe('AuthCallbackRoute', () => {
 		})
 
 		it('delegates onboarding completion to merge service (not call complete directly)', async () => {
-			mockAuth.handleCallback = vi.fn().mockResolvedValue({
-				profile: { email: 'user@example.com' },
-			})
+			mockAuth.handleCallback = vi
+				.fn()
+				.mockResolvedValue(authUser('user@example.com'))
 
 			const result = await sut.canLoad({}, {} as RouteNode)
 
@@ -229,9 +294,9 @@ describe('AuthCallbackRoute', () => {
 		// until a hard reload, with no signal from the test suite.
 		describe('applies backend preferredLanguage to i18n after sign-in', () => {
 			it('calls setLocale when preferredLanguage differs from current locale', async () => {
-				mockAuth.handleCallback = vi.fn().mockResolvedValue({
-					profile: { email: 'returning@example.com' },
-				})
+				mockAuth.handleCallback = vi
+					.fn()
+					.mockResolvedValue(authUser('returning@example.com'))
 				// Default mock i18n locale is 'ja'; ensureLoaded resolves a
 				// user whose stored language is 'en' — the guard
 				// ('en' !== 'ja') should fire setLocale('en').
@@ -240,7 +305,7 @@ describe('AuthCallbackRoute', () => {
 						id: 'u1',
 						preferredLanguage: 'en',
 					} as unknown as import('../../src/entities/user').User
-					return mockUserService.current
+					return { user: mockUserService.current, created: false }
 				})
 
 				const result = await sut.canLoad({}, {} as RouteNode)
@@ -250,9 +315,9 @@ describe('AuthCallbackRoute', () => {
 			})
 
 			it('does NOT call setLocale when preferredLanguage matches the current locale', async () => {
-				mockAuth.handleCallback = vi.fn().mockResolvedValue({
-					profile: { email: 'returning@example.com' },
-				})
+				mockAuth.handleCallback = vi
+					.fn()
+					.mockResolvedValue(authUser('returning@example.com'))
 				// preferredLanguage matches the mock locale 'ja' — guard
 				// short-circuits and setLocale stays untouched.
 				mockUserService.ensureLoaded = vi.fn().mockImplementation(async () => {
@@ -260,7 +325,7 @@ describe('AuthCallbackRoute', () => {
 						id: 'u1',
 						preferredLanguage: 'ja',
 					} as unknown as import('../../src/entities/user').User
-					return mockUserService.current
+					return { user: mockUserService.current, created: false }
 				})
 
 				const result = await sut.canLoad({}, {} as RouteNode)
@@ -270,9 +335,9 @@ describe('AuthCallbackRoute', () => {
 			})
 
 			it('does NOT call setLocale when preferredLanguage is unsupported', async () => {
-				mockAuth.handleCallback = vi.fn().mockResolvedValue({
-					profile: { email: 'returning@example.com' },
-				})
+				mockAuth.handleCallback = vi
+					.fn()
+					.mockResolvedValue(authUser('returning@example.com'))
 				// A future migration or loosened backend validation could
 				// leak an unsupported code into the DB. We skip the
 				// setLocale call (i18next would silently fall back to
@@ -283,7 +348,7 @@ describe('AuthCallbackRoute', () => {
 						id: 'u1',
 						preferredLanguage: 'fr',
 					} as unknown as import('../../src/entities/user').User
-					return mockUserService.current
+					return { user: mockUserService.current, created: false }
 				})
 
 				const result = await sut.canLoad({}, {} as RouteNode)

--- a/test/services/user-service.spec.ts
+++ b/test/services/user-service.spec.ts
@@ -87,7 +87,7 @@ describe('UserServiceClient', () => {
 	})
 
 	describe('ensureLoaded', () => {
-		it('falls back to idempotent Create when no user_id is cached', async () => {
+		it('falls back to idempotent Create when no user_id is cached and reports created=true', async () => {
 			rpc.create.mockResolvedValue(stubUser)
 			const svc = build({ storage, rpc })
 
@@ -95,11 +95,13 @@ describe('UserServiceClient', () => {
 
 			expect(rpc.get).not.toHaveBeenCalled()
 			expect(rpc.create).toHaveBeenCalledWith(userEmail, 'ja')
-			expect(result).toBe(stubUser)
+			expect(result.user).toBe(stubUser)
+			// No cached user_id → reached Create on the new-account path.
+			expect(result.created).toBe(true)
 			expect(storage.impl.setItem).toHaveBeenCalledWith(cacheKey, internalID)
 		})
 
-		it('returns undefined when no cache AND no email in JWT claims', async () => {
+		it('returns undefined user (created=false) when no cache AND no email in JWT claims', async () => {
 			const svc = build({
 				storage,
 				rpc,
@@ -108,12 +110,13 @@ describe('UserServiceClient', () => {
 
 			const result = await svc.ensureLoaded('ja')
 
-			expect(result).toBeUndefined()
+			expect(result.user).toBeUndefined()
+			expect(result.created).toBe(false)
 			expect(rpc.get).not.toHaveBeenCalled()
 			expect(rpc.create).not.toHaveBeenCalled()
 		})
 
-		it('calls Get with cached user_id and writes the result back to cache', async () => {
+		it('calls Get with cached user_id, writes back to cache, and reports created=false', async () => {
 			storage.map.set(cacheKey, internalID)
 			rpc.get.mockResolvedValue(stubUser)
 			const svc = build({ storage, rpc })
@@ -122,11 +125,13 @@ describe('UserServiceClient', () => {
 
 			expect(rpc.get).toHaveBeenCalledWith(internalID)
 			expect(rpc.create).not.toHaveBeenCalled()
-			expect(result).toBe(stubUser)
+			expect(result.user).toBe(stubUser)
+			// Cache hit → returning account, not new.
+			expect(result.created).toBe(false)
 			expect(storage.impl.setItem).toHaveBeenCalledWith(cacheKey, internalID)
 		})
 
-		it('returns the in-memory cached user without re-issuing Get on subsequent calls', async () => {
+		it('returns the in-memory cached user (created=false) without re-issuing Get on subsequent calls', async () => {
 			storage.map.set(cacheKey, internalID)
 			rpc.get.mockResolvedValue(stubUser)
 			const svc = build({ storage, rpc })
@@ -135,7 +140,8 @@ describe('UserServiceClient', () => {
 			const second = await svc.ensureLoaded('ja')
 
 			expect(rpc.get).toHaveBeenCalledTimes(1)
-			expect(second).toBe(stubUser)
+			expect(second.user).toBe(stubUser)
+			expect(second.created).toBe(false)
 		})
 
 		it('self-heals when cached user_id is rejected with PermissionDenied — clears cache and recovers via Create', async () => {
@@ -151,7 +157,7 @@ describe('UserServiceClient', () => {
 			expect(rpc.get).toHaveBeenCalledWith('stale-uuid')
 			expect(storage.impl.removeItem).toHaveBeenCalledWith(cacheKey)
 			expect(rpc.create).toHaveBeenCalledWith(userEmail, 'ja')
-			expect(result).toBe(stubUser)
+			expect(result.user).toBe(stubUser)
 			// New userId should be cached after Create succeeds
 			expect(storage.impl.setItem).toHaveBeenCalledWith(cacheKey, internalID)
 		})
@@ -168,15 +174,30 @@ describe('UserServiceClient', () => {
 	})
 
 	describe('create', () => {
-		it('writes the returned user_id to localStorage on success', async () => {
+		it('writes the returned user_id to localStorage and reports created=true for a fresh-cache identity', async () => {
 			rpc.create.mockResolvedValue(stubUser)
 			const svc = build({ storage, rpc })
 
 			const result = await svc.create('u@test.com', 'ja')
 
-			expect(result).toBe(stubUser)
+			expect(result.user).toBe(stubUser)
+			// No cached user_id before the call → genuinely new account.
+			expect(result.created).toBe(true)
 			expect(rpc.create).toHaveBeenCalledWith('u@test.com', 'ja', undefined)
 			expect(storage.impl.setItem).toHaveBeenCalledWith(cacheKey, internalID)
+		})
+
+		it('reports created=false when a user_id is already cached (returning identity tapping Sign up)', async () => {
+			// A returning user already has a cached user_id; the idempotent backend
+			// returns their existing row, so this is NOT a new account.
+			storage.map.set(cacheKey, internalID)
+			rpc.create.mockResolvedValue(stubUser)
+			const svc = build({ storage, rpc })
+
+			const result = await svc.create('u@test.com', 'ja')
+
+			expect(result.user).toBe(stubUser)
+			expect(result.created).toBe(false)
 		})
 	})
 


### PR DESCRIPTION
## Description

**Phase 2 of the entity-store-layer refactor** (OpenSpec `introduce-entity-store-layer`). Introduces `FollowStore` and moves guest-follow migration to an event-driven, store-owned flow with a boot-time reconciliation safety net.

`FollowStore` is the observable owner of the follow set + hype (composing the existing `FollowServiceClient`). Guest follow migration moves out of `GuestDataMergeService` into `FollowStore`, triggered by a `GuestMigrationRequested` event published by the auth callback on **every successful authentication** — so a guest who accumulates follows and then either signs up *or* signs in has them migrated (idempotent, receipt-guarded).

Frontend-only (TS); no backend/proto/DB changes.

## Type of Change

- [x] feat: store-layer Phase 2
- [x] refactor: event-driven guest migration + boot reconciliation

## Changes

- **`FollowStore`**: observable follow set; migrates guest follows/hype on `GuestMigrationRequested`, draining `guest.followedArtists` per-item only when both `Follow` and `SetHype` succeed (single batched persist), then writes a per-account guest-merge receipt. Empty queue is a no-op; receipt + backend idempotency prevent double-migration.
- **`SignedOut`** (published by `AuthService.signOut`): `FollowStore` self-clears, evicts its delegate cache, and clears guest-merge receipts — preserving the privacy guarantee of the old `clearAll()` sign-out path.
- **`FollowReconcileTask`** (boot AppTask): self-hydrates via `ensureLoaded` (no AppTask-ordering dependency); receipt-keyed — no receipt + leftover queue → migrate; receipt present + residual queue → clear without re-migrating (deterministic, no resurrection).
- Post-signup dialog is keyed on a genuinely-new account (backend `Create` minted a new row), not the sign-up *flow*.
- `GuestDataMergeService` retains only home/language/help cleanup + onboarding completion (follow migration handed to `FollowStore`); its deletion and the remaining `IFollowServiceClient` consumer migration are deferred to Phase 4.

## Verification

### Automated Tests
- [x] `npm run lint` passed (0 errors)
- [x] `npm run test` passed (1193 tests; new follow-store / reconcile / auth-callback / auth-service specs cover sign-up + sign-in migration, per-item drain with hype gating, receipt clear on sign-out, reconcile self-hydration, batched persist)
- [x] `npm run build` passes

### Manual Verification
Covered by tests; in-browser smoke pending (dev env stopped). This PR was additionally reviewed via multi-agent `/code-review` (two rounds) before push, which surfaced and fixed real correctness bugs (in-session migration loss, AppTask race, receipt edge cases, hype loss).

## Out of scope (later phases)
- Cache-only `ConcertStore`/`ArtistStore` (Phase 3)
- Remaining consumer migration + `GuestService`/`GuestDataMergeService` removal + welcome-route mirror removal (Phase 4)

## Checklist
- [x] Follows project style; self-reviewed; commented; docs (OpenSpec) updated; no new warnings

Refs: #368
