### PR TITLE
fix(settings): contain toggle, expandable consent, guest hero, purpose labels

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -261,7 +261,6 @@
 		"privacyPolicy": "Privacy Policy",
 		"ossLicenses": "OSS Licenses",
 		"account": "Account",
-		"guestPrompt": "Sign in to keep your favorites and notifications across devices",
 		"signIn": "Sign in",
 		"signUp": "Sign up",
 		"emailVerified": "Verified",
@@ -276,10 +275,14 @@
 		"languageChangeError": "Couldn't save the language change. Wait a moment and try again.",
 		"analytics": {
 			"sectionTitle": "Privacy & Analytics",
-			"toggleLabel": "Share anonymous usage insights",
-			"toggleDescription": "Helps us see which screens get loved and which trip people up — so we can make the next version better.",
-			"crossBorderLabel": "Allow cross-border analytics processing",
-			"crossBorderDescription": "Lets us include your activity in our EU-region analytics so we can compare cohorts across releases. Turn off to keep your data inside Japan only."
+			"toggleLabel": "Help improve the experience",
+			"toggleDescription": "We use anonymous data to find where people get stuck, so we can make the next update better. No personally identifying information is collected.",
+			"marketingLabel": "Help measure ad effectiveness",
+			"marketingDescription": "We anonymously measure how people who arrive via ads move through the app, to improve how we reach them. Turning this off has no effect on other features."
+		},
+		"guestHero": {
+			"heading": "Sign in for the full experience",
+			"body": "Use your favorites and notifications on any device"
 		}
 	},
 	"onboarding": {

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -261,7 +261,6 @@
 		"privacyPolicy": "プライバシーポリシー",
 		"ossLicenses": "OSSライセンス",
 		"account": "アカウント",
-		"guestPrompt": "ログインするとお気に入りや通知を端末をまたいで使えます",
 		"signIn": "ログイン",
 		"signUp": "新規登録",
 		"emailVerified": "認証済み",
@@ -276,10 +275,14 @@
 		"languageChangeError": "言語の変更を保存できませんでした。少し時間を置いてもう一度お試しください。",
 		"analytics": {
 			"sectionTitle": "プライバシーと分析",
-			"toggleLabel": "匿名の利用状況を共有する",
-			"toggleDescription": "どの画面が使われているか、どこでつまずいているかを把握して、次のアップデートをよりよくするために使います。",
-			"crossBorderLabel": "海外での分析処理を許可する",
-			"crossBorderDescription": "EUリージョンの分析ダッシュボードに匿名の利用データを含めます。オフにすると国内のみで処理します。"
+			"toggleLabel": "使い心地の改善に協力する",
+			"toggleDescription": "「どこで迷いやすいか」を匿名データから見つけ、次のアップデートに活かします。個人を特定する情報は集めません。",
+			"marketingLabel": "広告効果の測定に協力する",
+			"marketingDescription": "広告から来てくれた人の動きを匿名で測り、届け方の改善に役立てます。オフにしても他の機能には影響しません。"
+		},
+		"guestHero": {
+			"heading": "ログインして、もっと便利に",
+			"body": "お気に入りと通知を、どの端末でもそのまま使えます"
 		}
 	},
 	"onboarding": {

--- a/src/routes/settings/settings-route.css
+++ b/src/routes/settings/settings-route.css
@@ -148,13 +148,87 @@
 
 		.settings-toggle-col {
 			display: flex;
+			flex: 1;
 			flex-direction: column;
 			gap: var(--space-3xs);
 			align-items: flex-start;
+
+			/* Allow the text column to wrap instead of starving the track. */
+			min-inline-size: 0;
+		}
+
+		/* Toggle rows align their control to the first line of the label
+		   rather than the vertical centre of multi-line content. */
+		.settings-row-toggle {
+			align-items: flex-start;
+		}
+
+		/* Disclosure control wrapping the label + collapsible description.
+		   A sibling of `.settings-switch` — never a parent of it. */
+		.settings-expand {
+			display: flex;
+			flex: 1;
+			flex-direction: column;
+			gap: var(--space-3xs);
+			align-items: flex-start;
+
+			min-inline-size: 0;
+			padding: 0;
+
+			text-align: start;
+			cursor: pointer;
+
+			background: transparent;
+			border: 0;
+		}
+
+		.settings-expand-caret {
+			inline-size: 1rem;
+			block-size: 1rem;
+			color: var(--color-text-muted);
+
+			transition: transform 200ms;
+
+			&[data-expanded="true"] {
+				transform: rotate(90deg);
+			}
+		}
+
+		/* Switch control. Min block size lifts the tap target to 44px even
+		   though the visible track is 1.5rem tall. */
+		.settings-switch {
+			display: flex;
+			flex-shrink: 0;
+			align-items: center;
+			justify-content: center;
+
+			min-block-size: 2.75rem;
+			padding-inline: var(--space-2xs);
+
+			cursor: pointer;
+
+			background: transparent;
+			border: 0;
+		}
+
+		/* Collapsible toggle description. Decoupled from `.settings-row-hint`'s
+		   icon-alignment indent so it can use the full column width. */
+		.settings-toggle-desc {
+			font-size: var(--step--1);
+			line-height: var(--leading-relaxed);
+			color: var(--color-text-muted);
+
+			text-wrap: pretty;
 		}
 
 		.settings-toggle-track {
 			position: relative;
+
+			/* Never let the fixed-size control collapse when it competes for
+			   inline space with a long adjacent description in the same flex
+			   row — without this the track shrinks and the absolutely-positioned
+			   thumb overflows past the track and the card edge. */
+			flex-shrink: 0;
 
 			inline-size: 2.75rem;
 			block-size: 1.5rem;
@@ -233,6 +307,94 @@
 			font-size: var(--step--1);
 			font-weight: 600;
 			color: var(--_signout-color);
+		}
+
+		/* Guest sign-in hero. Brand-tinted to stand apart from the plain
+		   raised list cards — this is the primary action for a guest. */
+		.settings-guest-hero {
+			display: flex;
+			flex-direction: column;
+			gap: var(--space-2xs);
+
+			padding: var(--space-m) var(--space-s);
+			border: 1px solid oklch(from var(--color-brand-primary) l c h / 30%);
+			border-radius: var(--radius-card);
+
+			background: oklch(from var(--color-brand-primary) l c h / 12%);
+		}
+
+		.settings-guest-hero-heading {
+			font-family: var(--font-display);
+			font-size: var(--step-1);
+			font-weight: 600;
+			color: var(--color-text-primary);
+		}
+
+		.settings-guest-hero-body {
+			font-size: var(--step--1);
+			line-height: var(--leading-relaxed);
+			color: var(--color-text-secondary);
+
+			text-wrap: pretty;
+		}
+
+		.settings-guest-hero-actions {
+			display: flex;
+			flex-direction: column;
+			gap: var(--space-2xs);
+
+			margin-block-start: var(--space-2xs);
+		}
+
+		/* Filled primary — mirrors the consent screen's primary button. */
+		.settings-guest-hero-primary {
+			min-block-size: 2.75rem;
+			padding: var(--space-xs) var(--space-m);
+			border: 0;
+			border-radius: var(--radius-button);
+
+			font-weight: 600;
+			color: var(--color-white);
+
+			background: var(--color-brand-primary);
+			box-shadow: var(--shadow-button);
+
+			cursor: pointer;
+			transition:
+				background 200ms,
+				transform 200ms;
+
+			&:hover {
+				background: var(--color-brand-secondary);
+			}
+
+			&:active {
+				transform: scale(0.98);
+			}
+		}
+
+		/* Ghost secondary — subordinate to the filled primary. */
+		.settings-guest-hero-secondary {
+			min-block-size: 2.75rem;
+			padding: var(--space-2xs) var(--space-m);
+			border: 0;
+			border-radius: var(--radius-button);
+
+			font-weight: 600;
+			color: var(--color-brand-primary);
+
+			background: transparent;
+
+			cursor: pointer;
+			transition: background 200ms;
+
+			&:hover {
+				background: color-mix(
+					in oklch,
+					var(--color-brand-primary) 12%,
+					transparent
+				);
+			}
 		}
 
 		/* Language selector content (inside bottom-sheet) */

--- a/src/routes/settings/settings-route.html
+++ b/src/routes/settings/settings-route.html
@@ -2,6 +2,18 @@
 
 <main>
   <div class="[ settings-scroll ] [ stack ]">
+  <!-- Guest sign-in / sign-up hero. Top-of-page, guest-only: the most
+       important action for an unauthenticated user, lifted out of the
+       bottom ACCOUNT list so it reads as a primary CTA rather than a link. -->
+  <section if.bind="!auth.isAuthenticated" class="settings-guest-hero">
+    <h2 t="settings.guestHero.heading" class="settings-guest-hero-heading"></h2>
+    <p t="settings.guestHero.body" class="settings-guest-hero-body"></p>
+    <div class="settings-guest-hero-actions">
+      <button click.trigger="signIn()" t="settings.signIn" class="settings-guest-hero-primary"></button>
+      <button click.trigger="signUp()" t="settings.signUp" class="settings-guest-hero-secondary"></button>
+    </div>
+  </section>
+
   <!-- PREFERENCES Section -->
   <section>
     <h2 t="settings.preferences" class="settings-section-title"></h2>
@@ -46,7 +58,7 @@
         role="switch"
         aria-checked.bind="notificationsEnabled"
         disabled.bind="!vapidAvailable"
-        class="settings-row"
+        class="[ settings-row ] [ settings-row-toggle ]"
         data-disabled.bind="!vapidAvailable"
       >
         <div class="settings-toggle-col">
@@ -69,14 +81,14 @@
         click.trigger="toggleSound()"
         role="switch"
         aria-checked.bind="soundEnabled"
-        class="settings-row"
+        class="[ settings-row ] [ settings-row-toggle ]"
       >
         <div class="settings-toggle-col">
           <div class="settings-row-start">
             <svg-icon name="music" class="settings-icon"></svg-icon>
             <span t="settings.soundEffects" class="settings-row-label"></span>
           </div>
-          <span t="settings.soundEffectsHint" class="settings-row-hint"></span>
+          <span if.bind="isIOS" t="settings.soundEffectsHint" class="settings-toggle-desc"></span>
         </div>
         <!-- Toggle switch -->
         <div class="settings-toggle-track" data-on.bind="soundEnabled">
@@ -105,45 +117,70 @@
   <section>
     <h2 t="settings.analytics.sectionTitle" class="settings-section-title"></h2>
     <div class="settings-card">
-      <!-- Analytics consent toggle -->
-      <button
-        click.trigger="handleAnalyticsToggle()"
-        role="switch"
-        aria-checked.bind="analyticsConsent"
-        class="settings-row"
-      >
-        <div class="settings-toggle-col">
+      <!-- Analytics consent. Disclosure (expand description) and switch are
+           sibling buttons: a role="switch" must never contain another
+           interactive control. -->
+      <div class="[ settings-row ] [ settings-row-toggle ]">
+        <button
+          click.trigger="toggleAnalyticsDesc()"
+          aria-expanded.bind="analyticsDescExpanded"
+          class="settings-expand"
+        >
           <div class="settings-row-start">
             <svg-icon name="info" class="settings-icon"></svg-icon>
             <span t="settings.analytics.toggleLabel" class="settings-row-label"></span>
+            <svg-icon name="chevron-right" class="settings-expand-caret" data-expanded.bind="analyticsDescExpanded"></svg-icon>
           </div>
-          <span t="settings.analytics.toggleDescription" class="settings-row-hint"></span>
-        </div>
-        <div class="settings-toggle-track" data-on.bind="analyticsConsent">
-          <div class="settings-toggle-thumb" data-on.bind="analyticsConsent"></div>
-        </div>
-      </button>
+          <span
+            if.bind="analyticsDescExpanded"
+            t="settings.analytics.toggleDescription"
+            class="settings-toggle-desc"
+          ></span>
+        </button>
+        <button
+          click.trigger="handleAnalyticsToggle()"
+          role="switch"
+          aria-checked.bind="analyticsConsent"
+          class="settings-switch"
+        >
+          <div class="settings-toggle-track" data-on.bind="analyticsConsent">
+            <div class="settings-toggle-thumb" data-on.bind="analyticsConsent"></div>
+          </div>
+        </button>
+      </div>
 
       <hr class="settings-divider">
 
-      <!-- Cross-border marketing measurement toggle -->
-      <button
-        click.trigger="handleMarketingToggle()"
-        role="switch"
-        aria-checked.bind="marketingConsent"
-        class="settings-row"
-      >
-        <div class="settings-toggle-col">
+      <!-- Marketing-measurement consent. Labeled by purpose (ad-effectiveness
+           measurement), not by data geography. -->
+      <div class="[ settings-row ] [ settings-row-toggle ]">
+        <button
+          click.trigger="toggleMarketingDesc()"
+          aria-expanded.bind="marketingDescExpanded"
+          class="settings-expand"
+        >
           <div class="settings-row-start">
             <svg-icon name="globe" class="settings-icon"></svg-icon>
-            <span t="settings.analytics.crossBorderLabel" class="settings-row-label"></span>
+            <span t="settings.analytics.marketingLabel" class="settings-row-label"></span>
+            <svg-icon name="chevron-right" class="settings-expand-caret" data-expanded.bind="marketingDescExpanded"></svg-icon>
           </div>
-          <span t="settings.analytics.crossBorderDescription" class="settings-row-hint"></span>
-        </div>
-        <div class="settings-toggle-track" data-on.bind="marketingConsent">
-          <div class="settings-toggle-thumb" data-on.bind="marketingConsent"></div>
-        </div>
-      </button>
+          <span
+            if.bind="marketingDescExpanded"
+            t="settings.analytics.marketingDescription"
+            class="settings-toggle-desc"
+          ></span>
+        </button>
+        <button
+          click.trigger="handleMarketingToggle()"
+          role="switch"
+          aria-checked.bind="marketingConsent"
+          class="settings-switch"
+        >
+          <div class="settings-toggle-track" data-on.bind="marketingConsent">
+            <div class="settings-toggle-thumb" data-on.bind="marketingConsent"></div>
+          </div>
+        </button>
+      </div>
     </div>
   </section>
 
@@ -190,35 +227,13 @@
     </div>
   </section>
 
-  <!-- ACCOUNT Section -->
-  <section>
+  <!-- ACCOUNT Section. Authenticated-only: the guest sign-in / sign-up entry
+       lives in the top hero, so this section is hidden entirely for guests. -->
+  <section if.bind="auth.isAuthenticated">
     <h2 t="settings.account" class="settings-section-title"></h2>
 
-    <!-- Guest: sign-in / sign-up entry. Account-bound controls (email
-         verification, sign-out) are hidden, not blocked. -->
-    <div if.bind="!auth.isAuthenticated" class="settings-card">
-      <p t="settings.guestPrompt" class="settings-row-hint settings-guest-prompt"></p>
-      <button click.trigger="signIn()" class="settings-row">
-        <div class="settings-row-start">
-          <svg-icon name="lock" class="settings-icon"></svg-icon>
-          <span t="settings.signIn" class="settings-row-label"></span>
-        </div>
-        <svg-icon name="chevron-right" class="settings-chevron"></svg-icon>
-      </button>
-
-      <hr class="settings-divider">
-
-      <button click.trigger="signUp()" class="settings-row">
-        <div class="settings-row-start">
-          <svg-icon name="plus" class="settings-icon"></svg-icon>
-          <span t="settings.signUp" class="settings-row-label"></span>
-        </div>
-        <svg-icon name="chevron-right" class="settings-chevron"></svg-icon>
-      </button>
-    </div>
-
     <!-- Authenticated: email verification + sign out -->
-    <div if.bind="auth.isAuthenticated" class="settings-card">
+    <div class="settings-card">
       <!-- Email Verification -->
       <div class="settings-row">
         <div class="settings-row-start">

--- a/src/routes/settings/settings-route.ts
+++ b/src/routes/settings/settings-route.ts
@@ -54,8 +54,33 @@ export class SettingsRoute {
 	public analyticsConsent = false
 	public marketingConsent = false
 
+	/**
+	 * Per-row disclosure state for the Privacy & Analytics consent
+	 * descriptions. The description is hidden until the user expands it,
+	 * keeping each card compact while the full rationale stays one tap away.
+	 * Kept separate from the switch value so the disclosure and the switch
+	 * remain independent sibling controls (accessible: a `role="switch"`
+	 * button never nests another interactive element).
+	 */
+	public analyticsDescExpanded = false
+	public marketingDescExpanded = false
+
 	public isResendingVerification = false
 	public resendSuccess = false
+
+	/**
+	 * Whether the running platform is iOS/iPadOS. Used to gate the
+	 * sound-effects hint, which describes iOS-only silent-switch behaviour
+	 * and is noise on Android/desktop. Mirrors the detection in
+	 * `pwa-install-service`; defaults to false when uncertain so non-iOS
+	 * never sees the iOS-specific copy.
+	 */
+	public get isIOS(): boolean {
+		const ua = navigator.userAgent
+		if (/iphone|ipad|ipod/i.test(ua)) return true
+		// iPadOS 13+ reports a macOS desktop user-agent; detect via touch.
+		return navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1
+	}
 
 	// Display values derive from UserStore, the single observable owner of the
 	// current user's home + language. UserStore resolves guest(localStorage)
@@ -118,6 +143,16 @@ export class SettingsRoute {
 		const next = !this.marketingConsent
 		this.marketingConsent = next
 		this.writeConsent('marketingMeasurement', next)
+	}
+
+	/** Toggle the analytics consent description disclosure. */
+	public toggleAnalyticsDesc(): void {
+		this.analyticsDescExpanded = !this.analyticsDescExpanded
+	}
+
+	/** Toggle the marketing-measurement consent description disclosure. */
+	public toggleMarketingDesc(): void {
+		this.marketingDescExpanded = !this.marketingDescExpanded
 	}
 
 	private writeConsent(purpose: ConsentPurpose, grant: boolean): void {

--- a/test/routes/settings-route.spec.ts
+++ b/test/routes/settings-route.spec.ts
@@ -462,4 +462,42 @@ describe('SettingsRoute', () => {
 			expect(guestSut.currentLocale).toBe('en')
 		})
 	})
+
+	describe('consent description disclosure', () => {
+		it('toggleAnalyticsDesc flips the analytics disclosure state', () => {
+			expect(sut.analyticsDescExpanded).toBe(false)
+			sut.toggleAnalyticsDesc()
+			expect(sut.analyticsDescExpanded).toBe(true)
+			sut.toggleAnalyticsDesc()
+			expect(sut.analyticsDescExpanded).toBe(false)
+		})
+
+		it('disclosure toggle does not change the switch value (independent controls)', () => {
+			sut.marketingConsent = false
+			sut.toggleMarketingDesc()
+			expect(sut.marketingDescExpanded).toBe(true)
+			// The disclosure and the switch are separate controls — expanding
+			// the description must not grant/revoke the consent.
+			expect(sut.marketingConsent).toBe(false)
+		})
+	})
+
+	describe('isIOS', () => {
+		afterEach(() => {
+			// Drop any own-property override, restoring the prototype getter.
+			delete (navigator as { userAgent?: string }).userAgent
+		})
+
+		it('is false on a non-iOS user agent', () => {
+			expect(sut.isIOS).toBe(false)
+		})
+
+		it('is true on an iPhone user agent', () => {
+			Object.defineProperty(navigator, 'userAgent', {
+				configurable: true,
+				get: () => 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)',
+			})
+			expect(sut.isIOS).toBe(true)
+		})
+	})
 })


