### PR TITLE
feat(pwa): disable ticket-email import entry point

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -7,15 +7,6 @@
 	"background_color": "#1a1333",
 	"theme_color": "#1a1333",
 	"lang": "ja",
-	"share_target": {
-		"action": "/import/ticket-email",
-		"method": "POST",
-		"enctype": "multipart/form-data",
-		"params": {
-			"title": "title",
-			"text": "text"
-		}
-	},
 	"icons": [
 		{ "src": "/favicon.svg", "sizes": "any", "type": "image/svg+xml" },
 		{

--- a/src/routes/import-ticket-email/import-ticket-email-route.html
+++ b/src/routes/import-ticket-email/import-ticket-email-route.html
@@ -1,6 +1,20 @@
 <page-header title="チケットメール取り込み"></page-header>
 
 <section class="import-wizard">
+  <!--
+    Unavailable state. The wizard's only entry point (the Android Gmail share
+    sheet) was removed, so this route now presents an unavailable notice
+    instead of the wizard. The wizard markup below is retained so the flow can
+    be revived without re-implementation — see the route view-model for the
+    revival steps.
+  -->
+  <template if.bind="step === 'unavailable'">
+    <div class="wizard-error wizard-unavailable">
+      <p>チケットメール取り込みは現在ご利用いただけません。</p>
+      <a href="/dashboard">ダッシュボードに戻る</a>
+    </div>
+  </template>
+
   <!-- Validation Error -->
   <template if.bind="step === 'validation' && error">
     <div class="wizard-error">

--- a/src/routes/import-ticket-email/import-ticket-email-route.ts
+++ b/src/routes/import-ticket-email/import-ticket-email-route.ts
@@ -16,6 +16,7 @@ const TICKET_EMAIL_REGEX =
 	/抽選|当選|落選|チケット|入金期限|支払期限|先行|受付|e\+|ぴあ|ローチケ|ticket|lottery/i
 
 type WizardStep =
+	| 'unavailable'
 	| 'validation'
 	| 'artist'
 	| 'concert'
@@ -25,8 +26,15 @@ type WizardStep =
 	| 'done'
 
 export class ImportTicketEmailRoute {
-	// Wizard state
-	public step: WizardStep = 'validation'
+	// Wizard state.
+	//
+	// The wizard is currently UNAVAILABLE: its only entry point was the
+	// Android Gmail share sheet, whose `share_target` manifest declaration and
+	// Service Worker redirect have been removed. The wizard code below is kept
+	// intact so a future revival re-enables this flow without re-implementation
+	// — to restore it, re-add the manifest/SW entry points and reset the
+	// initial step to 'validation' (plus drop the early return in `loading`).
+	public step: WizardStep = 'unavailable'
 	public error = ''
 	public isLoading = false
 
@@ -60,6 +68,14 @@ export class ImportTicketEmailRoute {
 	private abortController: AbortController | null = null
 
 	public async loading(_params: Params, next: RouteNode): Promise<void> {
+		// Entry point disabled: keep the route registered (so a direct deep-link
+		// resolves rather than 404s) but present the "unavailable" state and skip
+		// all wizard/network logic. Remove this early return when the share-target
+		// entry point is revived.
+		if (this.step === 'unavailable') {
+			return
+		}
+
 		this.abortController = new AbortController()
 
 		// Extract shared data from URL query params (set by SW redirect).

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -77,29 +77,37 @@ self.addEventListener('install', (event) => {
 })
 
 // ---------------------------------------------------------------------------
-// PWA Share Target handler — intercepts POST from Android share sheet.
-// Extracts shared email data and redirects to the import wizard route.
+// PWA Share Target handler — DISABLED.
+//
+// This fetch handler intercepted the POST that the Android Gmail share sheet
+// sent to `/import/ticket-email`, extracted the shared email data, and
+// redirected to the import wizard route. The share entry point no longer
+// exists: the `share_target` declaration was removed from the manifest and
+// the Android share action that fed it is gone, so this interception can
+// never fire. It is kept (disabled) rather than deleted so a future revival
+// can re-enable the ticket-email import flow without re-implementation —
+// re-add `share_target` to the manifest and un-comment the handler below.
 // ---------------------------------------------------------------------------
-self.addEventListener('fetch', (event) => {
-	const url = new URL(event.request.url)
-	if (
-		event.request.method === 'POST' &&
-		url.pathname === '/import/ticket-email'
-	) {
-		event.respondWith(
-			(async () => {
-				const formData = await event.request.formData()
-				const title = formData.get('title')?.toString() ?? ''
-				const text = formData.get('text')?.toString() ?? ''
-				const params = new URLSearchParams({ title, text })
-				return Response.redirect(
-					`/import/ticket-email?${params.toString()}`,
-					303,
-				)
-			})(),
-		)
-	}
-})
+// self.addEventListener('fetch', (event) => {
+// 	const url = new URL(event.request.url)
+// 	if (
+// 		event.request.method === 'POST' &&
+// 		url.pathname === '/import/ticket-email'
+// 	) {
+// 		event.respondWith(
+// 			(async () => {
+// 				const formData = await event.request.formData()
+// 				const title = formData.get('title')?.toString() ?? ''
+// 				const text = formData.get('text')?.toString() ?? ''
+// 				const params = new URLSearchParams({ title, text })
+// 				return Response.redirect(
+// 					`/import/ticket-email?${params.toString()}`,
+// 					303,
+// 				)
+// 			})(),
+// 		)
+// 	}
+// })
 
 // ---------------------------------------------------------------------------
 // Background Sync for artist operations (listTop / listSimilar / search).

--- a/test/routes/import-ticket-email-route.spec.ts
+++ b/test/routes/import-ticket-email-route.spec.ts
@@ -73,7 +73,19 @@ describe('ImportTicketEmailRoute', () => {
 	})
 
 	describe('loading', () => {
+		// The wizard entry point is disabled: the route boots into the
+		// 'unavailable' step and `loading` early-returns. The tests below that
+		// exercise the retained wizard logic first reset `step` to 'validation'
+		// to simulate the revived entry point.
+		it('stays on the unavailable step and skips wizard logic by default', async () => {
+			await sut.loading({}, makeNext({ title: 'Test', text: 'チケット当選' }))
+
+			expect(sut.step).toBe('unavailable')
+			expect(mockFollow.listFollowed).not.toHaveBeenCalled()
+		})
+
 		it('sets validation error when email body does not match ticket regex', async () => {
+			sut.step = 'validation'
 			await sut.loading({}, makeNext({ title: 'Hello', text: 'PlainGreeting' }))
 
 			expect(sut.step).toBe('validation')
@@ -81,12 +93,14 @@ describe('ImportTicketEmailRoute', () => {
 		})
 
 		it('advances to artist step when email body matches ticket regex', async () => {
+			sut.step = 'validation'
 			await sut.loading({}, makeNext({ title: 'Test', text: 'チケット当選' }))
 
 			expect(sut.step).toBe('artist')
 		})
 
 		it('auto-matches artist when name appears in email body', async () => {
+			sut.step = 'validation'
 			mockFollow.listFollowed.mockResolvedValue([
 				{ artist: { id: 'a1', name: 'ArtistXYZ' } },
 			])
@@ -191,6 +205,7 @@ describe('ImportTicketEmailRoute', () => {
 
 	describe('detaching', () => {
 		it('aborts active request', async () => {
+			sut.step = 'validation'
 			await sut.loading({}, makeNext({ title: 'T', text: 'チケット' }))
 			const abortSpy = vi.spyOn(AbortController.prototype, 'abort')
 


### PR DESCRIPTION
## What

Disables the ticket-email import entry point while retaining all wizard and RPC-client code for a future revival:

- Removes the `share_target` entry from `manifest.webmanifest`.
- Disables (comments out, with revival instructions) the Service Worker handler that intercepted the share-target POST.
- Makes `/import/ticket-email` present an "unavailable" state instead of the wizard: the route stays registered (so a direct deep-link resolves rather than 404s) and boots into a new `'unavailable'` step that short-circuits `loading()` before any network/wizard logic.

## Why

The Android Gmail share action that fed this flow no longer exists, so the PWA Share Target ingestion path is dead and presents a broken entry point. Per the `add-sales-phase-timeline` OpenSpec change, the email-import feature is frozen (not deleted) — the sales-phase searcher becomes the sole writer of sales-schedule data, and email ingestion can be revived later by re-enabling these entry points (signposted in code comments).

## Notes

- Self-contained and **independent of the proto / BSR changes** — no generated-type dependency, safe to merge on its own.
- All wizard components and the generated RPC client are retained; tests updated to drive the retained code from the `'validation'` step so coverage is preserved.
- `make check` passes locally (biome, stylelint, tsc, brand-vocabulary, template lint, 1205 unit tests).

Refs: #571