### PR TITLE
docs: prod smoke runs after the automated pin-bump (not a manual PR)

### DIFF
--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -170,7 +170,7 @@ Out of scope for the runtime-config capability.
 |---|---|---|
 | Unit | Schema validator, host cross-check | [`src/config/app-config.spec.ts`](../src/config/app-config.spec.ts) |
 | Build-time gate | Every route chunk contains its template marker | `npm run verify:build-templates` (Dockerfile + CI) |
-| Post-deploy | SPA renders + `/config.json` env field matches host | `npm run test:smoke` (auto on push-to-main via `Deploy Frontend` workflow's `post-deploy-smoke` job; manual via `workflow_dispatch` for prod after the cloud-provisioning pin-bump PR merges) |
+| Post-deploy | SPA renders + `/config.json` env field matches host | `npm run test:smoke` (auto on push-to-main via `Deploy Frontend` workflow's `post-deploy-smoke` job; manual via `workflow_dispatch` for prod after the automated cloud-provisioning pin-bump lands on `main`) |
 
 ---
 


### PR DESCRIPTION
## 🔗 Related Issue
Refs liverty-music/specification#553

## 📝 Summary of Changes
Docs-only one-liner. The prod pin-bump is now CI-automated (OpenSpec `automate-prod-pin-bump`, shipped + verified in prod), so the `runtime-config.md` testing table's prod-smoke note ("after the cloud-provisioning pin-bump **PR** merges") is stale. Update it to "after the automated cloud-provisioning pin-bump lands on `main`".

No code change.

## ✅ Self-Checklist
- [x] Linked the related issue.
- [x] Docs-only; no behavior change.
