### PR TITLE
refactor(settings): align rows via card-grid + row-subgrid

### DIFF
--- a/src/routes/settings/settings-route.css
+++ b/src/routes/settings/settings-route.css
@@ -53,20 +53,37 @@
 			letter-spacing: 0.05em;
 		}
 
+		/* The card owns the shared column tracks (lead icon | content | trailing
+		   control); every row is a subgrid spanning them, so icons, labels, and
+		   controls line up across all rows regardless of each row's content or
+		   inner markup — alignment is structural, not emergent from per-row flex.
+		   Subgrid is Baseline (since 2023); each subgrid line carries an explicit
+		   track list above it as a same-cascade fallback for older engines. */
 		.settings-card {
 			overflow: hidden;
+			display: grid;
+			grid-template-columns: auto 1fr auto;
+
 			border: 1px solid color-mix(in oklch, var(--color-white) 10%, transparent);
 			border-radius: var(--radius-card);
+
 			background: var(--color-surface-raised);
 		}
 
 		.settings-row {
-			display: flex;
+			display: grid;
+			grid-column: 1 / -1;
+			grid-template-columns: auto 1fr auto;
+			grid-template-columns: subgrid;
+			column-gap: var(--space-xs);
 			align-items: center;
-			justify-content: space-between;
 
-			inline-size: 100%;
 			padding: var(--space-xs) var(--space-s);
+
+			/* Reset the UA `text-align: center` a <button>.settings-row would
+			   otherwise impose — its label is a stretched col2 grid item, so
+			   centred text would drift to the middle of the column. */
+			text-align: start;
 
 			transition: background 200ms;
 
@@ -82,46 +99,62 @@
 			&[data-disabled="true"]:hover {
 				background: transparent;
 			}
+		}
 
-			& .settings-row-start {
-				display: flex;
-				gap: var(--space-xs);
-				align-items: center;
-			}
+		/* Column placement. Each property targets whichever element is a DIRECT
+		   row child; the same class nested inside a flex cell (e.g. a label inside
+		   the toggle column) ignores `grid-column` harmlessly. */
+		.settings-icon {
+			grid-column: 1;
+			inline-size: 1.25rem;
+			block-size: 1.25rem;
+			color: var(--color-text-secondary);
+		}
 
-			& .settings-row-end {
-				display: flex;
-				gap: var(--space-2xs);
-				align-items: center;
-			}
+		.settings-row-label,
+		.settings-toggle-col,
+		.settings-expand,
+		.settings-account {
+			grid-column: 2;
+		}
 
-			& .settings-icon {
-				inline-size: 1.25rem;
-				block-size: 1.25rem;
-				color: var(--color-text-secondary);
-			}
+		.settings-row-end,
+		.settings-chevron,
+		.settings-toggle-track,
+		.settings-switch,
+		.settings-resend-btn {
+			grid-column: 3;
+			justify-self: end;
+		}
 
-			& .settings-chevron {
-				inline-size: 1rem;
-				block-size: 1rem;
-				color: var(--color-text-muted);
-			}
+		/* Trailing value + chevron cluster (nav rows). */
+		.settings-row-end {
+			display: flex;
+			gap: var(--space-2xs);
+			align-items: center;
+		}
 
-			& .settings-row-label {
-				font-size: var(--step--1);
-				color: var(--color-text-primary);
-			}
+		.settings-chevron {
+			inline-size: 1rem;
+			block-size: 1rem;
+			color: var(--color-text-muted);
+		}
 
-			& .settings-row-value {
-				font-size: var(--step--1);
-				color: var(--color-text-secondary);
-			}
+		.settings-row-label {
+			font-size: var(--step--1);
+			color: var(--color-text-primary);
+		}
 
