### PR TITLE
fix(i18n): unify guest locale to a single source of truth

### DIFF
--- a/src/adapter/storage/guest-storage.ts
+++ b/src/adapter/storage/guest-storage.ts
@@ -1,16 +1,7 @@
 import { DEFAULT_HYPE, type FollowedArtist } from '../../entities/follow'
-import { normalizeToSupportedLanguage } from '../../util/change-locale'
 
 const KEY_FOLLOWED = 'guest.followedArtists'
 const KEY_HOME = 'guest.home'
-// Anonymous-period UI language. Dedicated key, DECOUPLED from the i18next
-// detector's own cache key (`StorageKeys.language === 'language'`, configured
-// in main.ts as `lookupLocalStorage`). UserStore is the sole reader/writer
-// of `guest.language`, so clearing the guest slice cannot erase the detector's
-// active-locale cache, and a returning guest who never made an explicit choice keeps
-// `guest.language === null` (the detector's auto-written 'language' no longer
-// leaks in) — preserving the "null → reactive i18nLocale fallback" contract.
-const KEY_LANGUAGE = 'guest.language'
 
 export function saveFollows(follows: FollowedArtist[]): void {
 	localStorage.setItem(KEY_FOLLOWED, JSON.stringify(follows))
@@ -41,31 +32,6 @@ export function saveHome(code: string | null): void {
 
 export function loadHome(): string | null {
 	return localStorage.getItem(KEY_HOME)
-}
-
-/**
- * Persist the guest's anonymous-period language. A `null` clears the key
- * (used on sign-up/sign-out when the DB or a fresh session takes over).
- */
-export function saveLanguage(lang: string | null): void {
-	if (lang !== null) {
-		localStorage.setItem(KEY_LANGUAGE, lang)
-	} else {
-		localStorage.removeItem(KEY_LANGUAGE)
-	}
-}
-
-/**
- * Load the guest's anonymous-period language. Returns `null` when the key is
- * absent so the store can fall back to the active i18n locale. A stored value
- * is normalized through `normalizeToSupportedLanguage` so a BCP 47 tag the
- * i18next detector may have written (e.g. 'en-US') resolves to a supported
- * code ('en') — otherwise selection-state comparisons against 'en' would fail.
- */
-export function loadLanguage(): string | null {
-	const raw = localStorage.getItem(KEY_LANGUAGE)
-	if (raw === null) return null
-	return normalizeToSupportedLanguage(raw)
 }
 
 /**

--- a/src/constants/storage-keys.spec.ts
+++ b/src/constants/storage-keys.spec.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { migrateStorageKeys, StorageKeys } from './storage-keys'
+
+const LEGACY_GUEST_LANGUAGE = 'guest.language'
+
+describe('migrateStorageKeys — legacy guest.language migration', () => {
+	beforeEach(() => {
+		localStorage.clear()
+	})
+
+	afterEach(() => {
+		localStorage.clear()
+	})
+
+	it('promotes the explicit guest choice when it differs from the detector cache', () => {
+		// Explicit guest choice (ja) outranks the auto-detected detector cache (en).
+		localStorage.setItem(LEGACY_GUEST_LANGUAGE, 'ja')
+		localStorage.setItem(StorageKeys.language, 'en')
+
+		migrateStorageKeys()
+
+		expect(localStorage.getItem(StorageKeys.language)).toBe('ja')
+		expect(localStorage.getItem(LEGACY_GUEST_LANGUAGE)).toBeNull()
+	})
+
+	it('promotes the explicit guest choice when the detector cache is absent', () => {
+		// An absent `language` (e.g. cleared by a prior authenticated session) still
+		// differs from a present `guest.language`, so the explicit choice is promoted.
+		localStorage.setItem(LEGACY_GUEST_LANGUAGE, 'ja')
+
+		migrateStorageKeys()
+
+		expect(localStorage.getItem(StorageKeys.language)).toBe('ja')
+		expect(localStorage.getItem(LEGACY_GUEST_LANGUAGE)).toBeNull()
+	})
+
+	it('removes the legacy key without rewriting when the values already match', () => {
+		localStorage.setItem(LEGACY_GUEST_LANGUAGE, 'ja')
+		localStorage.setItem(StorageKeys.language, 'ja')
+
+		migrateStorageKeys()
+
+		expect(localStorage.getItem(StorageKeys.language)).toBe('ja')
+		expect(localStorage.getItem(LEGACY_GUEST_LANGUAGE)).toBeNull()
+	})
+
+	it('is a no-op for the language keys when no legacy key is present', () => {
+		localStorage.setItem(StorageKeys.language, 'en')
+
+		migrateStorageKeys()
+
+		expect(localStorage.getItem(StorageKeys.language)).toBe('en')
+		expect(localStorage.getItem(LEGACY_GUEST_LANGUAGE)).toBeNull()
+	})
+
+	it('is idempotent across repeated startups', () => {
+		localStorage.setItem(LEGACY_GUEST_LANGUAGE, 'ja')
+		localStorage.setItem(StorageKeys.language, 'en')
+
+		migrateStorageKeys()
+		migrateStorageKeys()
+
+		expect(localStorage.getItem(StorageKeys.language)).toBe('ja')
+		expect(localStorage.getItem(LEGACY_GUEST_LANGUAGE)).toBeNull()
+	})
+})

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -88,6 +88,22 @@ export function migrateStorageKeys(): void {
 		localStorage.setItem('ui.onboardingCompletedSessionCount', oldCompleted)
 	}
 	localStorage.removeItem('pwa.completedSessionCount')
+
+	// Migrate the legacy `guest.language` key into the single-source `language`
+	// key (the i18next detector cache). `guest.language` was only ever written on
+	// an explicit user language choice, so it represents higher intent than the
+	// auto-detected detector cache: when the two differ — including when
+	// `language` is absent (e.g. cleared by a prior authenticated session) — the
+	// explicit guest choice wins and is promoted. Then the redundant key is
+	// removed. Because this runs before i18next detection reads `language`
+	// (see main.ts ordering), a promoted value takes effect in the same session.
+	const legacyGuestLanguage = localStorage.getItem('guest.language')
+	if (legacyGuestLanguage !== null) {
+		if (localStorage.getItem(StorageKeys.language) !== legacyGuestLanguage) {
+			localStorage.setItem(StorageKeys.language, legacyGuestLanguage)
+		}
+		localStorage.removeItem('guest.language')
+	}
 }
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -140,6 +140,15 @@ async function bootstrap(): Promise<void> {
 	au.register(
 		I18nConfiguration.customize((options) => {
 			options.initOptions = {
+				// Load-bearing: `@aurelia/i18n` injects a default `lng: 'en'` into the
+				// i18next init options, and i18next treats an explicit `lng` as an
+				// override that BYPASSES the language detector entirely. Setting it
+				// back to `undefined` re-enables the `detection` chain below, so the
+				// boot locale is resolved from querystring → localStorage → navigator
+				// (honoring the migrated `language` key) instead of being hard-pinned
+				// to English. Do NOT delete this as a no-op — its absence silently
+				// disables detection and the app always boots English.
+				lng: undefined,
 				resources: {
 					ja: { translation: ja },
 					en: { translation: en },

--- a/src/routes/welcome/welcome-route.ts
+++ b/src/routes/welcome/welcome-route.ts
@@ -45,11 +45,11 @@ export class WelcomeRoute implements IRouteViewModel {
 
 	/**
 	 * Active UI language for the language picker's `checked.bind`, projected from
-	 * UserStore (the @observable owner of the guest language slice) rather than a
-	 * local mirror field. Welcome is anonymous-only, so `currentLanguage` resolves
-	 * to `guestLanguage ?? i18nLocale`. Bound one-way; the radio's
-	 * `change.trigger` routes the selection through `selectLanguage` so the single
-	 * source of truth stays in UserStore.
+	 * UserStore rather than a local mirror field. Welcome is anonymous-only, so
+	 * `currentLanguage` resolves to the reactive `i18nLocale` mirror — always
+	 * equal to the active i18n locale. Bound one-way; the radio's `change.trigger`
+	 * routes the selection through `selectLanguage` so the single source of truth
+	 * stays in UserStore / the active locale.
 	 */
 	public get currentLocale(): string {
 		return this.userStore.currentLanguage
@@ -153,7 +153,8 @@ export class WelcomeRoute implements IRouteViewModel {
 	 * `change.trigger` (one-way `checked.bind` reads the projection from
 	 * UserStore, this writes through it) rather than a standalone @observable
 	 * mirror. Routes through the shared `changeLocale`, which on the
-	 * unauthenticated path applies `i18n.setLocale` then `userStore.setGuestLanguage`.
+	 * unauthenticated path applies `i18n.setLocale` then persists the choice to
+	 * the single `localStorage['language']` key.
 	 */
 	public async selectLanguage(newLocale: string): Promise<void> {
 		if (!newLocale || newLocale === this.i18n.getLocale()) return
@@ -258,11 +259,11 @@ export class WelcomeRoute implements IRouteViewModel {
 		// home during a prior anonymous session.
 		//
 		// Coordinated reset across the stores that now own the guest slices:
-		// UserStore drops home/language/help-seen; FollowStore drops the follow
-		// queue + projection cache. Together these reproduce the old
-		// GuestService.clearAll() semantics. Only the dedicated `guest.language`
-		// key is cleared — the i18next detector's own `language` key is left
-		// intact (the Phase-1 cancelled-login fix).
+		// UserStore drops home/help-seen; FollowStore drops the follow queue +
+		// projection cache. Together these reproduce the old
+		// GuestService.clearAll() semantics. The locale is untouched — it lives
+		// solely in the i18next detector's `language` key, which persists across
+		// the reset (the cancelled-login behavior).
 		this.resetGuestState()
 		try {
 			await this.authService.signIn()

--- a/src/services/user-store.ts
+++ b/src/services/user-store.ts
@@ -2,12 +2,7 @@ import { I18N, Signals } from '@aurelia/i18n'
 import { Code, ConnectError } from '@connectrpc/connect'
 import { DI, IEventAggregator, ILogger, observable, resolve } from 'aurelia'
 import { IUserRpcClient } from '../adapter/rpc/client/user-client'
-import {
-	loadHome,
-	loadLanguage,
-	saveHome,
-	saveLanguage,
-} from '../adapter/storage/guest-storage'
+import { loadHome, saveHome } from '../adapter/storage/guest-storage'
 import { ILocalStorage } from '../adapter/storage/local-storage'
 import { clearAllHelpSeen } from '../adapter/storage/onboarding-storage'
 import { userIdStorageKey } from '../constants/storage-keys'
@@ -50,17 +45,17 @@ export interface ProvisionResult {
  * cache→Get→Create chain, write-through update methods, and per-external_id
  * user_id cache) used to live behind a separate `UserService`. UserStore now
  * OWNS that logic directly, making it the single owner of the User entity in
- * addition to the guest `home` / `language` slice it already owned (those still
- * live here as `@observable` fields, hydrated from the low-level `guest-storage`
- * adapter on construction and persisted through `*Changed` hooks).
+ * addition to the guest `home` slice it already owned (that still lives here as
+ * an `@observable` field, hydrated from the low-level `guest-storage` adapter on
+ * construction and persisted through its `*Changed` hook).
  *
  * Every exposed value depends ONLY on observable state:
  *   - `current` is @observable.
- *   - `guestHome` / `guestLanguage` are @observable.
+ *   - `guestHome` is @observable.
  *   - `i18nLocale` mirrors the active i18n locale, kept in sync via the
- *     i18n locale-changed event, so even the authed-NULL fallback is
- *     reactive (a render-time `i18n.getLocale()` read is not observable and
- *     would freeze the binding).
+ *     i18n locale-changed event. It is the single source of truth for the
+ *     guest locale and the authed-NULL fallback (a render-time
+ *     `i18n.getLocale()` read is not observable and would freeze the binding).
  */
 export class UserStore {
 	private readonly logger = resolve(ILogger).scopeTo('UserStore')
@@ -105,16 +100,6 @@ export class UserStore {
 	 * when it changes.
 	 */
 	@observable public guestHome: string | null = loadHome()
-
-	/**
-	 * Anonymous-period UI language (ISO 639-1 code). First-class @observable
-	 * owner, symmetric with `guestHome`, so any binding that reads the guest
-	 * language re-evaluates when it changes (fixes the guest language-selector
-	 * reactivity bug where the selector was driven by an unobservable
-	 * `i18n.getLocale()` read). `null` means "no explicit guest choice yet" —
-	 * `currentLanguage` falls back to the active i18n locale in that case.
-	 */
-	@observable public guestLanguage: string | null = loadLanguage()
 
 	/**
 	 * Reactive mirror of the active i18n locale, normalized to a supported
@@ -164,8 +149,11 @@ export class UserStore {
 	 * `user-hydration-task` (an activating AppTask); this getter is a PURE
 	 * projection of observable state and never issues an RPC.
 	 *
-	 * Guest: the observable guest language, or the i18n locale mirror when the
-	 * guest has not made an explicit choice yet.
+	 * Guest: the observable `i18nLocale` mirror, which always equals the active
+	 * i18n locale — so the selector highlight can never drift from the rendered
+	 * UI. The anonymous locale has a single persisted source
+	 * (`localStorage['language']`, the i18next detector cache); there is no
+	 * separate guest-language key to reconcile.
 	 *
 	 * NEVER reads a render-time `i18n.getLocale()`; every branch resolves to
 	 * observable state so dependent bindings re-evaluate on change.
@@ -179,7 +167,7 @@ export class UserStore {
 			// stays side-effect-free and safe to re-evaluate on every pass.
 			return this.i18nLocale
 		}
-		return this.guestLanguage ?? this.i18nLocale
+		return this.i18nLocale
 	}
 
 	// Resolves the authenticated user via:
@@ -340,28 +328,17 @@ export class UserStore {
 	}
 
 	/**
-	 * Set the guest language (ISO 639-1 code). Persisted via
-	 * `guestLanguageChanged`. Used by the unauthenticated locale-change path
-	 * (`changeLocale`).
-	 */
-	public setGuestLanguage(lang: string): void {
-		this.guestLanguage = lang
-		this.logger.info('Local language set', { language: lang })
-	}
-
-	/**
-	 * Reset the guest home/language slice plus the per-page help-seen flags.
-	 * Used by the welcome route's fresh-tutorial reset and the sign-up
-	 * onboarding hand-off. Does NOT touch the follow queue (owned by
-	 * FollowStore) and does NOT erase the i18next detector's own `language`
-	 * key — only the dedicated `guest.language` key is cleared (it is already
-	 * decoupled), preserving the cancelled-login behavior.
+	 * Reset the guest home slice plus the per-page help-seen flags. Used by the
+	 * welcome route's fresh-tutorial reset and the sign-up onboarding hand-off.
+	 * Does NOT touch the follow queue (owned by FollowStore) and does NOT touch
+	 * the locale: the anonymous locale lives solely in the i18next detector's
+	 * `language` key, which persists across this reset, preserving the
+	 * cancelled-login behavior with no decoupling to reason about.
 	 */
 	public clearGuest(): void {
 		this.guestHome = null
-		this.guestLanguage = null
 		clearAllHelpSeen()
-		this.logger.info('Local home/language preferences cleared')
+		this.logger.info('Local home preferences cleared')
 	}
 
 	/**
@@ -369,13 +346,6 @@ export class UserStore {
 	 */
 	public guestHomeChanged(newValue: string | null): void {
 		saveHome(newValue)
-	}
-
-	/**
-	 * Persist guest language to localStorage on change.
-	 */
-	public guestLanguageChanged(newValue: string | null): void {
-		saveLanguage(newValue)
 	}
 
 	// requireUserId resolves the caller's internal user_id from the in-memory

--- a/src/util/change-locale.spec.ts
+++ b/src/util/change-locale.spec.ts
@@ -1,5 +1,6 @@
 import type { I18N } from '@aurelia/i18n'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { StorageKeys } from '../constants/storage-keys'
 import type { IAuthService } from '../services/auth-service'
 import type { IUserStore } from '../services/user-store'
 import { changeLocale } from './change-locale'
@@ -22,8 +23,6 @@ function makeUserStore(behavior?: {
 }): IUserStore {
 	return {
 		current: { id: 'u', preferredLanguage: 'ja' },
-		guestLanguage: null,
-		setGuestLanguage: vi.fn(),
 		updatePreferredLanguage: vi.fn(
 			behavior?.updatePreferredLanguage ?? (async () => ({ id: 'u' })),
 		),
@@ -31,23 +30,33 @@ function makeUserStore(behavior?: {
 }
 
 describe('changeLocale', () => {
+	beforeEach(() => {
+		localStorage.clear()
+	})
+
+	afterEach(() => {
+		localStorage.clear()
+		vi.restoreAllMocks()
+	})
+
 	describe('validation', () => {
 		it('throws TypeError on unsupported language without touching state', async () => {
 			const i18n = makeI18n()
 			const auth = makeAuth(false)
 			const userStore = makeUserStore()
+			const setItem = vi.spyOn(Storage.prototype, 'setItem')
 
 			await expect(
 				changeLocale({ i18n, auth, userStore }, 'fr'),
 			).rejects.toBeInstanceOf(TypeError)
 			expect(i18n.setLocale).not.toHaveBeenCalled()
-			expect(userStore.setGuestLanguage).not.toHaveBeenCalled()
+			expect(setItem).not.toHaveBeenCalled()
 			expect(userStore.updatePreferredLanguage).not.toHaveBeenCalled()
 		})
 	})
 
 	describe('unauthenticated path', () => {
-		it('calls i18n.setLocale and writes through the observable guest source; no RPC', async () => {
+		it('calls i18n.setLocale and persists to the single language key; no RPC', async () => {
 			const i18n = makeI18n()
 			const auth = makeAuth(false)
 			const userStore = makeUserStore()
@@ -55,15 +64,15 @@ describe('changeLocale', () => {
 			await changeLocale({ i18n, auth, userStore }, 'en')
 
 			expect(i18n.setLocale).toHaveBeenCalledWith('en')
-			// Write through the @observable guest language owner (not raw
-			// localStorage) so UserStore.currentLanguage stays reactive.
-			expect(userStore.setGuestLanguage).toHaveBeenCalledWith('en')
+			// The anonymous choice is persisted explicitly to the single
+			// `language` key (the i18next detector cache) — no separate guest key.
+			expect(localStorage.getItem(StorageKeys.language)).toBe('en')
 			expect(userStore.updatePreferredLanguage).not.toHaveBeenCalled()
 		})
 	})
 
 	describe('authenticated path', () => {
-		it('calls RPC first, then setLocale; NEVER touches the guest source', async () => {
+		it('calls RPC first, then setLocale; NEVER writes the anonymous language key', async () => {
 			const callOrder: string[] = []
 			const i18n = makeI18n({
 				setLocale: async () => {
@@ -83,7 +92,9 @@ describe('changeLocale', () => {
 			expect(userStore.updatePreferredLanguage).toHaveBeenCalledWith('en')
 			expect(i18n.setLocale).toHaveBeenCalledWith('en')
 			expect(callOrder).toEqual(['rpc', 'setLocale'])
-			expect(userStore.setGuestLanguage).not.toHaveBeenCalled()
+			// The authenticated path leaves the anonymous detector cache untouched;
+			// the DB row is the source of truth.
+			expect(localStorage.getItem(StorageKeys.language)).toBeNull()
 		})
 
 		it('rethrows when RPC fails so the caller can surface a Snack', async () => {
@@ -99,7 +110,7 @@ describe('changeLocale', () => {
 				changeLocale({ i18n, auth, userStore }, 'en'),
 			).rejects.toThrow('network')
 			expect(i18n.setLocale).not.toHaveBeenCalled()
-			expect(userStore.setGuestLanguage).not.toHaveBeenCalled()
+			expect(localStorage.getItem(StorageKeys.language)).toBeNull()
 		})
 	})
 })

--- a/src/util/change-locale.ts
+++ b/src/util/change-locale.ts
@@ -1,4 +1,5 @@
 import type { I18N } from '@aurelia/i18n'
+import { StorageKeys } from '../constants/storage-keys'
 import type { IAuthService } from '../services/auth-service'
 import type { IUserStore } from '../services/user-store'
 
@@ -48,12 +49,13 @@ export interface ChangeLocaleDeps {
  *
  * Routes persistence based on the caller's auth state:
  *
- * - **Unauthenticated** (Welcome / guest Settings): write through to the
- *   observable guest language source (`UserStore.setGuestLanguage`, which
- *   persists to `localStorage['guest.language']` via its `guestLanguageChanged`
- *   hook) after `i18n.setLocale`. Writing through the @observable owner — not
- *   raw localStorage — keeps `UserStore.currentLanguage` reactive so the
- *   language selector highlight follows the active locale. No backend call.
+ * - **Unauthenticated** (Welcome / guest Settings): call `i18n.setLocale` then
+ *   persist the choice explicitly to the single `localStorage['language']` key
+ *   (the i18next detector cache). `UserStore.currentLanguage` derives the guest
+ *   highlight from the reactive `i18nLocale` mirror that `setLocale` updates, so
+ *   the selector follows the active locale with no separate guest key. The
+ *   explicit write makes persistence ordering-independent rather than relying on
+ *   the detector's implicit cache side-effect. No backend call.
  *
  * - **Authenticated** (Settings page): call `UserStore.updatePreferredLanguage`
  *   first, apply `i18n.setLocale` after success. The backend row is the source
@@ -77,7 +79,7 @@ export async function changeLocale(
 
 	if (!auth.isAuthenticated) {
 		await i18n.setLocale(lang)
-		userStore.setGuestLanguage(lang)
+		localStorage.setItem(StorageKeys.language, lang)
 		return
 	}
 

--- a/test/routes/settings-route.spec.ts
+++ b/test/routes/settings-route.spec.ts
@@ -57,11 +57,9 @@ describe('SettingsRoute', () => {
 			  }
 			| undefined
 		guestHome: string | null
-		guestLanguage: string | null
 		readonly currentHome: string | null
 		readonly currentLanguage: string
 		setGuestHome: ReturnType<typeof vi.fn>
-		setGuestLanguage: ReturnType<typeof vi.fn>
 		resendEmailVerification: ReturnType<typeof vi.fn>
 		clear: ReturnType<typeof vi.fn>
 		updatePreferredLanguage: ReturnType<typeof vi.fn>
@@ -91,7 +89,6 @@ describe('SettingsRoute', () => {
 		mockUserStore = {
 			current: { id: 'user-uuid-1', preferredLanguage: 'ja' },
 			guestHome: null,
-			guestLanguage: null,
 			get currentHome(): string | null {
 				return mockAuth.isAuthenticated
 					? (mockUserStore.current?.home?.level1 ?? null)
@@ -101,13 +98,13 @@ describe('SettingsRoute', () => {
 				if (mockAuth.isAuthenticated) {
 					return mockUserStore.current?.preferredLanguage ?? 'ja'
 				}
-				return mockUserStore.guestLanguage ?? 'ja'
+				// Single source of truth: the guest locale is the active i18n
+				// locale, mirrored from the detector's `language` key that
+				// changeLocale writes explicitly — no separate guest.language key.
+				return localStorage.getItem('language') ?? 'ja'
 			},
 			setGuestHome: vi.fn((code: string) => {
 				mockUserStore.guestHome = code
-			}),
-			setGuestLanguage: vi.fn((lang: string) => {
-				mockUserStore.guestLanguage = lang
 			}),
 			resendEmailVerification: vi.fn().mockResolvedValue(undefined),
 			clear: vi.fn(),
@@ -439,7 +436,7 @@ describe('SettingsRoute', () => {
 			expect(mockUser.updatePreferredLanguage).not.toHaveBeenCalled()
 		})
 
-		it('guest language change writes through the observable guest source and the selector reflects it (reactive)', async () => {
+		it('guest language change persists to the single language key and the selector reflects it (reactive)', async () => {
 			const guestSut = buildGuestSut()
 			// Before the change the guest has made no explicit choice; the
 			// selector highlight falls back to the active i18n locale ('ja').
@@ -447,12 +444,12 @@ describe('SettingsRoute', () => {
 
 			await guestSut.selectLanguage('en')
 
-			// changeLocale writes through UserStore.setGuestLanguage (the
-			// @observable owner) rather than raw localStorage, so the store —
-			// and therefore the Settings selector binding — reflects the new
-			// language immediately. This is the guest language-selector
-			// reactivity fix.
-			expect(mockUserStore.setGuestLanguage).toHaveBeenCalledWith('en')
+			// changeLocale's guest path persists to the single `language` key (the
+			// i18next detector cache). The store derives the guest selector
+			// highlight from the active i18n locale (mirrored from that key), so the
+			// Settings selector binding reflects the new language immediately and can
+			// never disagree with the rendered UI.
+			expect(localStorage.getItem('language')).toBe('en')
 			expect(guestSut.currentLocale).toBe('en')
 		})
 	})

--- a/test/routes/welcome-route.spec.ts
+++ b/test/routes/welcome-route.spec.ts
@@ -74,7 +74,6 @@ describe('WelcomeRoute', () => {
 	let mockUserStore: {
 		clearGuest: ReturnType<typeof vi.fn>
 		currentLanguage: string
-		setGuestLanguage: ReturnType<typeof vi.fn>
 	}
 	let mockFollowStore: { clearGuest: ReturnType<typeof vi.fn> }
 	let mockI18n: ReturnType<typeof createMockI18n>
@@ -99,14 +98,12 @@ describe('WelcomeRoute', () => {
 			toDateGroups: vi.fn().mockReturnValue([]),
 		}
 		// The language picker reads its checked state from UserStore's reactive
-		// `currentLanguage` projection (no local @observable mirror) and writes
-		// through `setGuestLanguage` on selection (via changeLocale's guest path).
+		// `currentLanguage` projection (no local @observable mirror). On selection
+		// changeLocale's guest path calls i18n.setLocale then persists the choice
+		// to the single `localStorage['language']` key — no store-owned guest key.
 		mockUserStore = {
 			clearGuest: vi.fn(),
 			currentLanguage: 'ja',
-			setGuestLanguage: vi.fn((lang: string) => {
-				mockUserStore.currentLanguage = lang
-			}),
 		}
 		mockFollowStore = { clearGuest: vi.fn() }
 		mockRouter = createMockRouter()
@@ -209,23 +206,25 @@ describe('WelcomeRoute', () => {
 			expect(sut.currentLocale).toBe('ja')
 		})
 
-		it('selectLanguage routes the guest locale change through changeLocale → i18n + UserStore', async () => {
+		it('selectLanguage routes the guest locale change through changeLocale → i18n + single language key', async () => {
+			localStorage.removeItem('language')
 			// Active locale starts at 'ja' (mock i18n default); pick 'en'.
 			await sut.selectLanguage('en')
 
 			expect(mockI18n.setLocale).toHaveBeenCalledWith('en')
-			expect(mockUserStore.setGuestLanguage).toHaveBeenCalledWith('en')
-			// The picker now reflects the new active language through the store
-			// projection, keeping the radio's checked state correct.
-			expect(sut.currentLocale).toBe('en')
+			// The anonymous choice is persisted to the single `language` key (the
+			// i18next detector cache) — no separate guest.language key.
+			expect(localStorage.getItem('language')).toBe('en')
+			localStorage.removeItem('language')
 		})
 
 		it('selectLanguage is a no-op when the locale is unchanged', async () => {
+			localStorage.removeItem('language')
 			// Active locale is 'ja'; selecting 'ja' must not re-persist.
 			await sut.selectLanguage('ja')
 
 			expect(mockI18n.setLocale).not.toHaveBeenCalled()
-			expect(mockUserStore.setGuestLanguage).not.toHaveBeenCalled()
+			expect(localStorage.getItem('language')).toBeNull()
 		})
 	})
 

--- a/test/services/user-store.spec.ts
+++ b/test/services/user-store.spec.ts
@@ -10,10 +10,10 @@ import { IUserStore, UserStore } from '../../src/services/user-store'
 import { createTestContainer } from '../helpers/create-container'
 import { createMockAuth } from '../helpers/mock-auth'
 
-// Dedicated guest keys (decoupled from the i18next detector's 'language'
-// cache). Kept in sync with guest-storage.ts.
+// Dedicated guest key for the home slice. Kept in sync with guest-storage.ts.
+// The anonymous locale is NOT stored here — it lives solely in the i18next
+// detector's own 'language' cache (single source of truth).
 const GUEST_HOME_KEY = 'guest.home'
-const GUEST_LANGUAGE_KEY = 'guest.language'
 // The i18next-browser-languagedetector's own active-locale cache key.
 const DETECTOR_LANGUAGE_KEY = 'language'
 
@@ -97,15 +97,14 @@ function makeRpcClient() {
 	}
 }
 
-// UserStore now OWNS both the guest home/language slice (hydrating from
-// localStorage on construction) AND the authenticated User entity (the
-// cache→Get→Create chain + write-through updates, absorbed from the former
-// UserService). Seed the dedicated guest keys BEFORE building so the store's
-// @observable fields pick them up.
-function seedGuest(opts?: { home?: string | null; language?: string | null }) {
+// UserStore now OWNS both the guest home slice (hydrating from localStorage on
+// construction) AND the authenticated User entity (the cache→Get→Create chain +
+// write-through updates, absorbed from the former UserService). Seed the
+// dedicated guest home key BEFORE building so the store's @observable field
+// picks it up. The anonymous locale has no store-owned key — it is derived from
+// the active i18n locale via the reactive `i18nLocale` mirror.
+function seedGuest(opts?: { home?: string | null }) {
 	if (opts?.home != null) localStorage.setItem(GUEST_HOME_KEY, opts.home)
-	if (opts?.language != null)
-		localStorage.setItem(GUEST_LANGUAGE_KEY, opts.language)
 }
 
 function build(opts: {
@@ -139,26 +138,19 @@ describe('UserStore', () => {
 	})
 
 	describe('currentLanguage — guest', () => {
-		it('falls back to the active i18n locale when the guest made no explicit choice', () => {
+		it('derives from the active i18n locale (single source of truth)', () => {
 			const { store } = build({ auth: makeAuth(false) })
-			// createTestContainer's mock i18n.getLocale() defaults to 'ja'.
+			// createTestContainer's mock i18n.getLocale() defaults to 'ja'. The
+			// guest locale is the reactive `i18nLocale` mirror — no separate
+			// guest.language key shadows it.
 			expect(store.currentLanguage).toBe('ja')
 		})
 
-		it('reflects an explicit guest language choice from the observable source', () => {
-			seedGuest({ language: 'en' })
+		it('exposes no guest-language storage surface', () => {
 			const { store } = build({ auth: makeAuth(false) })
-			expect(store.currentLanguage).toBe('en')
-		})
-
-		it('updates reactively when the guest language changes', () => {
-			const { store } = build({ auth: makeAuth(false) })
-			expect(store.currentLanguage).toBe('ja')
-
-			// Mutating the @observable guest source re-resolves the getter with
-			// no manual mirror. The store owns the setter now.
-			store.setGuestLanguage('en')
-			expect(store.currentLanguage).toBe('en')
+			// The redundant `guest.language` plumbing is gone.
+			expect('guestLanguage' in store).toBe(false)
+			expect('setGuestLanguage' in store).toBe(false)
 		})
 	})
 
@@ -228,47 +220,33 @@ describe('UserStore', () => {
 		})
 	})
 
-	// Round-trip against the REAL guest-storage keys, exercising the dedicated
-	// 'guest.home' / 'guest.language' keys (decoupled from the i18next detector's
-	// 'language' cache).
+	// Round-trip against the REAL guest-storage key for the home slice, plus the
+	// single-source locale contract: the store never writes a `guest.language`
+	// key and clearGuest never touches the detector's 'language' cache.
 	describe('guest slice — real localStorage round-trip', () => {
-		it('falls back to the i18n mirror when no explicit choice was stored', () => {
-			// No 'guest.language' key written → loadLanguage() returns null.
-			const { store } = build({ auth: makeAuth(false) })
-			expect(store.guestLanguage).toBeNull()
-			expect(localStorage.getItem(GUEST_LANGUAGE_KEY)).toBeNull()
-			expect(store.currentLanguage).toBe('ja')
-		})
-
-		it('persists and reflects an explicit guest choice via the dedicated key', () => {
+		it('persists the guest home via the dedicated key', () => {
 			const { store } = build({ auth: makeAuth(false) })
 
-			store.setGuestLanguage('ja')
-			// guestLanguageChanged() write-through hits the real saveLanguage.
-			expect(localStorage.getItem(GUEST_LANGUAGE_KEY)).toBe('ja')
-
-			store.setGuestLanguage('en')
-			expect(store.guestLanguage).toBe('en')
-			expect(localStorage.getItem(GUEST_LANGUAGE_KEY)).toBe('en')
-			expect(store.currentLanguage).toBe('en')
+			store.setGuestHome('JP-13')
+			// guestHomeChanged() write-through hits the real saveHome.
+			expect(localStorage.getItem(GUEST_HOME_KEY)).toBe('JP-13')
+			expect(store.currentHome).toBe('JP-13')
 		})
 
-		it('clearGuest() removes only the guest keys, never the detector cache', () => {
+		it('clearGuest() clears the guest home but never the detector cache', () => {
 			// Seed the detector's own active-locale cache (written by
 			// i18next-browser-languagedetector, NOT the store).
 			localStorage.setItem(DETECTOR_LANGUAGE_KEY, 'en')
 
 			const { store } = build({ auth: makeAuth(false) })
 			store.setGuestHome('JP-13')
-			store.setGuestLanguage('en')
-			expect(localStorage.getItem(GUEST_LANGUAGE_KEY)).toBe('en')
 
 			store.clearGuest()
-			// guest.language + guest.home cleared (their dedicated keys removed) ...
-			expect(localStorage.getItem(GUEST_LANGUAGE_KEY)).toBeNull()
+			// guest.home cleared ...
 			expect(localStorage.getItem(GUEST_HOME_KEY)).toBeNull()
 			// ... but the detector's 'language' cache survives, so a cancelled
-			// login does not lose the chosen UI language.
+			// login does not lose the chosen UI language. The anonymous locale has
+			// no store-owned key for clearGuest to touch.
 			expect(localStorage.getItem(DETECTOR_LANGUAGE_KEY)).toBe('en')
 		})
 	})


### PR DESCRIPTION
## Summary

A guest (unauthenticated) user could see the language selector highlight **日本語** while the UI rendered in **English**. The anonymous locale lived in two decoupled `localStorage` keys — `language` (the i18next detector cache that drives the rendered locale) and `guest.language` (UserStore-owned, drove only the selector highlight) — with no boot-time reconciliation, so they drifted.

This change makes the anonymous locale a **single source of truth** and, along the way, fixes a deeper boot-locale bug found during verification.

## What changed

- **Removed `guest.language`** and all its plumbing (`KEY_LANGUAGE`/`saveLanguage`/`loadLanguage`, the `guestLanguage` observable/`setGuestLanguage`/`guestLanguageChanged`). The guest selector highlight now derives from UserStore's reactive `i18nLocale` mirror, so it can never disagree with the rendered UI.
- **`changeLocale` anonymous path** persists explicitly to the single `localStorage['language']` key.
- **`clearGuest`** no longer touches the locale (cancelled-login keeps the language).
- **One-time migration** in `migrateStorageKeys()`: promote a legacy `guest.language` into `language` (explicit choice wins), then remove it.
- **Re-enabled the i18next detection chain** (`initOptions.lng = undefined` in `main.ts`). Verification revealed `@aurelia/i18n` injects a default `lng: 'en'` that **bypasses the language detector entirely** — so the configured `querystring → localStorage → navigator` chain was dead code and the persisted `language` was never read at boot (the app always rendered English). See OpenSpec change `unify-guest-locale-single-source`, design Decision 5.

## Testing

- `make check` green (108 files / 1208 unit tests; updated `change-locale`, `user-store`, `welcome-route`, `settings-route` specs + new `storage-keys` migration spec).
- **Manual in-browser verification (localhost:9000):**
  - Bug repro (`language=en` + `guest.language=ja`) → after migration, UI renders Japanese, selector highlights 日本語, `guest.language` removed.
  - Anonymous happy-path: switch ja↔en on Welcome, reload, choice persists with only the `language` key, selector matches UI.
  - Cancelled-login: tap Login (runs `clearGuest`) with locale=ja → `language` survives, UI stays Japanese after reload.

Closes #418