### PR TITLE
feat(event-detail): add official merch info link to detail sheet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
 			"dependencies": {
 				"@aurelia/i18n": "^2.0.0-rc.1",
 				"@aurelia/router": "^2.0.0-rc.1",
-				"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260524050818-e7f694dd726b.1",
-				"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260524050818-e7f694dd726b.2",
+				"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260603024137-cbe7ee103c78.1",
+				"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260603024137-cbe7ee103c78.2",
 				"@bufbuild/protobuf": "^1.10.1",
 				"@connectrpc/connect": "^1.7.0",
 				"@connectrpc/connect-web": "^1.7.0",
@@ -2163,8 +2163,8 @@
 			}
 		},
 		"node_modules/@buf/liverty-music_schema.bufbuild_es": {
-			"version": "1.10.0-20260524050818-e7f694dd726b.1",
-			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.bufbuild_es/-/liverty-music_schema.bufbuild_es-1.10.0-20260524050818-e7f694dd726b.1.tgz",
+			"version": "1.10.0-20260603024137-cbe7ee103c78.1",
+			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.bufbuild_es/-/liverty-music_schema.bufbuild_es-1.10.0-20260603024137-cbe7ee103c78.1.tgz",
 			"dependencies": {
 				"@buf/bufbuild_protovalidate.bufbuild_es": "1.10.0-20250717185734-6c6e0d3c608e.1",
 				"@buf/googleapis_googleapis.bufbuild_es": "1.10.0-20250411203938-61b203b9a916.1"
@@ -2174,12 +2174,12 @@
 			}
 		},
 		"node_modules/@buf/liverty-music_schema.connectrpc_es": {
-			"version": "1.6.1-20260524050818-e7f694dd726b.2",
-			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.connectrpc_es/-/liverty-music_schema.connectrpc_es-1.6.1-20260524050818-e7f694dd726b.2.tgz",
+			"version": "1.6.1-20260603024137-cbe7ee103c78.2",
+			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.connectrpc_es/-/liverty-music_schema.connectrpc_es-1.6.1-20260603024137-cbe7ee103c78.2.tgz",
 			"dependencies": {
 				"@buf/bufbuild_protovalidate.connectrpc_es": "1.6.1-20250717185734-6c6e0d3c608e.2",
 				"@buf/googleapis_googleapis.connectrpc_es": "1.6.1-20250411203938-61b203b9a916.2",
-				"@buf/liverty-music_schema.bufbuild_es": "1.10.0-20260524050818-e7f694dd726b.1"
+				"@buf/liverty-music_schema.bufbuild_es": "1.10.0-20260603024137-cbe7ee103c78.1"
 			},
 			"peerDependencies": {
 				"@connectrpc/connect": "^1.6.1"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
 	"dependencies": {
 		"@aurelia/i18n": "^2.0.0-rc.1",
 		"@aurelia/router": "^2.0.0-rc.1",
-		"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260524050818-e7f694dd726b.1",
-		"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260524050818-e7f694dd726b.2",
+		"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260603024137-cbe7ee103c78.1",
+		"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260603024137-cbe7ee103c78.2",
 		"@bufbuild/protobuf": "^1.10.1",
 		"@connectrpc/connect": "^1.7.0",
 		"@connectrpc/connect-web": "^1.7.0",

--- a/src/adapter/rpc/mapper/concert-mapper.ts
+++ b/src/adapter/rpc/mapper/concert-mapper.ts
@@ -73,6 +73,7 @@ export function concertFrom(
 		// and should be investigated rather than silently re-derived.
 		title: proto.series?.title?.value ?? '',
 		sourceUrl: proto.series?.sourceUrl?.value ?? '',
+		merchUrl: proto.series?.merchUrl?.value ?? '',
 		hypeLevel,
 		matched,
 		artist,

--- a/src/components/live-highway/event-detail-sheet.html
+++ b/src/components/live-highway/event-detail-sheet.html
@@ -202,6 +202,17 @@
           <span t="eventDetail.viewOfficialInfo"></span>
         </a>
         <a
+          if.bind="hasMerchUrl"
+          href.bind="event.merchUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="sheet-btn-secondary"
+          data-testid="merch-link"
+        >
+          <svg-icon name="link"></svg-icon>
+          <span t="eventDetail.viewMerch"></span>
+        </a>
+        <a
           href.bind="calendarUrl"
           target="_blank"
           rel="noopener noreferrer"

--- a/src/components/live-highway/event-detail-sheet.ts
+++ b/src/components/live-highway/event-detail-sheet.ts
@@ -45,10 +45,6 @@ export class EventDetailSheet {
 		return bestBackgroundUrl(this.event?.artist)
 	}
 
-	/**
-	 * Whether to render the merch-info link. True only when the event carries a
-	 * non-empty merch URL; the link is omitted entirely when absent.
-	 */
 	public get hasMerchUrl(): boolean {
 		return Boolean(this.event?.merchUrl)
 	}

--- a/src/components/live-highway/event-detail-sheet.ts
+++ b/src/components/live-highway/event-detail-sheet.ts
@@ -45,6 +45,14 @@ export class EventDetailSheet {
 		return bestBackgroundUrl(this.event?.artist)
 	}
 
+	/**
+	 * Whether to render the merch-info link. True only when the event carries a
+	 * non-empty merch URL; the link is omitted entirely when absent.
+	 */
+	public get hasMerchUrl(): boolean {
+		return Boolean(this.event?.merchUrl)
+	}
+
 	public get googleMapsUrl(): string {
 		if (!this.event) return '#'
 		const area = this.event.locationLabel

--- a/src/entities/concert.ts
+++ b/src/entities/concert.ts
@@ -25,6 +25,8 @@ export interface Concert {
 	openTime?: string
 	title: string
 	sourceUrl: string
+	/** Official merchandise info page (official site or social media post); empty when none is known. */
+	merchUrl: string
 
 	// --- UI-only ---
 	hypeLevel: HypeLevel

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -123,6 +123,7 @@
 		"ticketStatus": "Ticket Status",
 		"stopTracking": "Stop tracking",
 		"viewOfficialInfo": "View Official Info",
+		"viewMerch": "View Merch Info",
 		"addToCalendar": "Add to Calendar",
 		"journeyPhase": {
 			"process": "Application",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -123,6 +123,7 @@
 		"ticketStatus": "チケット状況",
 		"stopTracking": "追跡を停止",
 		"viewOfficialInfo": "公式情報を見る",
+		"viewMerch": "グッズ情報を見る",
 		"addToCalendar": "カレンダーに追加",
 		"journeyPhase": {
 			"process": "申込フロー",

--- a/test/adapter/rpc/mapper/concert-mapper.spec.ts
+++ b/test/adapter/rpc/mapper/concert-mapper.spec.ts
@@ -57,6 +57,7 @@ describe('concertFrom', () => {
 				id: { value: 's1' },
 				title: { value: 'Test Concert' },
 				sourceUrl: { value: 'https://example.com' },
+				merchUrl: { value: 'https://example.com/merch' },
 			},
 			localDate: { value: { year: 2026, month: 3, day: 15 } },
 			startTime: { value: { seconds: BigInt(1742054400), nanos: 0 } },
@@ -86,6 +87,7 @@ describe('concertFrom', () => {
 		expect(result!.venueName).toBe('Zepp DiverCity')
 		expect(result!.locationLabel).toBe('Display(JP-13)')
 		expect(result!.sourceUrl).toBe('https://example.com')
+		expect(result!.merchUrl).toBe('https://example.com/merch')
 		expect(result!.hypeLevel).toBe('home')
 		expect(result!.matched).toBe(true)
 		expect(result!.date).toBeInstanceOf(Date)

--- a/test/components/live-highway/event-detail-sheet.spec.ts
+++ b/test/components/live-highway/event-detail-sheet.spec.ts
@@ -22,6 +22,7 @@ function makeEvent(overrides: Partial<LiveEvent> = {}): LiveEvent {
 		startTime: '19:00',
 		title: 'Test Concert',
 		sourceUrl: 'https://example.com',
+		merchUrl: '',
 		hypeLevel: 'watch',
 		...overrides,
 	}
@@ -83,6 +84,23 @@ describe('EventDetailSheet', () => {
 		it('should return "#" when no event', () => {
 			sut.event = null
 			expect(sut.googleMapsUrl).toBe('#')
+		})
+	})
+
+	describe('hasMerchUrl (merch link gating)', () => {
+		it('is true when the event carries a merch URL', () => {
+			sut.event = makeEvent({ merchUrl: 'https://artist.example.com/goods' })
+			expect(sut.hasMerchUrl).toBe(true)
+		})
+
+		it('is false when the merch URL is empty', () => {
+			sut.event = makeEvent({ merchUrl: '' })
+			expect(sut.hasMerchUrl).toBe(false)
+		})
+
+		it('is false when there is no event', () => {
+			sut.event = null
+			expect(sut.hasMerchUrl).toBe(false)
 		})
 	})
 

--- a/test/helpers/mock-date-groups.ts
+++ b/test/helpers/mock-date-groups.ts
@@ -13,6 +13,7 @@ export function makeConcert(
 		startTime: '19:00',
 		title: 'Test Concert',
 		sourceUrl: 'https://example.com',
+		merchUrl: '',
 		hypeLevel: 'home',
 		matched: false,
 		...overrides,


### PR DESCRIPTION
## Description

Adds a "グッズ情報" (merch info) link to the event detail sheet so fans get a one-tap path from a concert to its official merchandise page. The link renders as a sibling to the official-info link **only when** the concert's series carries a `merch_url`, and is omitted entirely (no placeholder) when absent.

- Map `Series.merch_url` onto the flat `Concert` entity (`concert-mapper`), consuming the new field from the v0.42.0 schema package.
- Gate the link on a `hasMerchUrl` getter; open in a new tab (`rel="noopener noreferrer"`).
- Add the `eventDetail.viewMerch` i18n key with parallel JA/EN values.
- Bump the `@buf` schema packages to the v0.42.0 BSR commit, kept on the **protobuf-es v1 line** (the registry's `@latest` has moved to protobuf-es v2, which is a separate, larger migration).

## Type of Change

- [x] feat: A new feature

## Verification

### Automated Tests
- [x] `npm run lint` passed
- [x] `npm run test` passed <!-- make check: 1204 tests pass -->
- [x] `npm run build` passed <!-- covered by typecheck in make lint -->

### Manual Verification
Component tests cover the present case (`hasMerchUrl` true → link rendered) and absent case (empty / no event → no link). Mapper test asserts `merch_url` flows from proto to entity.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation <!-- N/A -->
- [x] My changes generate no new warnings

Refs #569