-			& .settings-row-hint {
-				margin-inline-start: var(--space-l);
-				font-size: var(--step--1);
-				color: var(--color-text-muted);
-			}
+		.settings-row-value {
+			font-size: var(--step--1);
+			color: var(--color-text-secondary);
+		}
+
+		/* Rows/elements that opt out of the 3-column model span the full width. */
+		.settings-divider,
+		.settings-volume-row,
+		.settings-sign-out {
+			grid-column: 1 / -1;
 		}
 
 		.settings-divider {
@@ -141,52 +174,59 @@
 		   the project's CSS rules forbid the vendor-prefixed hand-rolled slider
 		   that a custom WebKit fallback would require. */
 		.settings-volume-slider {
-			flex: 1;
 			cursor: pointer;
+			flex: 1;
 			accent-color: var(--color-brand-primary);
 		}
 
+		/* Content column (col2) for whole-row toggle buttons: label + optional
+		   hint/description stacked. */
 		.settings-toggle-col {
 			display: flex;
-			flex: 1;
 			flex-direction: column;
 			gap: var(--space-3xs);
 			align-items: flex-start;
 
-			/* Allow the text column to wrap instead of starving the track. */
 			min-inline-size: 0;
 		}
 
-		/* Toggle rows align their control to the first line of the label
-		   rather than the vertical centre of multi-line content. */
+		/* Toggle rows align their icon + control to the first line of the label
+		   rather than the vertical centre of an expanded description. */
 		.settings-row-toggle {
-			align-items: flex-start;
+			align-items: start;
 		}
 
-		/* Disclosure control wrapping the label + collapsible description.
-		   A sibling of `.settings-switch` — never a parent of it. */
+		/* Disclosure control (col2) wrapping the label + collapsible description.
+		   A sibling of `.settings-switch` — never a parent of it (a role="switch"
+		   must not nest another interactive control). */
 		.settings-expand {
+			cursor: pointer;
+
 			display: flex;
-			flex: 1;
 			flex-direction: column;
 			gap: var(--space-3xs);
 			align-items: flex-start;
 
 			min-inline-size: 0;
 			padding: 0;
+			border: 0;
 
 			text-align: start;
-			cursor: pointer;
 
 			background: transparent;
-			border: 0;
+		}
+
+		/* Label + expand caret on one line, above the collapsible description. */
+		.settings-expand-head {
+			display: flex;
+			gap: var(--space-2xs);
+			align-items: center;
 		}
 
 		.settings-expand-caret {
 			inline-size: 1rem;
 			block-size: 1rem;
 			color: var(--color-text-muted);
-
 			transition: transform 200ms;
 
 			&[data-expanded="true"] {
@@ -194,21 +234,22 @@
 			}
 		}
 
-		/* Switch control. Min block size lifts the tap target to 44px even
-		   though the visible track is 1.5rem tall. */
+		/* Switch control: the trailing (col3) cell for split consent rows. A
+		   transparent button wrapping just the track — `padding: 0` so the track
+		   sits flush at col3's end edge, pixel-aligned with every other row's
+		   trailing control. The track (2.75rem × 1.5rem) is the activation
+		   target: ≥24px on both axes per WCAG 2.5.8 (AA), with the adjacent
+		   disclosure control offering a larger neighbouring target. */
 		.settings-switch {
-			display: flex;
-			flex-shrink: 0;
-			align-items: center;
-			justify-content: center;
-
-			min-block-size: 2.75rem;
-			padding-inline: var(--space-2xs);
-
 			cursor: pointer;
 
-			background: transparent;
+			display: flex;
+			align-items: center;
+
+			padding: 0;
 			border: 0;
+
+			background: transparent;
 		}
 
 		/* Collapsible toggle description. Decoupled from `.settings-row-hint`'s
@@ -217,17 +258,16 @@
 			font-size: var(--step--1);
 			line-height: var(--leading-relaxed);
 			color: var(--color-text-muted);
-
 			text-wrap: pretty;
 		}
 
 		.settings-toggle-track {
 			position: relative;
 
-			/* Never let the fixed-size control collapse when it competes for
-			   inline space with a long adjacent description in the same flex
-			   row — without this the track shrinks and the absolutely-positioned
-			   thumb overflows past the track and the card edge. */
+			/* Fixed-size control. Its grid cell (col3) already pins the size;
+			   `flex-shrink: 0` additionally guards the consent rows, where the
+			   track lives inside a flex `.settings-switch` — without it the track
+			   could shrink and the absolutely-positioned thumb would overflow. */
 			flex-shrink: 0;
 
 			inline-size: 2.75rem;
@@ -262,6 +302,16 @@
 			&[data-on="true"] {
 				transform: translateX(1.25rem);
 			}
+		}
+
+		/* Email + verification badge stack (col2 of the account row). */
+		.settings-account {
+			display: flex;
+			flex-direction: column;
+			gap: var(--space-3xs);
+			align-items: flex-start;
+
+			min-inline-size: 0;
 		}
 
 		.settings-verification-badge {
@@ -299,8 +349,10 @@
 			}
 		}
 
+		/* Full-width, centred — overrides the subgrid column tracks. */
 		.settings-sign-out {
-			justify-content: center;
+			grid-template-columns: 1fr;
+			justify-items: center;
 		}
 
 		.settings-sign-out-text {
@@ -334,7 +386,6 @@
 			font-size: var(--step--1);
 			line-height: var(--leading-relaxed);
 			color: var(--color-text-secondary);
-
 			text-wrap: pretty;
 		}
 
