### PR TITLE
refactor(stores): rename Concert/Artist services to ConcertStore/ArtistStore (store-layer Phase 3)

### DIFF
--- a/src/lib/analytics/analytics-service.spec.ts
+++ b/src/lib/analytics/analytics-service.spec.ts
@@ -60,7 +60,7 @@ vi.mock('@opentelemetry/api', async (importOriginal) => {
 
 // ── Aurelia DI mock ────────────────────────────────────────────────────────
 //
-// Same `friendlyName`-keyed resolver stub the existing `concert-service`
+// Same `friendlyName`-keyed resolver stub the existing `concert-store`
 // spec uses. `config` and `consent` are mutated per-test via the
 // references captured below, so the SUT sees the runtime values selected
 // by the test without re-instantiating the mock map.

--- a/src/lib/consent/consent-service.spec.ts
+++ b/src/lib/consent/consent-service.spec.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
 //
-// Same pattern as `services/concert-service.spec.ts`: replace the
+// Same pattern as `services/concert-store.spec.ts`: replace the
 // `aurelia` `resolve()` export with a stub that maps DI tokens to mock
 // instances by the token's `friendlyName`. ConsentService resolves both
 // `ILogger` and `IEventAggregator`; the latter is the mutation publish

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,10 +59,10 @@ import { IAnalyticsService } from './lib/analytics/analytics-service'
 import { IConsentService } from './lib/consent/consent-service'
 import en from './locales/en/translation.json'
 import ja from './locales/ja/translation.json'
-import { IArtistServiceClient } from './services/artist-service-client'
+import { IArtistStore } from './services/artist-store'
 import { IAudioEngine } from './services/audio-engine'
 import { IAuthService } from './services/auth-service'
-import { IConcertService } from './services/concert-service'
+import { IConcertStore } from './services/concert-store'
 import { IErrorBoundaryService } from './services/error-boundary-service'
 import { FollowReconcileTask } from './services/follow-reconcile-task'
 import { IFollowServiceClient } from './services/follow-service-client'
@@ -190,9 +190,9 @@ async function bootstrap(): Promise<void> {
 	au.register(IConsentService)
 	au.register(IAnalyticsService)
 	au.register(UserHydrationTask)
-	au.register(IArtistServiceClient)
+	au.register(IArtistStore)
 	au.register(IFollowServiceClient)
-	au.register(IConcertService)
+	au.register(IConcertStore)
 	au.register(IOnboardingService)
 	au.register(IGuestService)
 	// UserStore composes IUserService + IGuestService into a single observable

--- a/src/routes/dashboard/dashboard-route.spec.ts
+++ b/src/routes/dashboard/dashboard-route.spec.ts
@@ -41,7 +41,7 @@ vi.mock('aurelia', async (importOriginal) => {
 				IHistory: mockHistory,
 				ILogger: mockLogger,
 				IAuthService: mockAuth,
-				IConcertService: mockConcertService,
+				IConcertStore: mockConcertService,
 				IFollowServiceClient: mockFollowService,
 				ITicketJourneyService: mockJourneyService,
 				IOnboardingService: mockOnboarding,

--- a/src/routes/dashboard/dashboard-route.ts
+++ b/src/routes/dashboard/dashboard-route.ts
@@ -13,7 +13,7 @@ import { StorageKeys } from '../../constants/storage-keys'
 import type { Artist } from '../../entities/artist'
 import type { JourneyStatus } from '../../entities/concert'
 import { IAuthService } from '../../services/auth-service'
-import { IConcertService } from '../../services/concert-service'
+import { IConcertStore } from '../../services/concert-store'
 import { IFollowServiceClient } from '../../services/follow-service-client'
 import { IGuestService } from '../../services/guest-service'
 import {
@@ -45,7 +45,7 @@ export class DashboardRoute {
 	private readonly logger = resolve(ILogger).scopeTo('DashboardRoute')
 	public readonly i18n = resolve(I18N)
 	private readonly authService = resolve(IAuthService)
-	private readonly concertService = resolve(IConcertService)
+	private readonly concertService = resolve(IConcertStore)
 	private readonly followService = resolve(IFollowServiceClient)
 	private readonly journeyService = resolve(ITicketJourneyService)
 	private readonly onboarding = resolve(IOnboardingService)

--- a/src/routes/discovery/discovery-route.ts
+++ b/src/routes/discovery/discovery-route.ts
@@ -8,8 +8,8 @@ import {
 	Events,
 	IAnalyticsService,
 } from '../../lib/analytics/analytics-service'
-import { IArtistServiceClient } from '../../services/artist-service-client'
-import { IConcertService } from '../../services/concert-service'
+import { IArtistStore } from '../../services/artist-store'
+import { IConcertStore } from '../../services/concert-store'
 import { IFollowServiceClient } from '../../services/follow-service-client'
 import { IGuestService } from '../../services/guest-service'
 import {
@@ -24,13 +24,13 @@ import { GenreFilterController } from './genre-filter-controller'
 import { SearchController } from './search-controller'
 
 export class DiscoveryRoute {
-	private readonly artistClient = resolve(IArtistServiceClient)
+	private readonly artistClient = resolve(IArtistStore)
 	private readonly followService = resolve(IFollowServiceClient)
 	private readonly onboarding = resolve(IOnboardingService)
 	private readonly router = resolve(IRouter)
 	private readonly ea = resolve(IEventAggregator)
 	private readonly guest = resolve(IGuestService)
-	private readonly concertService = resolve(IConcertService)
+	private readonly concertService = resolve(IConcertStore)
 	private readonly analytics = resolve(IAnalyticsService)
 	private readonly logger = resolve(ILogger).scopeTo('DiscoveryRoute')
 	public readonly i18n = resolve(I18N)

--- a/src/routes/import-ticket-email/import-ticket-email-route.ts
+++ b/src/routes/import-ticket-email/import-ticket-email-route.ts
@@ -4,7 +4,7 @@ import type { TicketEmail } from '@buf/liverty-music_schema.bufbuild_es/liverty_
 import { TicketJourneyStatus } from '@buf/liverty-music_schema.bufbuild_es/liverty_music/entity/v1/ticket_journey_pb.js'
 import { ILogger, resolve } from 'aurelia'
 import type { FollowedArtist } from '../../entities/follow'
-import { IConcertService } from '../../services/concert-service'
+import { IConcertStore } from '../../services/concert-store'
 import { IFollowServiceClient } from '../../services/follow-service-client'
 import {
 	type EmailType,
@@ -55,7 +55,7 @@ export class ImportTicketEmailRoute {
 
 	private readonly logger = resolve(ILogger).scopeTo('ImportTicketEmail')
 	private readonly followService = resolve(IFollowServiceClient)
-	private readonly concertService = resolve(IConcertService)
+	private readonly concertService = resolve(IConcertStore)
 	private readonly ticketEmailService = resolve(ITicketEmailService)
 	private abortController: AbortController | null = null
 

--- a/src/routes/welcome/welcome-route.ts
+++ b/src/routes/welcome/welcome-route.ts
@@ -15,7 +15,7 @@ import type { Artist } from '../../entities/artist'
 import type { DateGroup } from '../../entities/concert'
 import type { Hype } from '../../entities/follow'
 import { IAuthService } from '../../services/auth-service'
-import { IConcertService } from '../../services/concert-service'
+import { IConcertStore } from '../../services/concert-store'
 import { IGuestService } from '../../services/guest-service'
 import {
 	IOnboardingService,
@@ -33,7 +33,7 @@ export class WelcomeRoute implements IRouteViewModel {
 	private readonly logger = resolve(ILogger).scopeTo('WelcomeRoute')
 	private readonly ea = resolve(IEventAggregator)
 	private readonly i18n = resolve(I18N)
-	private readonly concertService = resolve(IConcertService)
+	private readonly concertService = resolve(IConcertStore)
 	private readonly host = resolve(INode) as HTMLElement
 
 	public readonly supportedLanguages = SUPPORTED_LANGUAGES

--- a/src/services/artist-service-client.ts
+++ b/src/services/artist-service-client.ts
@@ -1,4 +1,0 @@
-export {
-	IArtistRpcClient as IArtistServiceClient,
-	type IArtistRpcClient as IArtistServiceClientType,
-} from '../adapter/rpc/client/artist-client'

--- a/src/services/artist-store.ts
+++ b/src/services/artist-store.ts
@@ -1,0 +1,4 @@
+export {
+	IArtistRpcClient as IArtistStore,
+	type IArtistRpcClient as IArtistStoreType,
+} from '../adapter/rpc/client/artist-client'

--- a/src/services/concert-store.spec.ts
+++ b/src/services/concert-store.spec.ts
@@ -32,7 +32,7 @@ vi.mock('aurelia', async (importOriginal) => {
 	}
 })
 
-import { ConcertServiceClient } from './concert-service'
+import { ConcertStore } from './concert-store'
 
 function makeGroups(count: number): ProximityGroup[] {
 	return Array.from({ length: count }, (_, _i) => ({
@@ -43,13 +43,13 @@ function makeGroups(count: number): ProximityGroup[] {
 	})) as unknown as ProximityGroup[]
 }
 
-describe('ConcertServiceClient', () => {
-	let sut: ConcertServiceClient
+describe('ConcertStore', () => {
+	let sut: ConcertStore
 
 	beforeEach(() => {
 		vi.clearAllMocks()
 		mockAuth.isAuthenticated = true
-		sut = new ConcertServiceClient()
+		sut = new ConcertStore()
 	})
 
 	// Restore spies (including the Date.now spy used by the TTL-expiry

--- a/src/services/concert-store.ts
+++ b/src/services/concert-store.ts
@@ -20,15 +20,15 @@ import { IGuestService } from './guest-service'
 
 export type { ProtoConcert, ProximityGroup }
 
-export const IConcertService = DI.createInterface<IConcertService>(
-	'IConcertService',
-	(x) => x.singleton(ConcertServiceClient),
+export const IConcertStore = DI.createInterface<IConcertStore>(
+	'IConcertStore',
+	(x) => x.singleton(ConcertStore),
 )
 
-export interface IConcertService extends ConcertServiceClient {}
+export interface IConcertStore extends ConcertStore {}
 
-export class ConcertServiceClient {
-	private readonly logger = resolve(ILogger).scopeTo('ConcertService')
+export class ConcertStore {
+	private readonly logger = resolve(ILogger).scopeTo('ConcertStore')
 	private readonly authService = resolve(IAuthService)
 	private readonly guest = resolve(IGuestService)
 	private readonly rpcClient = resolve(IConcertRpcClient)
@@ -72,7 +72,7 @@ export class ConcertServiceClient {
 		if (
 			this.cachedGroups !== null &&
 			this.cacheTimestamp !== null &&
-			now - this.cacheTimestamp < ConcertServiceClient.CACHE_TTL_MS
+			now - this.cacheTimestamp < ConcertStore.CACHE_TTL_MS
 		) {
 			return this.cachedGroups
 		}

--- a/src/services/follow-service-client.spec.ts
+++ b/src/services/follow-service-client.spec.ts
@@ -29,7 +29,7 @@ vi.mock('aurelia', async (importOriginal) => {
 				IAuthService: mockAuth,
 				IGuestService: mockGuest,
 				IFollowRpcClient: mockRpcClient,
-				IConcertService: mockConcertService,
+				IConcertStore: mockConcertService,
 			}
 			const tokenAny = token as { friendlyName?: string }
 			return map[tokenAny.friendlyName ?? ''] ?? {}

--- a/src/services/follow-service-client.ts
+++ b/src/services/follow-service-client.ts
@@ -3,7 +3,7 @@ import { IFollowRpcClient } from '../adapter/rpc/client/follow-client'
 import type { Artist } from '../entities/artist'
 import type { FollowedArtist, Hype } from '../entities/follow'
 import { IAuthService } from './auth-service'
-import { IConcertService } from './concert-service'
+import { IConcertStore } from './concert-store'
 import { IGuestService } from './guest-service'
 
 export const IFollowServiceClient = DI.createInterface<IFollowServiceClient>(
@@ -18,7 +18,7 @@ export class FollowServiceClient {
 	private readonly authService = resolve(IAuthService)
 	private readonly guest = resolve(IGuestService)
 	private readonly rpcClient = resolve(IFollowRpcClient)
-	private readonly concertService = resolve(IConcertService)
+	private readonly concertStore = resolve(IConcertStore)
 
 	@observable public followedArtists: Artist[] = []
 
@@ -70,7 +70,7 @@ export class FollowServiceClient {
 
 		try {
 			await this.rpcClient.follow(artist.id)
-			this.concertService.invalidateFollowerCache()
+			this.concertStore.invalidateFollowerCache()
 			this.logger.info('Artist followed', {
 				followed: this.followedCount,
 			})
@@ -98,7 +98,7 @@ export class FollowServiceClient {
 			return
 		}
 		await this.rpcClient.unfollow(artistId)
-		this.concertService.invalidateFollowerCache()
+		this.concertStore.invalidateFollowerCache()
 		this.followedArtists = this.followedArtists.filter((a) => a.id !== artistId)
 	}
 

--- a/test/adapter/rpc/mapper/concert-mapper.spec.ts
+++ b/test/adapter/rpc/mapper/concert-mapper.spec.ts
@@ -190,7 +190,7 @@ describe('concertFrom', () => {
 	})
 
 	it('leaves artistId empty when no artist is resolved (no headliner fallback)', () => {
-		// concert-service is the only production caller and always passes the
+		// concert-store is the only production caller and always passes the
 		// resolved performer as `artist`. Without that resolution the artist
 		// trio (artistId / artistName / artist) all go blank so downstream
 		// dashboard filters do not see an artistId pointing at the headliner
@@ -214,7 +214,7 @@ describe('concertFrom', () => {
 	})
 
 	it('prefers artist.id over performers[0].id when both disagree', () => {
-		// concert-service resolves the followed performer (which may not be
+		// concert-store resolves the followed performer (which may not be
 		// the headliner) and forwards it as `artist`. The mapper must take
 		// that resolved id as the artistId so the entity's artistId /
 		// artistName / artist trio stay internally consistent. Without this

--- a/test/helpers/mock-rpc-clients.ts
+++ b/test/helpers/mock-rpc-clients.ts
@@ -1,14 +1,14 @@
 import { vi } from 'vitest'
-import type { IArtistServiceClient } from '../../src/services/artist-service-client'
+import type { IArtistStore } from '../../src/services/artist-store'
 import type { IAuthService } from '../../src/services/auth-service'
-import type { IConcertService } from '../../src/services/concert-service'
+import type { IConcertStore } from '../../src/services/concert-store'
 import type { IFollowServiceClient } from '../../src/services/follow-service-client'
 import type { IUserService } from '../../src/services/user-service'
 
 /**
- * Creates a mock implementation of IConcertService for testing.
+ * Creates a mock implementation of IConcertStore for testing.
  */
-export function createMockConcertService(): Partial<IConcertService> {
+export function createMockConcertService(): Partial<IConcertStore> {
 	return {
 		artistsWithConcerts: new Set<string>(),
 		artistsWithConcertsCount: 0,
@@ -19,9 +19,9 @@ export function createMockConcertService(): Partial<IConcertService> {
 }
 
 /**
- * Creates a mock implementation of IArtistServiceClient for testing.
+ * Creates a mock implementation of IArtistStore for testing.
  */
-export function createMockArtistServiceClient(): Partial<IArtistServiceClient> {
+export function createMockArtistServiceClient(): Partial<IArtistStore> {
 	return {
 		listTop: vi.fn().mockResolvedValue([]),
 		listSimilar: vi.fn().mockResolvedValue([]),

--- a/test/routes/dashboard-route.spec.ts
+++ b/test/routes/dashboard-route.spec.ts
@@ -7,7 +7,7 @@ import { createMockLocalStorage } from '../helpers/mock-local-storage'
 
 // --- DI tokens (must be created before vi.mock calls) ---
 const mockIAuthService = DI.createInterface('IAuthService')
-const mockIConcertService = DI.createInterface('IConcertService')
+const mockIConcertStore = DI.createInterface('IConcertStore')
 const mockIFollowServiceClient = DI.createInterface('IFollowServiceClient')
 const mockITicketJourneyService = DI.createInterface('ITicketJourneyService')
 const mockIOnboardingService = DI.createInterface('IOnboardingService')
@@ -19,8 +19,8 @@ const mockIHistory = DI.createInterface('IHistory')
 vi.mock('../../src/services/auth-service', () => ({
 	IAuthService: mockIAuthService,
 }))
-vi.mock('../../src/services/concert-service', () => ({
-	IConcertService: mockIConcertService,
+vi.mock('../../src/services/concert-store', () => ({
+	IConcertStore: mockIConcertStore,
 }))
 vi.mock('../../src/services/follow-service-client', () => ({
 	IFollowServiceClient: mockIFollowServiceClient,
@@ -119,7 +119,7 @@ describe('DashboardRoute', () => {
 	function buildSut() {
 		const container = createTestContainer(
 			Registration.instance(mockIAuthService, mockAuth),
-			Registration.instance(mockIConcertService, mockConcert),
+			Registration.instance(mockIConcertStore, mockConcert),
 			Registration.instance(mockIFollowServiceClient, mockFollow),
 			Registration.instance(mockITicketJourneyService, mockJourney),
 			Registration.instance(mockIOnboardingService, mockOnboarding),

--- a/test/routes/discovery-route.spec.ts
+++ b/test/routes/discovery-route.spec.ts
@@ -11,9 +11,9 @@ import {
 } from '../helpers/mock-rpc-clients'
 import { createMockEventAggregator } from '../helpers/mock-toast'
 
-const mockIArtistServiceClient = DI.createInterface('IArtistServiceClient')
+const mockIArtistStore = DI.createInterface('IArtistStore')
 const mockIFollowServiceClient = DI.createInterface('IFollowServiceClient')
-const mockIConcertService = DI.createInterface('IConcertService')
+const mockIConcertStore = DI.createInterface('IConcertStore')
 const mockIRouter = DI.createInterface('IRouter')
 const mockIOnboardingService = DI.createInterface('IOnboardingService')
 const mockIGuestService = DI.createInterface('IGuestService')
@@ -22,16 +22,16 @@ vi.mock('@aurelia/router', () => ({
 	IRouter: mockIRouter,
 }))
 
-vi.mock('../../src/services/artist-service-client', () => ({
-	IArtistServiceClient: mockIArtistServiceClient,
+vi.mock('../../src/services/artist-store', () => ({
+	IArtistStore: mockIArtistStore,
 }))
 
 vi.mock('../../src/services/follow-service-client', () => ({
 	IFollowServiceClient: mockIFollowServiceClient,
 }))
 
-vi.mock('../../src/services/concert-service', () => ({
-	IConcertService: mockIConcertService,
+vi.mock('../../src/services/concert-store', () => ({
+	IConcertStore: mockIConcertStore,
 }))
 
 vi.mock('../../src/services/onboarding-service', () => ({
@@ -145,9 +145,9 @@ describe('DiscoveryRoute', () => {
 		)
 
 		const container = createTestContainer(
-			Registration.instance(mockIArtistServiceClient, mockArtistClient),
+			Registration.instance(mockIArtistStore, mockArtistClient),
 			Registration.instance(mockIFollowServiceClient, mockFollowClient),
-			Registration.instance(mockIConcertService, mockConcert),
+			Registration.instance(mockIConcertStore, mockConcert),
 			Registration.instance(IEventAggregator, mockEa),
 			Registration.instance(mockIRouter, mockRouter),
 			Registration.instance(mockIOnboardingService, mockOnboarding),

--- a/test/routes/import-ticket-email-route.spec.ts
+++ b/test/routes/import-ticket-email-route.spec.ts
@@ -3,12 +3,12 @@ import { DI, Registration } from 'aurelia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createTestContainer } from '../helpers/create-container'
 
-const mockIConcertService = DI.createInterface('IConcertService')
+const mockIConcertStore = DI.createInterface('IConcertStore')
 const mockIFollowServiceClient = DI.createInterface('IFollowServiceClient')
 const mockITicketEmailService = DI.createInterface('ITicketEmailService')
 
-vi.mock('../../src/services/concert-service', () => ({
-	IConcertService: mockIConcertService,
+vi.mock('../../src/services/concert-store', () => ({
+	IConcertStore: mockIConcertStore,
 }))
 vi.mock('../../src/services/follow-service-client', () => ({
 	IFollowServiceClient: mockIFollowServiceClient,
@@ -60,7 +60,7 @@ describe('ImportTicketEmailRoute', () => {
 		}
 
 		const container = createTestContainer(
-			Registration.instance(mockIConcertService, mockConcert),
+			Registration.instance(mockIConcertStore, mockConcert),
 			Registration.instance(mockIFollowServiceClient, mockFollow),
 			Registration.instance(mockITicketEmailService, mockTicketEmail),
 		)

--- a/test/routes/welcome-route.spec.ts
+++ b/test/routes/welcome-route.spec.ts
@@ -8,7 +8,7 @@ import { createMockRouter } from '../helpers/mock-router'
 
 const mockIAuthService = DI.createInterface('IAuthService')
 const mockIOnboardingService = DI.createInterface('IOnboardingService')
-const mockIConcertService = DI.createInterface('IConcertService')
+const mockIConcertStore = DI.createInterface('IConcertStore')
 const mockIGuestService = DI.createInterface('IGuestService')
 
 vi.mock('../../src/services/auth-service', () => ({
@@ -27,8 +27,8 @@ vi.mock('../../src/services/onboarding-service', () => ({
 	},
 }))
 
-vi.mock('../../src/services/concert-service', () => ({
-	IConcertService: mockIConcertService,
+vi.mock('../../src/services/concert-store', () => ({
+	IConcertStore: mockIConcertStore,
 }))
 
 vi.mock('../../src/services/guest-service', () => ({
@@ -94,7 +94,7 @@ describe('WelcomeRoute', () => {
 		const container = createTestContainer(
 			Registration.instance(mockIAuthService, mockAuth),
 			Registration.instance(mockIOnboardingService, mockOnboarding),
-			Registration.instance(mockIConcertService, mockConcert),
+			Registration.instance(mockIConcertStore, mockConcert),
 			Registration.instance(mockIGuestService, mockGuest),
 			Registration.instance(IRouter, mockRouter),
 			Registration.instance(IEventAggregator, {

--- a/test/services/concert-store.spec.ts
+++ b/test/services/concert-store.spec.ts
@@ -37,12 +37,12 @@ vi.mock('../../src/services/guest-service', () => ({
 	IGuestService: mockIGuestService,
 }))
 
-const { ConcertServiceClient, IConcertService } = await import(
-	'../../src/services/concert-service'
+const { ConcertStore, IConcertStore } = await import(
+	'../../src/services/concert-store'
 )
 
-describe('ConcertServiceClient', () => {
-	let sut: InstanceType<typeof ConcertServiceClient>
+describe('ConcertStore', () => {
+	let sut: InstanceType<typeof ConcertStore>
 	let mockLoggerWarn: ReturnType<typeof vi.fn>
 
 	beforeEach(() => {
@@ -65,10 +65,10 @@ describe('ConcertServiceClient', () => {
 			}),
 			Registration.instance(mockIConcertRpcClient, mockConcertRpcClient),
 		)
-		container.register(ConcertServiceClient)
-		sut = container.get(IConcertService)
+		container.register(ConcertStore)
+		sut = container.get(IConcertStore)
 		// The mock ILogger's scopeTo returns the same instance (mockReturnThis),
-		// so the scoped logger inside ConcertServiceClient calls the very same
+		// so the scoped logger inside ConcertStore calls the very same
 		// warn spy we grab from the container here.
 		mockLoggerWarn = (
 			container.get(ILogger) as { warn: ReturnType<typeof vi.fn> }


### PR DESCRIPTION
## Description

**Phase 3 of the entity-store-layer refactor** (OpenSpec `introduce-entity-store-layer`). Pure rename for layer-naming consistency — the cache-only query services adopt the `*Store` naming used by the rest of the store layer (`UserStore`/`FollowStore`).

**No behavioral or caching change.** The underlying proto RPC clients (`IConcertRpcClient`/`IArtistRpcClient`) are untouched. These stores hold no guest/authed state and do not participate in the auth-boundary events.

## Type of Change

- [x] refactor: rename for store-layer naming consistency

## Changes

- `ConcertServiceClient` / `IConcertService` → `ConcertStore` / `IConcertStore` (`concert-service.ts` → `concert-store.ts`)
- `IArtistServiceClient` → `IArtistStore` (`artist-service-client.ts` → `artist-store.ts`)
- Consumers updated: `main.ts` (DI registrations), `follow-service-client.ts`, `dashboard-route`, `discovery-route`, `welcome-route`, `import-ticket-email-route`
- Specs/mocks updated; no dangling references to the old tokens

## Verification

### Automated Tests
- [x] `npm run lint` passed (0 errors)
- [x] `npm run test` passed (1193 tests)
- [x] `npm run build` passes

### Manual Verification
Pure rename; behavior identical. Verified via grep that no load-bearing references to the old interface/class tokens remain.

## Out of scope (Phase 4)
- Remaining `IFollowServiceClient` / `IGuestService` consumer migration + `GuestService`/`GuestDataMergeService` removal + welcome-route locale mirror removal.

## Checklist
- [x] Follows project style; self-reviewed; no new warnings

Refs: #368
