### PR TITLE
feat(live-highway): redesign ticket status journey control

### DIFF
--- a/e2e/visual/ticket-journey.visual.spec.ts
+++ b/e2e/visual/ticket-journey.visual.spec.ts
@@ -194,10 +194,10 @@ test.describe.fixme('Detail sheet journey controls visual regression', () => {
 		)
 		await trackingBtn.click()
 		await expect
-			.poll(async () => trackingBtn.getAttribute('data-active'), {
+			.poll(async () => trackingBtn.getAttribute('aria-checked'), {
 				timeout: 3_000,
 			})
-			.not.toBeNull()
+			.toBe('true')
 
 		await expect(page).toHaveScreenshot(
 			'ticket-journey-status-active.png',

--- a/src/adapter/rpc/mapper/concert-mapper.ts
+++ b/src/adapter/rpc/mapper/concert-mapper.ts
@@ -62,7 +62,6 @@ export function concertFrom(
 		artistId: artist?.id || '',
 		venueName,
 		locationLabel,
-		adminArea,
 		date: jsDate,
 		startTime,
 		openTime,

--- a/src/components/live-highway/event-card.css
+++ b/src/components/live-highway/event-card.css
@@ -95,29 +95,32 @@
 			background: var(--_journey-bg);
 		}
 
+		/* Hues sourced from shared journey-hue tokens; the badge keeps its own
+		   translucent-pill lightness/chroma. Single source of semantic identity
+		   shared with the detail-sheet flow nodes. */
 		.journey-badge[data-journey-status="tracking"] {
-			--_journey-bg: oklch(65% 0.18 255deg / 85%);
-			--_journey-text: oklch(95% 0.02 255deg);
+			--_journey-bg: oklch(65% 0.18 var(--journey-hue-tracking) / 85%);
+			--_journey-text: oklch(95% 0.02 var(--journey-hue-tracking));
 		}
 
 		.journey-badge[data-journey-status="applied"] {
-			--_journey-bg: oklch(65% 0.15 195deg / 85%);
-			--_journey-text: oklch(95% 0.02 195deg);
+			--_journey-bg: oklch(65% 0.15 var(--journey-hue-applied) / 85%);
+			--_journey-text: oklch(95% 0.02 var(--journey-hue-applied));
 		}
 
 		.journey-badge[data-journey-status="lost"] {
-			--_journey-bg: oklch(45% 0.08 0deg / 85%);
-			--_journey-text: oklch(75% 0.05 0deg);
+			--_journey-bg: oklch(45% 0.08 var(--journey-hue-lost) / 85%);
+			--_journey-text: oklch(75% 0.05 var(--journey-hue-lost));
 		}
 
 		.journey-badge[data-journey-status="unpaid"] {
-			--_journey-bg: oklch(65% 0.18 55deg / 85%);
-			--_journey-text: oklch(95% 0.02 55deg);
+			--_journey-bg: oklch(65% 0.18 var(--journey-hue-unpaid) / 85%);
+			--_journey-text: oklch(95% 0.02 var(--journey-hue-unpaid));
 		}
 
 		.journey-badge[data-journey-status="paid"] {
-			--_journey-bg: oklch(65% 0.18 152deg / 85%);
-			--_journey-text: oklch(95% 0.02 152deg);
+			--_journey-bg: oklch(65% 0.18 var(--journey-hue-paid) / 85%);
+			--_journey-text: oklch(95% 0.02 var(--journey-hue-paid));
 		}
 
 		/* =============================================

--- a/src/components/live-highway/event-detail-sheet.css
+++ b/src/components/live-highway/event-detail-sheet.css
@@ -114,13 +114,103 @@
 			color: var(--color-text-secondary);
 		}
 
-		.journey-controls {
+		.journey {
 			display: flex;
-			flex-wrap: wrap;
+			flex-direction: column;
+			gap: var(--space-xs);
+		}
+
+		.journey-phase {
+			display: flex;
+			flex-direction: column;
 			gap: var(--space-3xs);
 		}
 
-		.journey-btn {
+		.journey-phase-label {
+			display: flex;
+			gap: var(--space-2xs);
+			align-items: baseline;
+
+			font-size: var(--step--2);
+			color: var(--color-text-muted);
+			text-transform: uppercase;
+			letter-spacing: 0.05em;
+		}
+
+		.journey-pending-tag {
+			font-size: var(--step--2);
+			color: var(--color-text-muted);
+			text-transform: none;
+			letter-spacing: normal;
+
+			opacity: 0.85;
+		}
+
+		.journey-process {
+			display: flex;
+			gap: var(--space-3xs);
+			align-items: stretch;
+		}
+
+		.journey-outcome {
+			display: flex;
+			flex-direction: column;
+			gap: var(--space-2xs);
+		}
+
+		/* Outcome phase is de-emphasized until a result is reached */
+		.journey-phase[data-pending] .journey-outcome {
+			opacity: 0.55;
+		}
+
+		/* Both outcome routes share the same card framing */
+		.journey-route {
+			padding: var(--space-2xs);
+			border: 1px solid var(--_border-light);
+			border-radius: var(--radius-card);
+		}
+
+		/* Mutually exclusive routes: the unchosen route is dimmed */
+		.journey-route[data-dimmed] {
+			opacity: 0.4;
+		}
+
+		.journey-route-success {
+			display: flex;
+			flex-direction: column;
+			gap: var(--space-3xs);
+		}
+
+		.journey-route-label {
+			font-size: var(--step--2);
+			font-weight: 500;
+			color: var(--color-text-secondary);
+			text-transform: uppercase;
+			letter-spacing: 0.05em;
+		}
+
+		.journey-arrow {
+			align-self: center;
+			color: var(--color-text-muted);
+
+			&::before {
+				content: "\203a"; /* > */
+			}
+		}
+
+		.journey-arrow-down::before {
+			content: "\2193"; /* down */
+		}
+
+		/* Node: contrast comes from fill (current) vs outline (others) */
+		.journey-node {
+			display: inline-flex;
+			flex: 1 1 auto;
+			gap: var(--space-3xs);
+			align-items: center;
+			justify-content: center;
+
+			min-block-size: 2.75rem; /* 44px tap target */
 			padding-block: var(--space-3xs);
 			padding-inline: var(--space-2xs);
 			border: 1px solid var(--_border-light);
@@ -141,47 +231,81 @@
 				opacity: 0.5;
 			}
 
-			&:hover:not(:disabled) {
-				border-color: var(--_border-light-hover);
-				color: var(--color-text-primary);
-				background: var(--_bg-hover);
+			&:focus-visible {
+				outline: 2px solid var(--color-brand-primary);
+				outline-offset: 2px;
 			}
 		}
 
-		.journey-btn[data-active] {
-			border-color: var(--_journey-border);
-			color: var(--_journey-text);
-			background: var(--_journey-bg);
+		/* Hover affordance applies to every still-selectable node except the
+		   current one, so it never overrides the current node's solid fill while
+		   keeping feedback on the re-selectable completed nodes. */
+		.journey-node:not([data-state="current"]):hover:not(:disabled) {
+			border-color: var(--_border-light-hover);
+			color: var(--color-text-primary);
+			background: var(--_bg-hover);
 		}
 
-		.journey-btn[data-journey-status="tracking"] {
-			--_journey-border: oklch(65% 0.18 255deg);
-			--_journey-text: oklch(90% 0.05 255deg);
-			--_journey-bg: oklch(65% 0.18 255deg / 25%);
+		/* Cue glyph is chosen via a custom property to keep selector specificity low */
+		.journey-node-cue {
+			font-weight: 700;
+
+			&::before {
+				content: var(--_cue, "\25cb"); /* default: circle (future) */
+			}
 		}
 
-		.journey-btn[data-journey-status="applied"] {
-			--_journey-border: oklch(65% 0.15 195deg);
-			--_journey-text: oklch(90% 0.05 195deg);
-			--_journey-bg: oklch(65% 0.15 195deg / 25%);
+		/* Completed: low-emphasis outline with a check cue */
+		.journey-node[data-state="completed"] {
+			--_cue: "\2713"; /* check */
+
+			border-color: var(--_node-faint);
+			color: var(--color-text-muted);
 		}
 
-		.journey-btn[data-journey-status="lost"] {
-			--_journey-border: oklch(55% 0.1 0deg);
-			--_journey-text: oklch(80% 0.05 0deg);
-			--_journey-bg: oklch(45% 0.08 0deg / 25%);
+		/* Current: the single solid-filled node */
+		.journey-node[data-state="current"] {
+			--_cue: "\25cf"; /* filled dot */
+
+			border-color: var(--_node-fill);
+			font-weight: 700;
+			color: var(--_node-on);
+			background: var(--_node-fill);
 		}
 
-		.journey-btn[data-journey-status="unpaid"] {
-			--_journey-border: oklch(65% 0.18 55deg);
-			--_journey-text: oklch(90% 0.05 55deg);
-			--_journey-bg: oklch(65% 0.18 55deg / 25%);
+		.journey-node[data-state="current"][data-journey-status="unpaid"] {
+			--_cue: "\0021"; /* ! action required */
 		}
 
-		.journey-btn[data-journey-status="paid"] {
-			--_journey-border: oklch(65% 0.18 152deg);
-			--_journey-text: oklch(90% 0.05 152deg);
-			--_journey-bg: oklch(65% 0.18 152deg / 25%);
+		.journey-node[data-state="current"][data-journey-status="lost"] {
+			--_cue: "\2715"; /* cross */
+		}
+
+		/* Semantic hue per status sourced from shared journey-hue tokens;
+		   lightness/chroma stay local to this control's solid-fill treatment. */
+		.journey-node[data-journey-status="tracking"],
+		.journey-node[data-journey-status="applied"] {
+			--_node-fill: oklch(56% 0.14 var(--journey-hue-tracking));
+			--_node-on: oklch(98% 0.02 var(--journey-hue-tracking));
+			--_node-faint: oklch(62% 0.08 var(--journey-hue-tracking) / 45%);
+		}
+
+		.journey-node[data-journey-status="unpaid"] {
+			--_node-fill: oklch(72% 0.16 var(--journey-hue-unpaid));
+			--_node-on: oklch(25% 0.05 var(--journey-hue-unpaid));
+			--_node-faint: oklch(72% 0.1 var(--journey-hue-unpaid) / 45%);
+		}
+
+		.journey-node[data-journey-status="paid"] {
+			--_node-fill: oklch(58% 0.15 var(--journey-hue-paid));
+			--_node-on: oklch(98% 0.02 var(--journey-hue-paid));
+			--_node-faint: oklch(62% 0.09 var(--journey-hue-paid) / 45%);
+		}
+
+		.journey-node[data-journey-status="lost"] {
+			--_node-fill: oklch(52% 0.16 var(--journey-hue-lost));
+			--_node-on: oklch(98% 0.02 var(--journey-hue-lost));
+			--_node-faint: oklch(58% 0.09 var(--journey-hue-lost) / 45%);
 		}
 
 		.journey-remove-btn {
@@ -245,6 +369,14 @@
 				border-color: var(--_border-light-hover);
 				color: var(--color-text-primary);
 				background: var(--_bg-hover);
+			}
+		}
+
+		@media (prefers-reduced-motion: reduce) {
+			.journey-node,
+			.sheet-btn-primary,
+			.sheet-btn-secondary {
+				transition: none;
 			}
 		}
 	}

--- a/src/components/live-highway/event-detail-sheet.html
+++ b/src/components/live-highway/event-detail-sheet.html
@@ -50,7 +50,7 @@
           <span class="detail-icon"><svg-icon name="map-pin"></svg-icon></span>
           <div>
             <p class="detail-primary">${event.venueName}</p>
-            <p if.bind="event.adminArea" class="detail-secondary">${event.adminArea}</p>
+            <p if.bind="event.locationLabel" class="detail-secondary">${event.locationLabel}</p>
             <a
               href.bind="googleMapsUrl"
               target="_blank"
@@ -64,19 +64,123 @@
 
       <!-- Ticket journey status -->
       <section if.bind="isAuthenticated" class="sheet-journey" data-testid="sheet-journey">
-        <h3 class="journey-heading" t="eventDetail.ticketStatus"></h3>
-        <div class="journey-controls">
-          <button
-            repeat.for="s of journeyStatuses"
-            class="journey-btn"
-            data-testid="journey-btn"
-            data-journey-status.bind="s"
-            data-active.bind="event.journeyStatus === s || undefined"
-            disabled.bind="journeyUpdating"
-            click.trigger="setJourneyStatus(s)"
-            t.bind="'eventDetail.journeyStatus.' + s"
-          ></button>
+        <h3 id="journey-status-heading" class="journey-heading" t="eventDetail.ticketStatus"></h3>
+
+        <div
+          class="journey"
+          role="radiogroup"
+          aria-labelledby="journey-status-heading"
+          keydown.trigger="onJourneyKeydown($event)"
+        >
+          <!-- (1) Application process: tracking -> applied -->
+          <div class="journey-phase">
+            <p class="journey-phase-label" t="eventDetail.journeyPhase.process"></p>
+            <div class="journey-process">
+              <button
+                class="journey-node"
+                role="radio"
+                data-testid="journey-btn"
+                data-journey-status="tracking"
+                data-state.bind="nodeStates.tracking"
+                aria-checked.bind="event.journeyStatus === 'tracking'"
+                tabindex.bind="journeyTabindex('tracking')"
+                disabled.bind="journeyUpdating"
+                click.trigger="setJourneyStatus('tracking')"
+              >
+                <span class="journey-node-cue" aria-hidden="true"></span>
+                <span class="journey-node-label" t="eventDetail.journeyStatus.tracking"></span>
+              </button>
+              <span class="journey-arrow" aria-hidden="true"></span>
+              <button
+                class="journey-node"
+                role="radio"
+                data-testid="journey-btn"
+                data-journey-status="applied"
+                data-state.bind="nodeStates.applied"
+                aria-checked.bind="event.journeyStatus === 'applied'"
+                tabindex.bind="journeyTabindex('applied')"
+                disabled.bind="journeyUpdating"
+                click.trigger="setJourneyStatus('applied')"
+              >
+                <span class="journey-node-cue" aria-hidden="true"></span>
+                <span class="journey-node-label" t="eventDetail.journeyStatus.applied"></span>
+              </button>
+            </div>
+          </div>
+
+          <!-- (2) Outcome: success route (top) and failure route (below) -->
+          <div class="journey-phase" data-pending.bind="outcomePending || undefined">
+            <p class="journey-phase-label">
+              <span t="eventDetail.journeyPhase.outcome"></span>
+              <span
+                if.bind="outcomePending"
+                class="journey-pending-tag"
+                t="eventDetail.journeyPhase.pending"
+              ></span>
+            </p>
+
+            <div class="journey-outcome">
+              <!-- Win route: 当選 -> unpaid -> paid -->
+              <div
+                class="journey-route journey-route-success"
+                data-dimmed.bind="successDimmed || undefined"
+              >
+                <p class="journey-route-label" t="eventDetail.journeyRoute.won"></p>
+                <button
+                  class="journey-node"
+                  role="radio"
+                  data-testid="journey-btn"
+                  data-journey-status="unpaid"
+                  data-state.bind="nodeStates.unpaid"
+                  aria-checked.bind="event.journeyStatus === 'unpaid'"
+                  tabindex.bind="journeyTabindex('unpaid')"
+                  disabled.bind="journeyUpdating"
+                  click.trigger="setJourneyStatus('unpaid')"
+                >
+                  <span class="journey-node-cue" aria-hidden="true"></span>
+                  <span class="journey-node-label" t="eventDetail.journeyStatus.unpaid"></span>
+                </button>
+                <span class="journey-arrow journey-arrow-down" aria-hidden="true"></span>
+                <button
+                  class="journey-node"
+                  role="radio"
+                  data-testid="journey-btn"
+                  data-journey-status="paid"
+                  data-state.bind="nodeStates.paid"
+                  aria-checked.bind="event.journeyStatus === 'paid'"
+                  tabindex.bind="journeyTabindex('paid')"
+                  disabled.bind="journeyUpdating"
+                  click.trigger="setJourneyStatus('paid')"
+                >
+                  <span class="journey-node-cue" aria-hidden="true"></span>
+                  <span class="journey-node-label" t="eventDetail.journeyStatus.paid"></span>
+                </button>
+              </div>
+
+              <!-- Lose route: lost -->
+              <div
+                class="journey-route journey-route-failure"
+                data-dimmed.bind="failureDimmed || undefined"
+              >
+                <button
+                  class="journey-node"
+                  role="radio"
+                  data-testid="journey-btn"
+                  data-journey-status="lost"
+                  data-state.bind="nodeStates.lost"
+                  aria-checked.bind="event.journeyStatus === 'lost'"
+                  tabindex.bind="journeyTabindex('lost')"
+                  disabled.bind="journeyUpdating"
+                  click.trigger="setJourneyStatus('lost')"
+                >
+                  <span class="journey-node-cue" aria-hidden="true"></span>
+                  <span class="journey-node-label" t="eventDetail.journeyStatus.lost"></span>
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
+
         <button
           if.bind="event.journeyStatus"
           class="journey-remove-btn" data-testid="journey-remove-btn"

--- a/src/components/live-highway/event-detail-sheet.ts
+++ b/src/components/live-highway/event-detail-sheet.ts
@@ -1,7 +1,13 @@
 import { bindable, ILogger, resolve } from 'aurelia'
 import { IHistory } from '../../adapter/browser/history'
-import { displayName } from '../../constants/iso3166'
 import { bestBackgroundUrl } from '../../entities/artist'
+import {
+	JOURNEY_NAV_ORDER,
+	type JourneyNodeState,
+	type JourneyOutcome,
+	journeyNodeState,
+	journeyOutcome,
+} from '../../entities/ticket-journey'
 import {
 	Events,
 	IAnalyticsService,
@@ -41,7 +47,7 @@ export class EventDetailSheet {
 
 	public get googleMapsUrl(): string {
 		if (!this.event) return '#'
-		const area = this.event.adminArea ? displayName(this.event.adminArea) : ''
+		const area = this.event.locationLabel
 		const query = area
 			? `${this.event.venueName} ${area}`
 			: this.event.venueName
@@ -103,8 +109,92 @@ export class EventDetailSheet {
 		this.close()
 	}
 
-	public get journeyStatuses(): JourneyStatus[] {
-		return ['tracking', 'applied', 'lost', 'unpaid', 'paid']
+	/**
+	 * Per-status display state derived from the single stored `journeyStatus`,
+	 * using the fixed journey DAG: tracking → applied → { lost | unpaid → paid }.
+	 * `current` is the selected node, `completed` the nodes already passed on its
+	 * path, `future` the not-yet-reached nodes. Mutual exclusivity of the win/lose
+	 * routes is handled at the route-container level (see successDimmed/failureDimmed).
+	 */
+	public get nodeStates(): Record<JourneyStatus, JourneyNodeState> {
+		const current = this.event?.journeyStatus
+		return {
+			tracking: journeyNodeState('tracking', current),
+			applied: journeyNodeState('applied', current),
+			lost: journeyNodeState('lost', current),
+			unpaid: journeyNodeState('unpaid', current),
+			paid: journeyNodeState('paid', current),
+		}
+	}
+
+	/**
+	 * Roving tabindex for the journey radiogroup: exactly one node is a tab stop
+	 * (the selected status, or the first node when nothing is selected yet).
+	 */
+	public journeyTabindex(status: JourneyStatus): number {
+		const active = this.event?.journeyStatus ?? JOURNEY_NAV_ORDER[0]
+		return status === active ? 0 : -1
+	}
+
+	/**
+	 * ARIA radio keyboard pattern: arrow keys (and Home/End) move focus along the
+	 * journey graph and select the focused node. Selection follows focus, matching
+	 * the WAI-ARIA radiogroup contract that screen readers announce.
+	 */
+	public async onJourneyKeydown(event: KeyboardEvent): Promise<void> {
+		const order = JOURNEY_NAV_ORDER
+		const current = this.event?.journeyStatus ?? order[0]
+		let index = order.indexOf(current)
+		switch (event.key) {
+			case 'ArrowRight':
+			case 'ArrowDown':
+				index = (index + 1) % order.length
+				break
+			case 'ArrowLeft':
+			case 'ArrowUp':
+				index = (index - 1 + order.length) % order.length
+				break
+			case 'Home':
+				index = 0
+				break
+			case 'End':
+				index = order.length - 1
+				break
+			default:
+				return
+		}
+		event.preventDefault()
+		// Capture the group element before awaiting — `currentTarget` is nulled
+		// once the event finishes dispatching.
+		const group = event.currentTarget as HTMLElement
+		const next = order[index]
+		await this.setJourneyStatus(next)
+		// Move focus only after the status update settles, so the target button
+		// (briefly disabled while updating) is focusable again.
+		group.querySelector<HTMLElement>(`[data-journey-status="${next}"]`)?.focus()
+	}
+
+	/**
+	 * Single classification of the win/lose fork; the gating and per-route
+	 * dimming below all derive from it so the rule lives in one place.
+	 */
+	public get outcome(): JourneyOutcome {
+		return journeyOutcome(this.event?.journeyStatus)
+	}
+
+	/** The outcome phase is shown dimmed ("結果待ち") until a result is reached. */
+	public get outcomePending(): boolean {
+		return this.outcome === 'pending'
+	}
+
+	/** Win route is dimmed once the mutually-exclusive loss is recorded. */
+	public get successDimmed(): boolean {
+		return this.outcome === 'lost'
+	}
+
+	/** Loss route is dimmed once the mutually-exclusive win is recorded. */
+	public get failureDimmed(): boolean {
+		return this.outcome === 'won'
 	}
 
 	public get openTimeOrFallback(): string {
@@ -113,10 +203,13 @@ export class EventDetailSheet {
 
 	public async setJourneyStatus(status: JourneyStatus): Promise<void> {
 		if (!this.event || this.journeyUpdating) return
+		// Capture the event so a sheet reopen on a different concert mid-request
+		// cannot redirect the write to the wrong event after the await.
+		const event = this.event
 		this.journeyUpdating = true
 		try {
-			await this.journeyService.setStatus(this.event.id, status)
-			this.event.journeyStatus = status
+			await this.journeyService.setStatus(event.id, status)
+			event.journeyStatus = status
 		} catch (err) {
 			this.logger.warn('Failed to set journey status', { error: err })
 		} finally {
@@ -126,10 +219,11 @@ export class EventDetailSheet {
 
 	public async removeJourney(): Promise<void> {
 		if (!this.event || this.journeyUpdating) return
+		const event = this.event
 		this.journeyUpdating = true
 		try {
-			await this.journeyService.delete(this.event.id)
-			this.event.journeyStatus = undefined
+			await this.journeyService.delete(event.id)
+			event.journeyStatus = undefined
 		} catch (err) {
 			this.logger.warn('Failed to remove journey', { error: err })
 		} finally {

--- a/src/entities/concert.ts
+++ b/src/entities/concert.ts
@@ -20,7 +20,6 @@ export interface Concert {
 	artistId: string
 	venueName: string
 	locationLabel: string
-	adminArea?: string
 	date: Date
 	startTime: string
 	openTime?: string

--- a/src/entities/ticket-journey.ts
+++ b/src/entities/ticket-journey.ts
@@ -1,0 +1,60 @@
+import type { JourneyStatus } from './concert'
+
+/**
+ * The ticket-acquisition journey as a fixed state machine:
+ * `tracking → applied → { lost | unpaid → paid }`.
+ *
+ * This is domain knowledge (the order and branching of the journey), kept here
+ * as the single source of truth rather than embedded in a component, so every
+ * consumer (detail sheet, future timeline, tests) derives from the same graph.
+ */
+
+/** Display state of a single journey node relative to the current status. */
+export type JourneyNodeState = 'completed' | 'current' | 'future'
+
+/**
+ * Linear focus/navigation order across the branching graph, used for keyboard
+ * arrow navigation of the journey radiogroup (DOM order: process then outcome).
+ */
+export const JOURNEY_NAV_ORDER: readonly JourneyStatus[] = [
+	'tracking',
+	'applied',
+	'unpaid',
+	'paid',
+	'lost',
+]
+
+/** Nodes already passed for each status, per the journey DAG. */
+const COMPLETED_BY: Record<JourneyStatus, readonly JourneyStatus[]> = {
+	tracking: [],
+	applied: ['tracking'],
+	lost: ['tracking', 'applied'],
+	unpaid: ['tracking', 'applied'],
+	paid: ['tracking', 'applied', 'unpaid'],
+}
+
+/** Resolve a node's display state relative to the current status. */
+export function journeyNodeState(
+	node: JourneyStatus,
+	current: JourneyStatus | undefined,
+): JourneyNodeState {
+	if (node === current) return 'current'
+	if (current && COMPLETED_BY[current].includes(node)) return 'completed'
+	return 'future'
+}
+
+/**
+ * Which side of the win/lose fork the journey has resolved to. `pending` means
+ * no result is recorded yet (before/at application). Single source for the
+ * outcome-phase gating and the mutual-exclusivity dimming of the two routes.
+ */
+export type JourneyOutcome = 'pending' | 'won' | 'lost'
+
+/** Classify the current status into the outcome fork. */
+export function journeyOutcome(
+	current: JourneyStatus | undefined,
+): JourneyOutcome {
+	if (current === 'unpaid' || current === 'paid') return 'won'
+	if (current === 'lost') return 'lost'
+	return 'pending'
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -124,6 +124,14 @@
 		"stopTracking": "Stop tracking",
 		"viewOfficialInfo": "View Official Info",
 		"addToCalendar": "Add to Calendar",
+		"journeyPhase": {
+			"process": "Application",
+			"outcome": "Result",
+			"pending": "Pending"
+		},
+		"journeyRoute": {
+			"won": "Won"
+		},
 		"journeyStatus": {
 			"tracking": "Tracking",
 			"applied": "Applied",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -124,6 +124,14 @@
 		"stopTracking": "追跡を停止",
 		"viewOfficialInfo": "公式情報を見る",
 		"addToCalendar": "カレンダーに追加",
+		"journeyPhase": {
+			"process": "申込フロー",
+			"outcome": "結果",
+			"pending": "結果待ち"
+		},
+		"journeyRoute": {
+			"won": "当選"
+		},
 		"journeyStatus": {
 			"tracking": "追跡中",
 			"applied": "申込済み",

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -26,6 +26,15 @@
 		--color-success: oklch(80% 0.18 152deg);
 		--color-white: oklch(100% 0 0deg);
 
+		/* Ticket journey status hues — single source of semantic identity,
+		   shared by the dashboard card badge and the detail-sheet flow nodes.
+		   Each consumer chooses its own lightness/chroma/opacity. */
+		--journey-hue-tracking: 255deg; /* process — neutral blue */
+		--journey-hue-applied: 255deg; /* process — neutral blue */
+		--journey-hue-unpaid: 75deg; /* action required — amber */
+		--journey-hue-paid: 150deg; /* success — green */
+		--journey-hue-lost: 25deg; /* failure — red */
+
 		/* Border colors */
 		--color-border-subtle: oklch(98.5% 0 0deg / 12%);
 		--color-border-muted: oklch(98.5% 0 0deg / 22%);

--- a/test/adapter/rpc/mapper/concert-mapper.spec.ts
+++ b/test/adapter/rpc/mapper/concert-mapper.spec.ts
@@ -85,7 +85,6 @@ describe('concertFrom', () => {
 		expect(result!.title).toBe('Test Concert')
 		expect(result!.venueName).toBe('Zepp DiverCity')
 		expect(result!.locationLabel).toBe('Display(JP-13)')
-		expect(result!.adminArea).toBe('JP-13')
 		expect(result!.sourceUrl).toBe('https://example.com')
 		expect(result!.hypeLevel).toBe('home')
 		expect(result!.matched).toBe(true)
@@ -157,7 +156,6 @@ describe('concertFrom', () => {
 		})
 		const result = concertFrom(proto as any, 'Artist', 'watch', false)
 		expect(result!.locationLabel).toBe('')
-		expect(result!.adminArea).toBeUndefined()
 	})
 
 	it('attaches artist when provided', () => {

--- a/test/components/live-highway/event-detail-sheet.spec.ts
+++ b/test/components/live-highway/event-detail-sheet.spec.ts
@@ -18,7 +18,6 @@ function makeEvent(overrides: Partial<LiveEvent> = {}): LiveEvent {
 		artistId: 'a1',
 		venueName: 'Test Venue',
 		locationLabel: 'Tokyo',
-		adminArea: 'Tokyo',
 		date: new Date(2026, 2, 15), // March 15, 2026
 		startTime: '19:00',
 		title: 'Test Concert',
@@ -65,16 +64,16 @@ describe('EventDetailSheet', () => {
 	})
 
 	describe('googleMapsUrl', () => {
-		it('should construct URL with venue and admin area', () => {
-			sut.event = makeEvent({ venueName: 'Budokan', adminArea: 'Tokyo' })
+		it('should construct URL with venue and localized area label', () => {
+			sut.event = makeEvent({ venueName: 'Budokan', locationLabel: 'Tokyo' })
 
 			expect(sut.googleMapsUrl).toBe(
 				'https://www.google.com/maps/search/?api=1&query=Budokan%20Tokyo',
 			)
 		})
 
-		it('should use only venue name when no admin area', () => {
-			sut.event = makeEvent({ venueName: 'Budokan', adminArea: undefined })
+		it('should use only venue name when no area label', () => {
+			sut.event = makeEvent({ venueName: 'Budokan', locationLabel: '' })
 
 			expect(sut.googleMapsUrl).toBe(
 				'https://www.google.com/maps/search/?api=1&query=Budokan',
@@ -220,6 +219,190 @@ describe('EventDetailSheet', () => {
 			window.dispatchEvent(new PopStateEvent('popstate'))
 
 			expect(closeSpy).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('journey view-model', () => {
+		it('marks passed states completed, current solid, future outlined (paid)', () => {
+			sut.event = makeEvent({ journeyStatus: 'paid' })
+
+			expect(sut.nodeStates).toEqual({
+				tracking: 'completed',
+				applied: 'completed',
+				unpaid: 'completed',
+				paid: 'current',
+				lost: 'future',
+			})
+		})
+
+		it('treats outcome as future while applied (result pending)', () => {
+			sut.event = makeEvent({ journeyStatus: 'applied' })
+
+			expect(sut.nodeStates).toEqual({
+				tracking: 'completed',
+				applied: 'current',
+				lost: 'future',
+				unpaid: 'future',
+				paid: 'future',
+			})
+			expect(sut.outcomePending).toBe(true)
+		})
+
+		it('keeps outcome pending for tracking and undefined', () => {
+			sut.event = makeEvent({ journeyStatus: 'tracking' })
+			expect(sut.outcomePending).toBe(true)
+
+			sut.event = makeEvent({ journeyStatus: undefined })
+			expect(sut.outcomePending).toBe(true)
+		})
+
+		it('clears outcome pending once a result is recorded', () => {
+			for (const status of ['lost', 'unpaid', 'paid'] as const) {
+				sut.event = makeEvent({ journeyStatus: status })
+				expect(sut.outcomePending).toBe(false)
+			}
+		})
+
+		it('dims the win route when a loss is recorded', () => {
+			sut.event = makeEvent({ journeyStatus: 'lost' })
+
+			expect(sut.successDimmed).toBe(true)
+			expect(sut.failureDimmed).toBe(false)
+			expect(sut.nodeStates.lost).toBe('current')
+		})
+
+		it('dims the loss route when a win is recorded', () => {
+			for (const status of ['unpaid', 'paid'] as const) {
+				sut.event = makeEvent({ journeyStatus: status })
+				expect(sut.failureDimmed).toBe(true)
+				expect(sut.successDimmed).toBe(false)
+			}
+		})
+
+		it('exposes exactly one current node per status', () => {
+			for (const status of [
+				'tracking',
+				'applied',
+				'lost',
+				'unpaid',
+				'paid',
+			] as const) {
+				sut.event = makeEvent({ journeyStatus: status })
+				const current = Object.values(sut.nodeStates).filter(
+					(s) => s === 'current',
+				)
+				expect(current).toHaveLength(1)
+			}
+		})
+	})
+
+	describe('journey radiogroup keyboard navigation', () => {
+		// Build a KeyboardEvent stub whose currentTarget mimics the radiogroup
+		// element: querySelector returns a focusable node we can assert on.
+		function makeKeydown(key: string) {
+			const focused = { focus: vi.fn() }
+			const group = { querySelector: vi.fn(() => focused) }
+			const event = {
+				key,
+				preventDefault: vi.fn(),
+				currentTarget: group,
+			} as unknown as KeyboardEvent
+			return { event, group, focused }
+		}
+
+		it('gives the selected status the only tab stop (roving tabindex)', () => {
+			sut.event = makeEvent({ journeyStatus: 'paid' })
+			expect(sut.journeyTabindex('paid')).toBe(0)
+			expect(sut.journeyTabindex('tracking')).toBe(-1)
+			expect(sut.journeyTabindex('lost')).toBe(-1)
+		})
+
+		it('makes the first node the tab stop when nothing is selected', () => {
+			sut.event = makeEvent({ journeyStatus: undefined })
+			expect(sut.journeyTabindex('tracking')).toBe(0)
+			expect(sut.journeyTabindex('applied')).toBe(-1)
+		})
+
+		it('ArrowRight selects the next node and moves focus to it', async () => {
+			sut.event = makeEvent({ journeyStatus: 'tracking' })
+			const setStatus = vi
+				.spyOn(
+					(
+						sut as unknown as {
+							journeyService: { setStatus: () => Promise<void> }
+						}
+					).journeyService,
+					'setStatus',
+				)
+				.mockResolvedValue(undefined)
+			const { event, group, focused } = makeKeydown('ArrowRight')
+
+			await sut.onJourneyKeydown(event)
+
+			expect(event.preventDefault).toHaveBeenCalled()
+			expect(setStatus).toHaveBeenCalledWith('c1', 'applied')
+			expect(group.querySelector).toHaveBeenCalledWith(
+				'[data-journey-status="applied"]',
+			)
+			expect(focused.focus).toHaveBeenCalled()
+		})
+
+		it('ArrowLeft wraps from the first node to the last', async () => {
+			sut.event = makeEvent({ journeyStatus: 'tracking' })
+			const setStatus = vi
+				.spyOn(
+					(
+						sut as unknown as {
+							journeyService: { setStatus: () => Promise<void> }
+						}
+					).journeyService,
+					'setStatus',
+				)
+				.mockResolvedValue(undefined)
+
+			await sut.onJourneyKeydown(makeKeydown('ArrowLeft').event)
+
+			expect(setStatus).toHaveBeenCalledWith('c1', 'lost')
+		})
+
+		it('Home and End jump to the first and last nodes', async () => {
+			sut.event = makeEvent({ journeyStatus: 'unpaid' })
+			const setStatus = vi
+				.spyOn(
+					(
+						sut as unknown as {
+							journeyService: { setStatus: () => Promise<void> }
+						}
+					).journeyService,
+					'setStatus',
+				)
+				.mockResolvedValue(undefined)
+
+			await sut.onJourneyKeydown(makeKeydown('Home').event)
+			expect(setStatus).toHaveBeenLastCalledWith('c1', 'tracking')
+
+			await sut.onJourneyKeydown(makeKeydown('End').event)
+			expect(setStatus).toHaveBeenLastCalledWith('c1', 'lost')
+		})
+
+		it('ignores non-navigation keys', async () => {
+			sut.event = makeEvent({ journeyStatus: 'tracking' })
+			const setStatus = vi
+				.spyOn(
+					(
+						sut as unknown as {
+							journeyService: { setStatus: () => Promise<void> }
+						}
+					).journeyService,
+					'setStatus',
+				)
+				.mockResolvedValue(undefined)
+			const { event } = makeKeydown('a')
+
+			await sut.onJourneyKeydown(event)
+
+			expect(event.preventDefault).not.toHaveBeenCalled()
+			expect(setStatus).not.toHaveBeenCalled()
 		})
 	})
 

--- a/test/entities/ticket-journey.spec.ts
+++ b/test/entities/ticket-journey.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import type { JourneyStatus } from '../../src/entities/concert'
+import {
+	JOURNEY_NAV_ORDER,
+	journeyNodeState,
+} from '../../src/entities/ticket-journey'
+
+describe('journeyNodeState', () => {
+	it('marks the matching node as current', () => {
+		expect(journeyNodeState('applied', 'applied')).toBe('current')
+	})
+
+	it('marks nodes on the path to the current status as completed', () => {
+		// paid implies tracking -> applied -> unpaid all passed
+		expect(journeyNodeState('tracking', 'paid')).toBe('completed')
+		expect(journeyNodeState('applied', 'paid')).toBe('completed')
+		expect(journeyNodeState('unpaid', 'paid')).toBe('completed')
+	})
+
+	it('marks not-yet-reached nodes as future', () => {
+		expect(journeyNodeState('paid', 'applied')).toBe('future')
+		expect(journeyNodeState('lost', 'applied')).toBe('future')
+	})
+
+	it('keeps the mutually exclusive branch as future, never completed', () => {
+		// On the win path, the loss node is never "completed"
+		expect(journeyNodeState('lost', 'paid')).toBe('future')
+		// On the loss path, win-only nodes are never "completed"
+		expect(journeyNodeState('unpaid', 'lost')).toBe('future')
+		expect(journeyNodeState('paid', 'lost')).toBe('future')
+	})
+
+	it('treats everything as future when no status is set', () => {
+		for (const node of JOURNEY_NAV_ORDER) {
+			expect(journeyNodeState(node, undefined)).toBe('future')
+		}
+	})
+
+	it('never reports a node as completed-by-itself', () => {
+		for (const status of JOURNEY_NAV_ORDER) {
+			expect(journeyNodeState(status, status)).toBe('current')
+		}
+	})
+})
+
+describe('JOURNEY_NAV_ORDER', () => {
+	it('covers every JourneyStatus exactly once', () => {
+		const all: JourneyStatus[] = [
+			'tracking',
+			'applied',
+			'lost',
+			'unpaid',
+			'paid',
+		]
+		expect([...JOURNEY_NAV_ORDER].sort()).toEqual([...all].sort())
+	})
+
+	it('follows DOM/visual order: process then outcome', () => {
+		expect(JOURNEY_NAV_ORDER).toEqual([
+			'tracking',
+			'applied',
+			'unpaid',
+			'paid',
+			'lost',
+		])
+	})
+})

--- a/test/helpers/mock-date-groups.ts
+++ b/test/helpers/mock-date-groups.ts
@@ -9,7 +9,6 @@ export function makeConcert(
 		artistId: 'artist-1',
 		venueName: 'Test Venue',
 		locationLabel: 'Tokyo',
-		adminArea: 'JP-13',
 		date: new Date('2026-04-01T19:00:00'),
 		startTime: '19:00',
 		title: 'Test Concert',


### PR DESCRIPTION
## Description

Redesigns the Ticket Status "journey" control in `EventDetailSheet` and fixes the venue label that displayed a raw region code.

**Journey UI redesign (#412)**
The flat horizontal pill row conveyed the selected status only via a 25%-opacity tint over the dark sheet (barely visible, worst for `LOST`) and hid the real branching journey. It is now a two-phase control:

- **① 申込フロー** — `TRACKING ▸ APPLIED` as a horizontal segment.
- **② 結果** — the 当選 success route (`UNPAID → PAID`, vertical mini-flow) stacked above a de-emphasised `LOST` route; the unchosen route dims (mutual exclusivity), and the whole phase is dimmed ("結果待ち") until a result is recorded.

Contrast now comes from a **solid fill on the current node** (not colour intensity), so the selection is unmistakable regardless of hue. Cumulative progress marks passed nodes as completed; semantic hues (`UNPAID`=amber, `PAID`=green, `LOST`=red, process=blue) are sourced from shared `--journey-hue-*` tokens reused by the dashboard badge. Keyboard a11y is a `role="radiogroup"` with roving `tabindex` and arrow/Home/End navigation (selection follows focus). The journey DAG is extracted to `entities/ticket-journey` as the single source of truth.

**Venue label fix (#413)**
The venue secondary line bound the raw `adminArea` ISO 3166-2 code (e.g. `JP-13`) instead of the localised label. It now binds `locationLabel` (as the dashboard card already does), and the unused raw `adminArea` is dropped from the `Concert` entity.

Frontend-only — no proto/backend changes.

## Type of Change

- [x] feat: A new feature
- [x] fix: A bug fix

## Verification

### Automated Tests
- [x] `npm run lint` passed (`make check`)
- [x] `npm run test` passed (1166 tests; new unit tests for node-state derivation, outcome classification, roving tabindex, and keyboard navigation)
- [x] `npm run build` passed

### Manual Verification
Drove the running app (authenticated, mocked RPC) under Playwright at the iPhone 14 viewport and captured all five journey states. Confirmed: two-phase layout, cumulative progress, exclusive-route dimming, `UNPAID` amber emphasis, `role=radiogroup`/`radio` with `aria-checked`, and the current node keeping its solid fill while hovered.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

Closes #412
Closes #413