### PR DESCRIPTION
## Summary

Fixes the Settings page toggle layout defect and several adjacent UX / consent-labeling gaps. Tracked as the OpenSpec change `redesign-settings-ui` (modifies the `settings` capability).

## Problem

- **Toggle layout breakage.** `.settings-toggle-track` lacked `flex-shrink: 0`, so when it shared a flex row with a long Japanese consent description the declared 44px track collapsed. Reproduced at 412px: the track rendered **20.63px** and the thumb overflowed it by **+21px**, poking **+4px past the card's right edge** — the "white dot pinned to the card edge with no visible track" symptom.
- Privacy consent descriptions wrapped into a cramped 3-line column beside the toggle.
- The 2nd analytics toggle binds to `consent.marketingMeasurement` but was labeled by **geography** ("海外での分析処理を許可する"), not by its consent purpose.
- The guest sign-in / sign-up entry was buried at the bottom as plain chevron rows identical to the legal links.
- The iOS-specific sound-effects hint rendered on every platform.
- Orphan `.settings-guest-prompt` class (markup-only, undefined in CSS).

## Changes

- **Toggle integrity:** `flex-shrink: 0` on the track, `min-inline-size: 0` on the text column, first-line alignment for toggle rows. Track now holds 44px and the thumb stays contained.
- **Expandable consent descriptions:** each long-description toggle row is split into **sibling controls** — a disclosure `<button aria-expanded>` (label + collapsible description + rotating chevron) and the `<button role="switch">` (a `role="switch"` must never nest another interactive element). The switch keeps a ≥44px tap target.
- **Consent copy:** opt-in-friendly, purpose-based wording; the marketing toggle is **relabeled by purpose** (ad-effectiveness measurement) and kept visible as the persistent opt-out the analytics-consent spec requires. Keys renamed `crossBorder*` → `marketing*` (ja + en).
- **Guest hero:** brand-tinted sign-in hero at the top of Settings (filled primary + ghost secondary), guest-only; authenticated account controls remain in the bottom ACCOUNT section.
- **iOS sound hint** gated behind an `isIOS` platform check.
- Removed the orphan class.

## Testing

- `make check` green: biome lint, brand-vocabulary, CUBE-CSS lint rules, typecheck, format.
- 33/33 `settings-route` unit tests pass (4 new: disclosure independence, `isIOS` gating).
- Flex-shrink fix empirically re-verified at 412px (track = 44px, thumb contained).

> **Visual baselines:** this is an intentional UI change, so `e2e/visual/settings.auth.visual.spec.ts` baselines will need regeneration via the main-branch visual-baseline refresh process (delete stale baseline artifacts to force regen).

close: #400
