### PR TITLE
chore(onboarding): remove dead bringToFront / onBringToFront plumbing

### DIFF
--- a/src/components/coach-mark/coach-mark.spec.ts
+++ b/src/components/coach-mark/coach-mark.spec.ts
@@ -26,15 +26,12 @@ const fakeLogger = {
 	scopeTo: vi.fn(() => fakeLogger),
 }
 
-const fakeOnboarding = {
-	onBringToFront: undefined as (() => void) | undefined,
-}
+const fakeOnboarding = {}
 
 describe('CoachMark', () => {
 	let sut: CoachMark
 
 	beforeEach(() => {
-		fakeOnboarding.onBringToFront = undefined
 		sut = new CoachMark()
 	})
 
@@ -122,22 +119,7 @@ describe('CoachMark', () => {
 		})
 	})
 
-	describe('bound lifecycle', () => {
-		it('registers onBringToFront callback', () => {
-			sut.bound()
-
-			expect(fakeOnboarding.onBringToFront).toBeDefined()
-		})
-	})
-
 	describe('detaching lifecycle', () => {
-		it('unregisters onBringToFront callback', () => {
-			sut.bound()
-			sut.detaching()
-
-			expect(fakeOnboarding.onBringToFront).toBeUndefined()
-		})
-
 		it('sets visible to false', () => {
 			sut.visible = true
 			sut.detaching()

--- a/src/components/coach-mark/coach-mark.ts
+++ b/src/components/coach-mark/coach-mark.ts
@@ -1,5 +1,4 @@
 import { bindable, ILogger, resolve } from 'aurelia'
-import { IOnboardingService } from '../../services/onboarding-service'
 
 const MAX_RETRY_MS = 5000
 const INITIAL_RETRY_MS = 100
@@ -22,7 +21,6 @@ export class CoachMark {
 	private scrollEndHandler: (() => void) | null = null
 
 	private readonly logger = resolve(ILogger).scopeTo('CoachMark')
-	private readonly onboarding = resolve(IOnboardingService)
 
 	public activeChanged(): void {
 		if (this.active) {
@@ -33,14 +31,12 @@ export class CoachMark {
 	}
 
 	public bound(): void {
-		this.onboarding.onBringToFront = () => this.bringToFront()
 		if (this.active) {
 			this.findAndHighlight()
 		}
 	}
 
 	public detaching(): void {
-		this.onboarding.onBringToFront = undefined
 		this.deactivate()
 	}
 
@@ -150,23 +146,6 @@ export class CoachMark {
 			this.isPopoverOpen = false
 		}
 		this.cleanup()
-	}
-
-	/**
-	 * Re-insert the coach mark popover at the top of the LIFO stack.
-	 * Used when another popover (e.g. detail sheet) has entered the top layer
-	 * after the coach mark and needs to appear below it.
-	 */
-	public bringToFront(): void {
-		if (!this.isPopoverOpen) return
-		requestAnimationFrame(() => {
-			try {
-				this.overlayEl.hidePopover()
-				this.overlayEl.showPopover()
-			} catch {
-				// Popover state may have changed between frames
-			}
-		})
 	}
 
 	public onBlockerClick(): void {

--- a/src/services/onboarding-service.ts
+++ b/src/services/onboarding-service.ts
@@ -60,7 +60,6 @@ export class OnboardingService {
 
 	// Callbacks — not state, cannot live in a store
 	public onSpotlightTap: (() => void) | undefined = undefined
-	public onBringToFront: (() => void) | undefined = undefined
 
 	/**
 	 * Persist step to localStorage on change.
@@ -95,14 +94,6 @@ export class OnboardingService {
 		this.spotlightRadius = '12px'
 		this.spotlightActive = false
 		this.onSpotlightTap = undefined
-	}
-
-	/**
-	 * Re-insert the spotlight popover at the top of the LIFO stack.
-	 * Used when another popover has entered the top layer after the coach mark.
-	 */
-	public bringSpotlightToFront(): void {
-		this.onBringToFront?.()
 	}
 
 	/**

--- a/test/components/coach-mark.spec.ts
+++ b/test/components/coach-mark.spec.ts
@@ -13,12 +13,10 @@ function createMockOnboarding() {
 		spotlightRadius: '12px',
 		spotlightActive: false,
 		onSpotlightTap: undefined as (() => void) | undefined,
-		onBringToFront: undefined as (() => void) | undefined,
 		isOnboarding: false,
 		isCompleted: true,
 		activateSpotlight: vi.fn(),
 		deactivateSpotlight: vi.fn(),
-		bringSpotlightToFront: vi.fn(),
 		setStep: vi.fn(),
 		complete: vi.fn(),
 		reset: vi.fn(),
@@ -281,66 +279,6 @@ describe('CoachMark', () => {
 			await vi.advanceTimersByTimeAsync(6000)
 
 			expect(sut.visible).toBe(false)
-		})
-	})
-
-	describe('bringToFront', () => {
-		it('should call hidePopover then showPopover when popover is open', async () => {
-			// Open the popover first
-			sut.active = true
-			sut.activeChanged()
-			await vi.advanceTimersByTimeAsync(900)
-
-			expect(overlayEl.showPopover).toHaveBeenCalledTimes(1)
-
-			// Reset call counts
-			;(overlayEl.hidePopover as ReturnType<typeof vi.fn>).mockClear()
-			;(overlayEl.showPopover as ReturnType<typeof vi.fn>).mockClear()
-
-			sut.bringToFront()
-			await vi.advanceTimersByTimeAsync(16) // requestAnimationFrame
-
-			expect(overlayEl.hidePopover).toHaveBeenCalledTimes(1)
-			expect(overlayEl.showPopover).toHaveBeenCalledTimes(1)
-		})
-
-		it('should be no-op when popover is not open', async () => {
-			sut.bringToFront()
-			await vi.advanceTimersByTimeAsync(16)
-
-			expect(overlayEl.hidePopover).not.toHaveBeenCalled()
-			expect(overlayEl.showPopover).not.toHaveBeenCalled()
-		})
-	})
-
-	describe('onboarding service integration', () => {
-		it('should register onBringToFront callback on bound()', () => {
-			sut.bound()
-			expect(mockOnboarding.onBringToFront).toBeTypeOf('function')
-		})
-
-		it('should clear onBringToFront callback on detaching()', () => {
-			sut.bound()
-			expect(mockOnboarding.onBringToFront).toBeDefined()
-
-			sut.detaching()
-			expect(mockOnboarding.onBringToFront).toBeUndefined()
-		})
-
-		it('should trigger bringToFront when onboarding service calls callback', async () => {
-			sut.active = true
-			sut.bound()
-			await vi.advanceTimersByTimeAsync(900)
-
-			;(overlayEl.hidePopover as ReturnType<typeof vi.fn>).mockClear()
-			;(overlayEl.showPopover as ReturnType<typeof vi.fn>).mockClear()
-
-			// Simulate onboarding service calling the callback
-			mockOnboarding.onBringToFront?.()
-			await vi.advanceTimersByTimeAsync(16)
-
-			expect(overlayEl.hidePopover).toHaveBeenCalledTimes(1)
-			expect(overlayEl.showPopover).toHaveBeenCalledTimes(1)
 		})
 	})
 })

--- a/test/services/onboarding-service.spec.ts
+++ b/test/services/onboarding-service.spec.ts
@@ -176,25 +176,6 @@ describe('OnboardingService', () => {
 		})
 	})
 
-	describe('bringSpotlightToFront', () => {
-		it('should invoke onBringToFront callback when set', () => {
-			const sut = createService()
-			const bringFn = vi.fn()
-			sut.onBringToFront = bringFn
-
-			sut.bringSpotlightToFront()
-
-			expect(bringFn).toHaveBeenCalledOnce()
-		})
-
-		it('should be a no-op when callback is not set', () => {
-			const sut = createService()
-
-			// Should not throw
-			expect(() => sut.bringSpotlightToFront()).not.toThrow()
-		})
-	})
-
 	describe('readyForDashboard', () => {
 		it('should return true when followedCount meets the threshold', () => {
 			const sut = createService({ step: OnboardingStep.DISCOVERY })


### PR DESCRIPTION
## Description

Dead-code cleanup following the #399 bottom-sheet `<dialog>.showModal()` migration. The coach-mark LIFO re-stack chain (`OnboardingService.bringSpotlightToFront` → `onBringToFront` callback → `CoachMark.bringToFront`) had **no production caller** — only tests exercised it. Its purpose (re-stacking the coach-mark popover above the concert detail sheet during onboarding) is moot now the shared bottom-sheet is a modal `<dialog>`: the coach mark and any bottom-sheet never coexist in current flows.

## Type of Change

- [x] chore: Other changes that don't modify src or test files in a behavioural way (dead-code removal)

## Verification

### Automated Tests
- [x] `npm run lint` passed
- [x] `npm run test` passed (1180 tests; removed 9 tests that asserted the dead plumbing)
- [x] `npm run build` (tsc) passed

### Manual Verification
- No runtime behaviour change: the removed chain was never invoked in production. Coach-mark spotlight behaviour (highlight, popover open/close, tap-to-advance) is unchanged and still covered by its remaining tests.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

Refs: #399