@@ -342,12 +393,13 @@
 			display: flex;
 			flex-direction: column;
 			gap: var(--space-2xs);
-
 			margin-block-start: var(--space-2xs);
 		}
 
 		/* Filled primary — mirrors the consent screen's primary button. */
 		.settings-guest-hero-primary {
+			cursor: pointer;
+
 			min-block-size: 2.75rem;
 			padding: var(--space-xs) var(--space-m);
 			border: 0;
@@ -359,7 +411,6 @@
 			background: var(--color-brand-primary);
 			box-shadow: var(--shadow-button);
 
-			cursor: pointer;
 			transition:
 				background 200ms,
 				transform 200ms;
@@ -375,6 +426,8 @@
 
 		/* Ghost secondary — subordinate to the filled primary. */
 		.settings-guest-hero-secondary {
+			cursor: pointer;
+
 			min-block-size: 2.75rem;
 			padding: var(--space-2xs) var(--space-m);
 			border: 0;
@@ -385,7 +438,6 @@
 
 			background: transparent;
 
-			cursor: pointer;
 			transition: background 200ms;
 
 			&:hover {

--- a/src/routes/settings/settings-route.html
+++ b/src/routes/settings/settings-route.html
@@ -14,19 +14,18 @@
     </div>
   </section>
 
-  <!-- PREFERENCES Section -->
+  <!-- PREFERENCES Section.
+       Every row is a subgrid spanning the card's `icon | content | control`
+       columns: the first child lands in the icon column, the content in the
+       1fr column, the trailing control in the auto column — so all rows align
+       regardless of type. -->
   <section>
     <h2 t="settings.preferences" class="settings-section-title"></h2>
     <div class="settings-card">
       <!-- My Home Area -->
-      <button
-        click.trigger="openHomeSelector()"
-        class="settings-row"
-      >
-        <div class="settings-row-start">
-          <svg-icon name="map-pin" class="settings-icon"></svg-icon>
-          <span t="settings.myHomeArea" class="settings-row-label"></span>
-        </div>
+      <button click.trigger="openHomeSelector()" class="settings-row">
+        <svg-icon name="map-pin" class="settings-icon"></svg-icon>
+        <span t="settings.myHomeArea" class="settings-row-label"></span>
         <div class="settings-row-end">
           <span class="settings-row-value" t.bind="currentHomeKey"></span>
           <svg-icon name="chevron-right" class="settings-chevron"></svg-icon>
@@ -36,14 +35,9 @@
       <hr class="settings-divider">
 
       <!-- Language -->
-      <button
-        click.trigger="openLanguageSelector()"
-        class="settings-row"
-      >
-        <div class="settings-row-start">
-          <svg-icon name="globe" class="settings-icon"></svg-icon>
-          <span t="settings.language" class="settings-row-label"></span>
-        </div>
+      <button click.trigger="openLanguageSelector()" class="settings-row">
+        <svg-icon name="globe" class="settings-icon"></svg-icon>
+        <span t="settings.language" class="settings-row-label"></span>
         <div class="settings-row-end">
           <span class="settings-row-value" t.bind="'languages.' + currentLocale"></span>
           <svg-icon name="chevron-right" class="settings-chevron"></svg-icon>
@@ -52,7 +46,7 @@
 
       <hr class="settings-divider">
 
-      <!-- Push Notifications -->
+      <!-- Push Notifications (whole row is the switch) -->
       <button
         click.trigger="toggleNotifications()"
         role="switch"
@@ -61,14 +55,11 @@
         class="[ settings-row ] [ settings-row-toggle ]"
         data-disabled.bind="!vapidAvailable"
       >
+        <svg-icon name="bell" class="settings-icon"></svg-icon>
         <div class="settings-toggle-col">
-          <div class="settings-row-start">
-            <svg-icon name="bell" class="settings-icon"></svg-icon>
-            <span t="settings.pushNotifications" class="settings-row-label"></span>
-          </div>
-          <span if.bind="!vapidAvailable" t="settings.notAvailable" class="settings-row-hint"></span>
+          <span t="settings.pushNotifications" class="settings-row-label"></span>
+          <span if.bind="!vapidAvailable" t="settings.notAvailable" class="settings-toggle-desc"></span>
         </div>
-        <!-- Toggle switch -->
         <div class="settings-toggle-track" data-on.bind="notificationsEnabled">
           <div class="settings-toggle-thumb" data-on.bind="notificationsEnabled"></div>
         </div>
@@ -76,21 +67,18 @@
 
       <hr class="settings-divider">
 
-      <!-- Sound Effects -->
+      <!-- Sound Effects (whole row is the switch) -->
       <button
         click.trigger="toggleSound()"
         role="switch"
         aria-checked.bind="soundEnabled"
         class="[ settings-row ] [ settings-row-toggle ]"
       >
+        <svg-icon name="music" class="settings-icon"></svg-icon>
         <div class="settings-toggle-col">
-          <div class="settings-row-start">
-            <svg-icon name="music" class="settings-icon"></svg-icon>
-            <span t="settings.soundEffects" class="settings-row-label"></span>
-          </div>
+          <span t="settings.soundEffects" class="settings-row-label"></span>
           <span if.bind="isIOS" t="settings.soundEffectsHint" class="settings-toggle-desc"></span>
         </div>
-        <!-- Toggle switch -->
         <div class="settings-toggle-track" data-on.bind="soundEnabled">
           <div class="settings-toggle-thumb" data-on.bind="soundEnabled"></div>
         </div>
@@ -117,20 +105,21 @@
   <section>
     <h2 t="settings.analytics.sectionTitle" class="settings-section-title"></h2>
     <div class="settings-card">
-      <!-- Analytics consent. Disclosure (expand description) and switch are
-           sibling buttons: a role="switch" must never contain another
-           interactive control. -->
+      <!-- Analytics consent. Icon (col1), disclosure (col2), switch (col3) are
+           siblings — a role="switch" must never contain another interactive
+           control, and keeping the icon a direct row child aligns it with the
+           other rows' icons. -->
       <div class="[ settings-row ] [ settings-row-toggle ]">
+        <svg-icon name="info" class="settings-icon"></svg-icon>
         <button
           click.trigger="toggleAnalyticsDesc()"
           aria-expanded.bind="analyticsDescExpanded"
           class="settings-expand"
         >
-          <div class="settings-row-start">
-            <svg-icon name="info" class="settings-icon"></svg-icon>
+          <span class="settings-expand-head">
             <span t="settings.analytics.toggleLabel" class="settings-row-label"></span>
             <svg-icon name="chevron-right" class="settings-expand-caret" data-expanded.bind="analyticsDescExpanded"></svg-icon>
-          </div>
+          </span>
           <span
             if.bind="analyticsDescExpanded"
             t="settings.analytics.toggleDescription"
@@ -154,16 +143,16 @@
       <!-- Marketing-measurement consent. Labeled by purpose (ad-effectiveness
            measurement), not by data geography. -->
       <div class="[ settings-row ] [ settings-row-toggle ]">
+        <svg-icon name="globe" class="settings-icon"></svg-icon>
         <button
           click.trigger="toggleMarketingDesc()"
           aria-expanded.bind="marketingDescExpanded"
           class="settings-expand"
         >
-          <div class="settings-row-start">
-            <svg-icon name="globe" class="settings-icon"></svg-icon>
+          <span class="settings-expand-head">
             <span t="settings.analytics.marketingLabel" class="settings-row-label"></span>
             <svg-icon name="chevron-right" class="settings-expand-caret" data-expanded.bind="marketingDescExpanded"></svg-icon>
-          </div>
+          </span>
           <span
             if.bind="marketingDescExpanded"
             t="settings.analytics.marketingDescription"
@@ -184,17 +173,13 @@
     </div>
   </section>
 
-  <!-- ABOUT Section -->
+  <!-- ABOUT Section. Iconless rows: the label still lands in the content
+       column, so it lines up with the icon rows' labels above. -->
   <section>
     <h2 t="settings.about" class="settings-section-title"></h2>
     <div class="settings-card">
       <!-- Terms of Service -->
-      <a
-        href="https://liverty.me/terms"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="settings-row"
-      >
+      <a href="https://liverty.me/terms" target="_blank" rel="noopener noreferrer" class="settings-row">
         <span t="settings.termsOfService" class="settings-row-label"></span>
         <svg-icon name="chevron-right" class="settings-chevron"></svg-icon>
       </a>
@@ -202,12 +187,7 @@
       <hr class="settings-divider">
 
       <!-- Privacy Policy -->
-      <a
-        href="https://liverty.me/privacy"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="settings-row"
-      >
+      <a href="https://liverty.me/privacy" target="_blank" rel="noopener noreferrer" class="settings-row">
         <span t="settings.privacyPolicy" class="settings-row-label"></span>
         <svg-icon name="chevron-right" class="settings-chevron"></svg-icon>
       </a>
@@ -215,12 +195,7 @@
       <hr class="settings-divider">
 
       <!-- OSS Licenses -->
-      <a
-        href="https://liverty.me/licenses"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="settings-row"
-      >
+      <a href="https://liverty.me/licenses" target="_blank" rel="noopener noreferrer" class="settings-row">
         <span t="settings.ossLicenses" class="settings-row-label"></span>
         <svg-icon name="chevron-right" class="settings-chevron"></svg-icon>
       </a>
@@ -232,22 +207,19 @@
   <section if.bind="auth.isAuthenticated">
     <h2 t="settings.account" class="settings-section-title"></h2>
 
-    <!-- Authenticated: email verification + sign out -->
     <div class="settings-card">
       <!-- Email Verification -->
       <div class="settings-row">
-        <div class="settings-row-start">
-          <svg-icon name="mail" class="settings-icon"></svg-icon>
-          <div>
-            <span class="settings-row-label">${auth.user.profile.email}</span>
-            <span
-              class="settings-verification-badge"
-              data-verified.bind="emailVerified"
-            >
-              <span if.bind="emailVerified" t="settings.emailVerified"></span>
-              <span if.bind="!emailVerified" t="settings.emailNotVerified"></span>
-            </span>
-          </div>
+        <svg-icon name="mail" class="settings-icon"></svg-icon>
+        <div class="settings-account">
+          <span class="settings-row-label">${auth.user.profile.email}</span>
+          <span
+            class="settings-verification-badge"
+            data-verified.bind="emailVerified"
+          >
+            <span if.bind="emailVerified" t="settings.emailVerified"></span>
+            <span if.bind="!emailVerified" t="settings.emailNotVerified"></span>
+          </span>
         </div>
         <button
           if.bind="!emailVerified"
@@ -263,10 +235,7 @@
 
       <hr class="settings-divider">
 
-      <button
-        click.trigger="signOut()"
-        class="settings-row settings-sign-out"
-      >
+      <button click.trigger="signOut()" class="settings-row settings-sign-out">
         <span t="settings.signOut" class="settings-sign-out-text"></span>
       </button>
     </div>


### PR DESCRIPTION
## Summary

Refactors the settings list row layout from per-row flexbox to **card-grid + row-subgrid**, so column alignment (lead icon | content | trailing control) is guaranteed structurally across all row types. Follow-up to `redesign-settings-ui` (design decision D0); fixes the privacy-toggle misalignment reported against that UI.

## Problem

Each `.settings-row` was an independent flex container pushing its trailing control to the right edge. Cross-row alignment was *emergent* — it held only while every row's box model matched. It didn't: the consent rows wrapped the toggle in a `.settings-switch` button whose padding inset the track ~6–8px, so the privacy toggles sat out of line with the preference toggles. A single stray padding broke the whole column.

## Changes

- `.settings-card` → `display: grid; grid-template-columns: auto 1fr auto`.
- `.settings-row` → `grid-template-columns: subgrid` spanning the card tracks (explicit track list above as same-cascade fallback).
- Column placement: icon → col1, content → col2, trailing control → col3 (`justify-self: end`).
- Whole-row interactive rows (`<button>`/`<a>`) are themselves the subgrid container — element keeps its box and role; `display: contents` avoided. Split consent rows keep the icon as a direct row child, so no nested subgrid is needed (disclosure → col2, switch → col3).
- `.settings-row` resets `text-align: start` (a `<button>` inherits UA `text-align: center`, which centred the stretched col2 label).
- Opt-out rows — sign-out (centred), volume slider (full-width flex), dividers — span `grid-column: 1 / -1`.

## Testing

- Measured at 412px across every row type (nav, toggle, consent collapsed + expanded, about, email, sign-out): icons aligned (col1), labels aligned within icon cards (col2), **all trailing controls — toggles, chevrons, resend button — aligned at the same right edge (col3)**.
- `make check` green (biome, stylelint incl. CUBE-CSS plugin, typecheck, brand-vocabulary, tests).
- 33/33 `settings-route` unit tests pass (VM unchanged).

## Notes

- Subgrid is Baseline (since 2023-09-15, incl. iOS Safari 16+) per `modern-web-guidance`; layout-engine choice per `web-design-specialist`.
- No CUBE-CSS lint violations; the only stylelint findings were property-order warnings, auto-fixed.
- Intentional layout change — visual baselines may regenerate on the next main run.

close: #408
