### PR TITLE
feat(dashboard): add ticket-journey filter facet and counted artist chips

### DIFF
--- a/e2e/functional/artist-filter-bar.spec.ts
+++ b/e2e/functional/artist-filter-bar.spec.ts
@@ -28,7 +28,9 @@ async function mockRpcRoutes(page: Page): Promise<void> {
 			})
 		}
 
-		if (url.includes('ListByFollower')) {
+		// ListByFollower is the authenticated path; ListWithProximity is the guest
+		// path (ConcertStore.listByFollowerGuest). Both return the same groups.
+		if (url.includes('ListByFollower') || url.includes('ListWithProximity')) {
 			return route.fulfill({
 				status: 200,
 				contentType: 'application/json',
@@ -54,6 +56,32 @@ async function mockRpcRoutes(page: Page): Promise<void> {
 									],
 									series: {
 										id: { value: 's-1' },
+										title: { value: 'Zepp Live' },
+									},
+									localDate: {
+										value: {
+											year: tomorrow.getFullYear(),
+											month: tomorrow.getMonth() + 1,
+											day: tomorrow.getDate(),
+										},
+									},
+									venue: {
+										name: { value: 'Zepp DiverCity' },
+										adminArea: { value: 'JP-13' },
+									},
+									sourceUrl: { value: 'https://example.com' },
+								},
+								{
+									id: { value: 'c-2' },
+									performers: [
+										{
+											id: { value: 'artist-2' },
+											name: { value: 'Vaundy' },
+											mbid: { value: '' },
+										},
+									],
+									series: {
+										id: { value: 's-2' },
 										title: { value: 'Zepp Live' },
 									},
 									localDate: {
@@ -129,15 +157,20 @@ test.describe('Artist filter bar bottom sheet', () => {
 		await page.waitForLoadState('networkidle')
 
 		// Open the filter sheet
-		await page.click('button[aria-label="アーティストで絞り込む"]')
+		await page.click('button[aria-label="絞り込む"]')
 
 		// Sheet should be open with artist list
 		const sheet = page.locator('artist-filter-bar bottom-sheet')
 		await expect(sheet).toBeVisible()
 
-		// Both artists should be visible in the sheet
-		await expect(page.getByText('YOASOBI')).toBeVisible()
-		await expect(page.getByText('Vaundy')).toBeVisible()
+		// Both artists should be present as chips in the sheet (scoped to the
+		// sheet — the artist name also appears on the concert-highway cards).
+		await expect(
+			sheet.locator('label.artist-chip', { hasText: 'YOASOBI' }),
+		).toBeVisible()
+		await expect(
+			sheet.locator('label.artist-chip', { hasText: 'Vaundy' }),
+		).toBeVisible()
 	})
 
 	test('selecting an artist and confirming activates the filter button', async ({
@@ -159,18 +192,56 @@ test.describe('Artist filter bar bottom sheet', () => {
 		await page.goto('/dashboard')
 		await page.waitForLoadState('networkidle')
 
-		await page.click('button[aria-label="アーティストで絞り込む"]')
-		await expect(page.getByText('YOASOBI')).toBeVisible()
+		await page.click('button[aria-label="絞り込む"]')
+		const yoasobiChip = page.locator('label.artist-chip', {
+			hasText: 'YOASOBI',
+		})
+		await expect(yoasobiChip).toBeVisible()
 
 		// Click the YOASOBI chip (input is visually-hidden; click the label instead)
-		await page.locator('label.artist-chip', { hasText: 'YOASOBI' }).click()
+		await yoasobiChip.click()
 
 		// Confirm
 		await page.click('button.btn-confirm')
 
 		// Filter button should show active state; no chips in the header
-		const filterBtn = page.locator('button[aria-label="アーティストで絞り込む"]')
+		const filterBtn = page.locator('button[aria-label="絞り込む"]')
 		await expect(filterBtn).toHaveAttribute('data-active', 'true')
 		await expect(page.locator('.chip-name')).toHaveCount(0)
+	})
+
+	test('round-trips the artist filter through the URL query param', async ({
+		page,
+	}) => {
+		await page.addInitScript(() => {
+			localStorage.setItem('onboardingStep', 'completed')
+			localStorage.setItem('onboarding.celebrationShown', '1')
+			localStorage.setItem('guest.home', 'JP-13')
+			localStorage.setItem(
+				'guest.followedArtists',
+				JSON.stringify([
+					{ artist: { id: 'artist-1', name: 'YOASOBI', mbid: '' }, hype: 'watch' },
+					{ artist: { id: 'artist-2', name: 'Vaundy', mbid: '' }, hype: 'watch' },
+				]),
+			)
+		})
+
+		// Deep link: the artist filter is parsed from the URL on load.
+		await page.goto('/dashboard?artists=artist-1')
+		await page.waitForLoadState('networkidle')
+
+		const filterBtn = page.locator('button[aria-label="絞り込む"]')
+		await expect(filterBtn).toHaveAttribute('data-active', 'true')
+
+		// Open the sheet; the deep-linked artist is pre-selected.
+		await filterBtn.click()
+		const yoasobiChip = page.locator('label.artist-chip', { hasText: 'YOASOBI' })
+		await expect(yoasobiChip.locator('input')).toBeChecked()
+
+		// Add the second artist and confirm — the URL reflects both, written once.
+		await page.locator('label.artist-chip', { hasText: 'Vaundy' }).click()
+		await page.click('button.btn-confirm')
+
+		await expect(page).toHaveURL(/\/dashboard\?artists=artist-1,artist-2$/)
 	})
 })

--- a/src/components/artist-filter-bar/artist-filter-bar.css
+++ b/src/components/artist-filter-bar/artist-filter-bar.css
@@ -106,6 +106,19 @@
 			}
 		}
 
+		/* ── Facet section: heading + chip group ── */
+		.filter-facet {
+			display: flex;
+			flex-direction: column;
+			gap: var(--space-2xs);
+		}
+
+		.facet-heading {
+			font-size: var(--step--1);
+			font-weight: 600;
+			color: var(--color-text-muted);
+		}
+
 		/* ── Artist chip list (flex wrap — single-axis wrapping flow) ── */
 		.artists-list {
 			display: flex;
@@ -116,6 +129,17 @@
 			padding: 0;
 
 			list-style: none;
+		}
+
+		/* Upcoming-concert count prefix on each artist chip. */
+		.artist-count {
+			font-weight: 600;
+			font-variant-numeric: tabular-nums;
+			color: var(--color-text-muted);
+		}
+
+		.artist-chip:has(input:checked) .artist-count {
+			color: var(--color-text-primary);
 		}
 
 		/* ── Individual chip ──
@@ -179,6 +203,89 @@
 					display: block;
 				}
 			}
+		}
+
+		/* ── Journey-status chip group ── */
+		.journey-list {
+			display: flex;
+			flex-wrap: wrap;
+			gap: var(--space-2xs);
+
+			margin: 0;
+			padding: 0;
+
+			list-style: none;
+		}
+
+		/* Forces a wrap: process chips land on the row above the outcome chips. */
+		.journey-list-break {
+			flex-basis: 100%;
+			block-size: 0;
+		}
+
+		/* Unselected: neutral outline retaining icon + label (non-colour cue).
+		   Selected: filled with the status's semantic hue via :has(input:checked).
+		   --_hue is set per status below so one rule body covers every chip. */
+		.journey-chip {
+			cursor: pointer;
+
+			display: flex;
+			gap: var(--space-3xs);
+			align-items: center;
+
+			padding: var(--space-3xs) var(--space-s);
+			border: 1px solid var(--color-border-muted);
+			border-radius: var(--radius-full);
+
+			font-size: var(--step--1);
+			color: var(--color-text-secondary);
+
+			background: var(--color-surface-raised);
+
+			transition:
+				border-color var(--transition-fast),
+				background var(--transition-fast),
+				color var(--transition-fast);
+
+			&[data-journey-status="tracking"] {
+				--_hue: var(--journey-hue-tracking);
+			}
+
+			&[data-journey-status="applied"] {
+				--_hue: var(--journey-hue-applied);
+			}
+
+			&[data-journey-status="unpaid"] {
+				--_hue: var(--journey-hue-unpaid);
+			}
+
+			&[data-journey-status="paid"] {
+				--_hue: var(--journey-hue-paid);
+			}
+
+			&[data-journey-status="lost"] {
+				--_hue: var(--journey-hue-lost);
+			}
+
+			&:hover {
+				border-color: oklch(65% 0.14 var(--_hue) / 60%);
+			}
+
+			&:focus-within {
+				outline: 2px solid var(--color-brand-primary);
+				outline-offset: 2px;
+			}
+
+			/* Selected: fill with the status hue, label flips to high-contrast. */
+			&:has(input:checked) {
+				border-color: oklch(65% 0.16 var(--_hue));
+				color: var(--color-white);
+				background: oklch(58% 0.16 var(--_hue));
+			}
+		}
+
+		.journey-chip-icon {
+			line-height: var(--leading-none);
 		}
 
 		/* ── Confirm button row ── */

--- a/src/components/artist-filter-bar/artist-filter-bar.html
+++ b/src/components/artist-filter-bar/artist-filter-bar.html
@@ -6,24 +6,24 @@
   type="button"
   class="filter-trigger"
   click.trigger="openSheet()"
-  aria-label="アーティストで絞り込む"
-  data-active.bind="selectedIds.length > 0"
+  aria-label="絞り込む"
+  data-active.bind="selectedIds.length > 0 || selectedStatuses.length > 0"
 >
   <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24" width="16" height="16">
     <path d="M3 6h18M7 12h10M11 18h2" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
   </svg>
 </button>
 
-<!-- Artist selection bottom sheet -->
+<!-- Filter bottom sheet -->
 <!-- sheet-closed keeps isSheetOpen in sync when user swipes/clicks outside -->
 <bottom-sheet
   open.bind="isSheetOpen"
   sheet-closed.trigger="closeSheet()"
   aria-labelledby="filter-sheet-title"
 >
-  <section class="filter-sheet-content">
+  <div class="filter-sheet-content">
     <div class="sheet-header">
-      <h2 class="sheet-title" id="filter-sheet-title">アーティストで絞り込む</h2>
+      <h2 class="sheet-title" id="filter-sheet-title">絞り込み</h2>
       <button
         type="button"
         class="btn-clear-all"
@@ -32,25 +32,69 @@
       >全て解除</button>
     </div>
 
-    <ul class="artists-list" aria-labelledby="filter-sheet-title">
-      <li repeat.for="artist of followedArtists">
-        <label class="artist-chip">
-          <input
-            type="checkbox"
-            class="visually-hidden"
-            checked.bind="pendingIds"
-            model.bind="artist.id"
-          />
-          <svg class="chip-check" aria-hidden="true" focusable="false" viewBox="0 0 12 12" width="12" height="12">
-            <path d="M2 6l3 3 5-5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
-          </svg>
-          <span>${artist.name}</span>
-        </label>
-      </li>
-    </ul>
+    <!-- Artist facet -->
+    <section class="filter-facet" aria-labelledby="filter-artist-heading">
+      <h3 class="facet-heading" id="filter-artist-heading">アーティスト</h3>
+      <ul class="artists-list" aria-labelledby="filter-artist-heading">
+        <li repeat.for="artist of countedArtists" key.bind="artist.id">
+          <label class="artist-chip">
+            <input
+              type="checkbox"
+              class="visually-hidden"
+              checked.bind="pendingIds"
+              model.bind="artist.id"
+            />
+            <svg class="chip-check" aria-hidden="true" focusable="false" viewBox="0 0 12 12" width="12" height="12">
+              <path d="M2 6l3 3 5-5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+            </svg>
+            <span class="artist-count">${artist.count}</span>
+            <span>${artist.name}</span>
+          </label>
+        </li>
+      </ul>
+    </section>
+
+    <!-- Journey-status facet (authenticated users only) -->
+    <section
+      if.bind="showJourneyFacet"
+      class="filter-facet"
+      aria-labelledby="filter-journey-heading"
+    >
+      <h3 class="facet-heading" id="filter-journey-heading" t="eventDetail.ticketStatus"></h3>
+      <ul class="journey-list" aria-labelledby="filter-journey-heading">
+        <!-- Process phase: tracking -> applied -->
+        <li repeat.for="config of processStatuses" key.bind="config.status">
+          <label class="journey-chip" data-journey-status.bind="config.status">
+            <input
+              type="checkbox"
+              class="visually-hidden"
+              checked.bind="pendingStatuses"
+              model.bind="config.status"
+            />
+            <span class="journey-chip-icon" aria-hidden="true">${config.icon}</span>
+            <span t.bind="config.labelKey"></span>
+          </label>
+        </li>
+        <!-- Visual break separating process from outcome -->
+        <li class="journey-list-break" aria-hidden="true"></li>
+        <!-- Outcome phase: unpaid, paid, lost -->
+        <li repeat.for="config of outcomeStatuses" key.bind="config.status">
+          <label class="journey-chip" data-journey-status.bind="config.status">
+            <input
+              type="checkbox"
+              class="visually-hidden"
+              checked.bind="pendingStatuses"
+              model.bind="config.status"
+            />
+            <span class="journey-chip-icon" aria-hidden="true">${config.icon}</span>
+            <span t.bind="config.labelKey"></span>
+          </label>
+        </li>
+      </ul>
+    </section>
 
     <div class="confirm-row">
       <button type="button" class="btn-confirm" click.trigger="confirmSelection()">完了</button>
     </div>
-  </section>
+  </div>
 </bottom-sheet>

--- a/src/components/artist-filter-bar/artist-filter-bar.spec.ts
+++ b/src/components/artist-filter-bar/artist-filter-bar.spec.ts
@@ -5,11 +5,11 @@ vi.mock('aurelia', async (importOriginal) => {
 	return { ...actual, bindable: actual.bindable }
 })
 
-import type { Artist } from '../../entities/artist'
+import type { CountedArtist } from '../../entities/artist'
 import { ArtistFilterBar } from './artist-filter-bar'
 
-function makeArtist(id: string, name: string): Artist {
-	return { id, name } as Artist
+function makeCounted(id: string, name: string, count: number): CountedArtist {
+	return { id, name, count }
 }
 
 describe('ArtistFilterBar', () => {
@@ -18,64 +18,116 @@ describe('ArtistFilterBar', () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
 		sut = new ArtistFilterBar()
-		sut.followedArtists = [
-			makeArtist('a1', 'Artist One'),
-			makeArtist('a2', 'Artist Two'),
+		sut.countedArtists = [
+			makeCounted('a1', 'Artist One', 3),
+			makeCounted('a2', 'Artist Two', 1),
 		]
 	})
 
 	describe('openSheet', () => {
-		it('copies selectedIds to pendingIds and opens the sheet', () => {
+		it('copies both facet selections to pending and opens the sheet', () => {
 			sut.selectedIds = ['a1']
+			sut.selectedStatuses = ['applied']
 			sut.openSheet()
 
 			expect(sut.pendingIds).toEqual(['a1'])
+			expect(sut.pendingStatuses).toEqual(['applied'])
 			expect(sut.isSheetOpen).toBe(true)
+		})
+
+		it('resets pending selections to current on a second open', () => {
+			sut.selectedIds = ['a1']
+			sut.selectedStatuses = ['applied']
+			sut.openSheet()
+			sut.pendingIds = ['a1', 'a2']
+			sut.pendingStatuses = ['applied', 'paid']
+
+			sut.openSheet()
+
+			expect(sut.pendingIds).toEqual(['a1'])
+			expect(sut.pendingStatuses).toEqual(['applied'])
 		})
 	})
 
 	describe('confirmSelection', () => {
-		it('commits pendingIds to selectedIds and closes the sheet', () => {
-			sut.selectedIds = ['a1']
+		it('commits both pending facets and closes the sheet', () => {
 			sut.openSheet()
 			sut.pendingIds = ['a1', 'a2']
+			sut.pendingStatuses = ['unpaid']
 			sut.confirmSelection()
 
 			expect(sut.selectedIds).toEqual(['a1', 'a2'])
+			expect(sut.selectedStatuses).toEqual(['unpaid'])
 			expect(sut.isSheetOpen).toBe(false)
 		})
 
-		it('clears selectedIds when all pending are deselected', () => {
+		it('clears both filters when all pending are deselected', () => {
 			sut.selectedIds = ['a1']
+			sut.selectedStatuses = ['applied']
 			sut.openSheet()
 			sut.pendingIds = []
+			sut.pendingStatuses = []
 			sut.confirmSelection()
 
 			expect(sut.selectedIds).toEqual([])
+			expect(sut.selectedStatuses).toEqual([])
 		})
 	})
 
-	describe('openSheet with empty followedArtists', () => {
-		it('sets pendingIds to [] when followedArtists is empty', () => {
-			sut.followedArtists = []
-			sut.selectedIds = []
+	describe('clearAll', () => {
+		it('clears pending selections across both facets', () => {
 			sut.openSheet()
+			sut.pendingIds = ['a1']
+			sut.pendingStatuses = ['applied']
+
+			sut.clearAll()
 
 			expect(sut.pendingIds).toEqual([])
-			expect(sut.isSheetOpen).toBe(true)
+			expect(sut.pendingStatuses).toEqual([])
 		})
 	})
 
-	describe('openSheet called twice', () => {
-		it('resets pendingIds to current selectedIds on second open', () => {
-			sut.selectedIds = ['a1']
-			sut.openSheet()
-			sut.pendingIds = ['a1', 'a2']
+	describe('hasPendingSelection', () => {
+		it('is true when only an artist is pending', () => {
+			sut.pendingIds = ['a1']
+			sut.pendingStatuses = []
+			expect(sut.hasPendingSelection).toBe(true)
+		})
 
-			// Open again without confirming — pendingIds should reset
-			sut.openSheet()
+		it('is true when only a journey status is pending', () => {
+			sut.pendingIds = []
+			sut.pendingStatuses = ['paid']
+			expect(sut.hasPendingSelection).toBe(true)
+		})
 
-			expect(sut.pendingIds).toEqual(['a1'])
+		it('is false when nothing is pending in either facet', () => {
+			sut.pendingIds = []
+			sut.pendingStatuses = []
+			expect(sut.hasPendingSelection).toBe(false)
+		})
+	})
+
+	describe('showJourneyFacet', () => {
+		it('is hidden for guests and shown for authenticated users', () => {
+			sut.isAuthenticated = false
+			expect(sut.showJourneyFacet).toBe(false)
+
+			sut.isAuthenticated = true
+			expect(sut.showJourneyFacet).toBe(true)
+		})
+	})
+
+	describe('journey phase ordering', () => {
+		it('splits statuses into process then outcome with the flow order', () => {
+			expect(sut.processStatuses.map((c) => c.status)).toEqual([
+				'tracking',
+				'applied',
+			])
+			expect(sut.outcomeStatuses.map((c) => c.status)).toEqual([
+				'unpaid',
+				'paid',
+				'lost',
+			])
 		})
 	})
 })

--- a/src/components/artist-filter-bar/artist-filter-bar.ts
+++ b/src/components/artist-filter-bar/artist-filter-bar.ts
@@ -1,21 +1,49 @@
 import { bindable, observable } from 'aurelia'
-import type { Artist } from '../../entities/artist'
+import type { CountedArtist } from '../../entities/artist'
+import type { JourneyStatus } from '../../entities/concert'
+import {
+	JOURNEY_STATUS_CONFIG,
+	type JourneyStatusConfig,
+	journeyOutcome,
+} from '../../entities/ticket-journey'
 
 export class ArtistFilterBar {
-	@bindable public followedArtists: Artist[] = []
+	/** Followed artists with upcoming-concert counts (already sorted, zero hidden). */
+	@bindable public countedArtists: CountedArtist[] = []
 	@bindable({ mode: 'twoWay' }) public selectedIds: string[] = []
+	@bindable({ mode: 'twoWay' }) public selectedStatuses: JourneyStatus[] = []
+	/** Drives journey-facet visibility; the artist facet is always present. */
+	@bindable public isAuthenticated = false
 
 	public isSheetOpen = false
 
-	/** Pending selection inside the bottom sheet (committed on confirm). */
+	/** Pending selections inside the bottom sheet (committed on confirm). */
 	@observable public pendingIds: string[] = []
+	@observable public pendingStatuses: JourneyStatus[] = []
+
+	/**
+	 * Journey chips split into the two journey-flow phases, so the template can
+	 * render a process row (tracking, applied) and an outcome row (unpaid, paid,
+	 * lost) with a visual break between them. Derived from the canonical map via
+	 * the existing outcome classifier — no inline ordering.
+	 */
+	public readonly processStatuses: readonly JourneyStatusConfig[] =
+		JOURNEY_STATUS_CONFIG.filter((c) => journeyOutcome(c.status) === 'pending')
+	public readonly outcomeStatuses: readonly JourneyStatusConfig[] =
+		JOURNEY_STATUS_CONFIG.filter((c) => journeyOutcome(c.status) !== 'pending')
+
+	/** Journey facet is gated to authenticated users (absent from the DOM otherwise). */
+	public get showJourneyFacet(): boolean {
+		return this.isAuthenticated
+	}
 
 	public get hasPendingSelection(): boolean {
-		return this.pendingIds.length > 0
+		return this.pendingIds.length > 0 || this.pendingStatuses.length > 0
 	}
 
 	public openSheet(): void {
 		this.pendingIds = [...this.selectedIds]
+		this.pendingStatuses = [...this.selectedStatuses]
 		this.isSheetOpen = true
 	}
 
@@ -25,10 +53,12 @@ export class ArtistFilterBar {
 
 	public clearAll(): void {
 		this.pendingIds = []
+		this.pendingStatuses = []
 	}
 
 	public confirmSelection(): void {
 		this.selectedIds = [...this.pendingIds]
+		this.selectedStatuses = [...this.pendingStatuses]
 		this.isSheetOpen = false
 	}
 }

--- a/src/components/live-highway/event-card.css
+++ b/src/components/live-highway/event-card.css
@@ -80,6 +80,10 @@
 			inset-block-start: var(--space-3xs);
 			inset-inline-end: var(--space-3xs);
 
+			display: inline-flex;
+			gap: var(--space-3xs);
+			align-items: center;
+
 			/* stylelint-disable-next-line cube/require-token-variables -- badge pill needs tighter padding than any token */
 			padding-block: 1px;
 			padding-inline: var(--space-3xs);
@@ -93,6 +97,12 @@
 			letter-spacing: 0.03em;
 
 			background: var(--_journey-bg);
+		}
+
+		/* Emoji keeps its own colour — exempt it from the badge text tint. */
+		.journey-badge-icon {
+			font-size: var(--step--1);
+			line-height: var(--leading-none);
 		}
 
 		/* Hues sourced from shared journey-hue tokens; the badge keeps its own

--- a/src/components/live-highway/event-card.html
+++ b/src/components/live-highway/event-card.html
@@ -20,10 +20,12 @@ class="[ event-card ]"
       ${event.locationLabel}
     </span>
     <span
-      if.bind="event.journeyStatus"
+      if.bind="journeyConfig"
       data-journey-status.bind="event.journeyStatus"
       class="journey-badge" data-testid="journey-badge"
-      t.bind="'eventDetail.journeyStatus.' + event.journeyStatus"
-    ></span>
+    >
+      <span class="journey-badge-icon" aria-hidden="true">${journeyConfig.icon}</span>
+      <span t.bind="journeyConfig.labelKey"></span>
+    </span>
   </article>
 </template>

--- a/src/components/live-highway/event-card.ts
+++ b/src/components/live-highway/event-card.ts
@@ -1,6 +1,10 @@
 import { bindable, INode, resolve } from 'aurelia'
 import { bestLogoUrl } from '../../entities/artist'
 import {
+	JOURNEY_STATUS_CONFIG_MAP,
+	type JourneyStatusConfig,
+} from '../../entities/ticket-journey'
+import {
 	Events,
 	IAnalyticsService,
 } from '../../lib/analytics/analytics-service'
@@ -17,6 +21,12 @@ export class EventCard {
 
 	public get logoUrl(): string | undefined {
 		return bestLogoUrl(this.event.artist)
+	}
+
+	/** Canonical label/icon/hue for the concert's journey status, if any. */
+	public get journeyConfig(): JourneyStatusConfig | undefined {
+		const status = this.event.journeyStatus
+		return status ? JOURNEY_STATUS_CONFIG_MAP[status] : undefined
 	}
 
 	public eventChanged(): void {

--- a/src/components/live-highway/event-detail-sheet.css
+++ b/src/components/live-highway/event-detail-sheet.css
@@ -246,39 +246,25 @@
 			background: var(--_bg-hover);
 		}
 
-		/* Cue glyph is chosen via a custom property to keep selector specificity low */
+		/* Holds the status's canonical emoji icon; node state (future / completed /
+		   current) is conveyed by the fill, border, and colour treatment below. */
 		.journey-node-cue {
-			font-weight: 700;
-
-			&::before {
-				content: var(--_cue, "\25cb"); /* default: circle (future) */
-			}
+			font-size: var(--step-0);
+			line-height: var(--leading-none);
 		}
 
-		/* Completed: low-emphasis outline with a check cue */
+		/* Completed: low-emphasis outline */
 		.journey-node[data-state="completed"] {
-			--_cue: "\2713"; /* check */
-
 			border-color: var(--_node-faint);
 			color: var(--color-text-muted);
 		}
 
 		/* Current: the single solid-filled node */
 		.journey-node[data-state="current"] {
-			--_cue: "\25cf"; /* filled dot */
-
 			border-color: var(--_node-fill);
 			font-weight: 700;
 			color: var(--_node-on);
 			background: var(--_node-fill);
-		}
-
-		.journey-node[data-state="current"][data-journey-status="unpaid"] {
-			--_cue: "\0021"; /* ! action required */
-		}
-
-		.journey-node[data-state="current"][data-journey-status="lost"] {
-			--_cue: "\2715"; /* cross */
 		}
 
 		/* Semantic hue per status sourced from shared journey-hue tokens;

--- a/src/components/live-highway/event-detail-sheet.html
+++ b/src/components/live-highway/event-detail-sheet.html
@@ -87,8 +87,8 @@
                 disabled.bind="journeyUpdating"
                 click.trigger="setJourneyStatus('tracking')"
               >
-                <span class="journey-node-cue" aria-hidden="true"></span>
-                <span class="journey-node-label" t="eventDetail.journeyStatus.tracking"></span>
+                <span class="journey-node-cue" aria-hidden="true">${journeyConfig.tracking.icon}</span>
+                <span class="journey-node-label" t.bind="journeyConfig.tracking.labelKey"></span>
               </button>
               <span class="journey-arrow" aria-hidden="true"></span>
               <button
@@ -102,8 +102,8 @@
                 disabled.bind="journeyUpdating"
                 click.trigger="setJourneyStatus('applied')"
               >
-                <span class="journey-node-cue" aria-hidden="true"></span>
-                <span class="journey-node-label" t="eventDetail.journeyStatus.applied"></span>
+                <span class="journey-node-cue" aria-hidden="true">${journeyConfig.applied.icon}</span>
+                <span class="journey-node-label" t.bind="journeyConfig.applied.labelKey"></span>
               </button>
             </div>
           </div>
@@ -137,8 +137,8 @@
                   disabled.bind="journeyUpdating"
                   click.trigger="setJourneyStatus('unpaid')"
                 >
-                  <span class="journey-node-cue" aria-hidden="true"></span>
-                  <span class="journey-node-label" t="eventDetail.journeyStatus.unpaid"></span>
+                  <span class="journey-node-cue" aria-hidden="true">${journeyConfig.unpaid.icon}</span>
+                  <span class="journey-node-label" t.bind="journeyConfig.unpaid.labelKey"></span>
                 </button>
                 <span class="journey-arrow journey-arrow-down" aria-hidden="true"></span>
                 <button
@@ -152,8 +152,8 @@
                   disabled.bind="journeyUpdating"
                   click.trigger="setJourneyStatus('paid')"
                 >
-                  <span class="journey-node-cue" aria-hidden="true"></span>
-                  <span class="journey-node-label" t="eventDetail.journeyStatus.paid"></span>
+                  <span class="journey-node-cue" aria-hidden="true">${journeyConfig.paid.icon}</span>
+                  <span class="journey-node-label" t.bind="journeyConfig.paid.labelKey"></span>
                 </button>
               </div>
 
@@ -173,8 +173,8 @@
                   disabled.bind="journeyUpdating"
                   click.trigger="setJourneyStatus('lost')"
                 >
-                  <span class="journey-node-cue" aria-hidden="true"></span>
-                  <span class="journey-node-label" t="eventDetail.journeyStatus.lost"></span>
+                  <span class="journey-node-cue" aria-hidden="true">${journeyConfig.lost.icon}</span>
+                  <span class="journey-node-label" t.bind="journeyConfig.lost.labelKey"></span>
                 </button>
               </div>
             </div>

--- a/src/components/live-highway/event-detail-sheet.ts
+++ b/src/components/live-highway/event-detail-sheet.ts
@@ -3,6 +3,7 @@ import { IHistory } from '../../adapter/browser/history'
 import { bestBackgroundUrl } from '../../entities/artist'
 import {
 	JOURNEY_NAV_ORDER,
+	JOURNEY_STATUS_CONFIG_MAP,
 	type JourneyNodeState,
 	type JourneyOutcome,
 	journeyNodeState,
@@ -22,6 +23,9 @@ export class EventDetailSheet {
 
 	public isOpen = false
 	public journeyUpdating = false
+
+	/** Canonical label/icon/hue per status, sourced once for every node. */
+	public readonly journeyConfig = JOURNEY_STATUS_CONFIG_MAP
 
 	private readonly logger = resolve(ILogger).scopeTo('EventDetailSheet')
 	private readonly journeyService = resolve(ITicketJourneyService)

--- a/src/entities/artist.ts
+++ b/src/entities/artist.ts
@@ -10,6 +10,16 @@ export interface Artist {
 }
 
 /**
+ * A followed artist projected with the count of its upcoming concerts in the
+ * loaded dashboard set — drives the count-prefixed, count-sorted filter chips.
+ */
+export interface CountedArtist {
+	id: string
+	name: string
+	count: number
+}
+
+/**
  * Community-curated artist images from fanart.tv.
  * @source proto/liverty_music/entity/v1/artist.proto — Fanart
  */

--- a/src/entities/ticket-journey.spec.ts
+++ b/src/entities/ticket-journey.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import type { JourneyStatus } from './concert'
+import {
+	JOURNEY_STATUS_CONFIG,
+	JOURNEY_STATUS_CONFIG_MAP,
+} from './ticket-journey'
+
+const ALL_STATUSES: readonly JourneyStatus[] = [
+	'tracking',
+	'applied',
+	'unpaid',
+	'paid',
+	'lost',
+]
+
+describe('JOURNEY_STATUS_CONFIG', () => {
+	it('covers all five journey statuses exactly once', () => {
+		const statuses = JOURNEY_STATUS_CONFIG.map((c) => c.status)
+		expect(statuses).toHaveLength(ALL_STATUSES.length)
+		expect(new Set(statuses)).toEqual(new Set(ALL_STATUSES))
+	})
+
+	it('reuses the existing eventDetail.journeyStatus.* i18n keys', () => {
+		for (const config of JOURNEY_STATUS_CONFIG) {
+			expect(config.labelKey).toBe(`eventDetail.journeyStatus.${config.status}`)
+		}
+	})
+
+	it('assigns the specified emoji icon per status', () => {
+		const iconByStatus = Object.fromEntries(
+			JOURNEY_STATUS_CONFIG.map((c) => [c.status, c.icon]),
+		)
+		expect(iconByStatus).toEqual({
+			tracking: '👀',
+			applied: '📝',
+			unpaid: '💰',
+			paid: '🎟️',
+			lost: '💔',
+		})
+	})
+
+	it('points each status at its shared journey-hue token', () => {
+		for (const config of JOURNEY_STATUS_CONFIG) {
+			expect(config.hueToken).toBe(`--journey-hue-${config.status}`)
+		}
+	})
+
+	it('exposes a by-status lookup covering every status', () => {
+		for (const status of ALL_STATUSES) {
+			expect(JOURNEY_STATUS_CONFIG_MAP[status].status).toBe(status)
+		}
+	})
+})

--- a/src/entities/ticket-journey.ts
+++ b/src/entities/ticket-journey.ts
@@ -12,6 +12,65 @@ import type { JourneyStatus } from './concert'
 /** Display state of a single journey node relative to the current status. */
 export type JourneyNodeState = 'completed' | 'current' | 'future'
 
+/** Presentation metadata for a single journey status. */
+export interface JourneyStatusConfig {
+	status: JourneyStatus
+	/** i18n key for the human label (reuses the existing detail-sheet keys). */
+	labelKey: string
+	/** Emoji glyph shown alongside the label as a non-colour cue. */
+	icon: string
+	/** CSS custom property holding the status's semantic hue. */
+	hueToken: string
+}
+
+/**
+ * Canonical journey-status presentation map: the single source of truth for the
+ * label, icon, and semantic hue of each status, consumed by the dashboard filter
+ * chips, the concert-card badge, and the concert-detail status control, so a
+ * status's visual identity is consistent app-wide. Ordered in journey-flow order
+ * (process then outcome) so consumers can iterate it directly.
+ */
+export const JOURNEY_STATUS_CONFIG: readonly JourneyStatusConfig[] = [
+	{
+		status: 'tracking',
+		labelKey: 'eventDetail.journeyStatus.tracking',
+		icon: '👀',
+		hueToken: '--journey-hue-tracking',
+	},
+	{
+		status: 'applied',
+		labelKey: 'eventDetail.journeyStatus.applied',
+		icon: '📝',
+		hueToken: '--journey-hue-applied',
+	},
+	{
+		status: 'unpaid',
+		labelKey: 'eventDetail.journeyStatus.unpaid',
+		icon: '💰',
+		hueToken: '--journey-hue-unpaid',
+	},
+	{
+		status: 'paid',
+		labelKey: 'eventDetail.journeyStatus.paid',
+		icon: '🎟️',
+		hueToken: '--journey-hue-paid',
+	},
+	{
+		status: 'lost',
+		labelKey: 'eventDetail.journeyStatus.lost',
+		icon: '💔',
+		hueToken: '--journey-hue-lost',
+	},
+]
+
+/** Status → presentation config, for O(1) per-status lookup in components. */
+export const JOURNEY_STATUS_CONFIG_MAP: Record<
+	JourneyStatus,
+	JourneyStatusConfig
+> = Object.fromEntries(
+	JOURNEY_STATUS_CONFIG.map((config) => [config.status, config]),
+) as Record<JourneyStatus, JourneyStatusConfig>
+
 /**
  * Linear focus/navigation order across the branching graph, used for keyboard
  * arrow navigation of the journey radiogroup (DOM order: process then outcome).
@@ -23,6 +82,11 @@ export const JOURNEY_NAV_ORDER: readonly JourneyStatus[] = [
 	'paid',
 	'lost',
 ]
+
+/** Type guard: whether an arbitrary string is a valid journey status. */
+export function isJourneyStatus(value: string): value is JourneyStatus {
+	return (JOURNEY_NAV_ORDER as readonly string[]).includes(value)
+}
 
 /** Nodes already passed for each status, per the journey DAG. */
 const COMPLETED_BY: Record<JourneyStatus, readonly JourneyStatus[]> = {

--- a/src/routes/dashboard/dashboard-route.html
+++ b/src/routes/dashboard/dashboard-route.html
@@ -1,8 +1,10 @@
 <page-header title-key="nav.home">
   <artist-filter-bar
     if.bind="!isOnboarding"
-    followed-artists.bind="followedArtists"
+    counted-artists.bind="countedArtists"
     selected-ids.two-way="filteredArtistIds"
+    selected-statuses.two-way="filteredStatuses"
+    is-authenticated.bind="isAuthenticated"
   ></artist-filter-bar>
   <page-help page="dashboard"></page-help>
 </page-header>

--- a/src/routes/dashboard/dashboard-route.spec.ts
+++ b/src/routes/dashboard/dashboard-route.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { DateGroup } from '../../entities/concert'
+import type { Artist } from '../../entities/artist'
+import type { DateGroup, JourneyStatus } from '../../entities/concert'
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
@@ -78,14 +79,23 @@ import { DashboardRoute } from './dashboard-route'
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-function makeGroup(artistId: string): DateGroup {
+function makeGroup(artistId: string, journeyStatus?: JourneyStatus): DateGroup {
 	return {
 		label: '4月1日(火)',
 		dateKey: '2026-04-01',
-		home: [{ artistId, id: `h-${artistId}` } as never],
+		home: [{ artistId, id: `h-${artistId}`, journeyStatus } as never],
 		nearby: [],
 		away: [],
 	}
+}
+
+function makeArtist(id: string, name: string): Artist {
+	return { id, name } as Artist
+}
+
+/** Call the protected URL-sync watcher handler directly in unit tests. */
+function syncFilterUrl(route: DashboardRoute): void {
+	;(route as unknown as { syncFilterUrl(): void }).syncFilterUrl()
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────
@@ -98,6 +108,7 @@ describe('DashboardRoute', () => {
 		mockOnboarding.isOnboarding = false
 		mockOnboarding.currentStep = 'done'
 		mockAuth.isAuthenticated = false
+		mockFollowStore.followedArtists = []
 		mockStorage.getItem.mockReturnValue(null)
 		sut = new DashboardRoute()
 	})
@@ -148,10 +159,100 @@ describe('DashboardRoute', () => {
 		})
 	})
 
-	describe('updateFilterUrl (via filteredArtistIdsChanged)', () => {
-		it('replaces URL to /dashboard when filter is cleared', () => {
+	describe('filteredDateGroups — journey facet', () => {
+		it('keeps only concerts whose status is in the journey filter', () => {
+			sut.dateGroups = [makeGroup('a1', 'applied'), makeGroup('a2', 'paid')]
+			sut.filteredStatuses = ['applied']
+
+			const result = sut.filteredDateGroups
+			expect(result).toHaveLength(1)
+			expect(result[0].home[0].journeyStatus).toBe('applied')
+		})
+
+		it('combines multiple statuses as OR', () => {
+			sut.dateGroups = [
+				makeGroup('a1', 'applied'),
+				makeGroup('a2', 'unpaid'),
+				makeGroup('a3', 'paid'),
+			]
+			sut.filteredStatuses = ['applied', 'unpaid']
+
+			expect(sut.filteredDateGroups).toHaveLength(2)
+		})
+
+		it('excludes concerts with no status set while filtering', () => {
+			sut.dateGroups = [makeGroup('a1', 'applied'), makeGroup('a2')]
+			sut.filteredStatuses = ['applied']
+
+			const result = sut.filteredDateGroups
+			expect(result).toHaveLength(1)
+			expect(result[0].home[0].artistId).toBe('a1')
+		})
+
+		it('applies artist AND journey facets together', () => {
+			sut.dateGroups = [
+				makeGroup('a1', 'applied'),
+				makeGroup('a1', 'paid'),
+				makeGroup('a2', 'applied'),
+			]
+			sut.filteredArtistIds = ['a1']
+			sut.filteredStatuses = ['applied']
+
+			const result = sut.filteredDateGroups
+			expect(result).toHaveLength(1)
+			expect(result[0].home[0].artistId).toBe('a1')
+			expect(result[0].home[0].journeyStatus).toBe('applied')
+		})
+
+		it('strips blank-artistId concerts even under a journey filter', () => {
+			sut.dateGroups = [makeGroup('', 'applied')]
+			sut.filteredStatuses = ['applied']
+
+			expect(sut.filteredDateGroups).toHaveLength(0)
+		})
+	})
+
+	describe('countedArtists', () => {
+		it('counts over the unfiltered set, hides zero, sorts by count then name', () => {
+			mockFollowStore.followedArtists = [
+				makeArtist('a1', 'Beta'),
+				makeArtist('a2', 'Alpha'),
+				makeArtist('a3', 'Gamma'),
+				makeArtist('a4', 'Zero'),
+			]
+			sut.dateGroups = [
+				makeGroup('a1'),
+				makeGroup('a2'),
+				makeGroup('a2'),
+				makeGroup('a3'),
+			]
+			// a4 has no concerts → hidden; a2 has 2 → first; a1 & a3 tie at 1 → name asc
+			expect(sut.countedArtists).toEqual([
+				{ id: 'a2', name: 'Alpha', count: 2 },
+				{ id: 'a1', name: 'Beta', count: 1 },
+				{ id: 'a3', name: 'Gamma', count: 1 },
+			])
+		})
+
+		it('keeps counts stable over the unfiltered set while a filter is active', () => {
+			mockFollowStore.followedArtists = [
+				makeArtist('a1', 'One'),
+				makeArtist('a2', 'Two'),
+			]
+			sut.dateGroups = [makeGroup('a1'), makeGroup('a2')]
+			sut.filteredArtistIds = ['a1']
+
+			const counts = sut.countedArtists
+			expect(counts).toHaveLength(2)
+			expect(counts.find((a) => a.id === 'a2')?.count).toBe(1)
+		})
+	})
+
+	describe('syncFilterUrl', () => {
+		it('replaces URL to /dashboard when both facets are empty', () => {
 			sut.filteredArtistIds = []
-			sut.filteredArtistIdsChanged()
+			sut.filteredStatuses = []
+			syncFilterUrl(sut)
 
 			expect(mockHistory.replaceState).toHaveBeenCalledWith(
 				null,
@@ -160,9 +261,9 @@ describe('DashboardRoute', () => {
 			)
 		})
 
-		it('replaces URL with artists param when filter is set', () => {
+		it('writes the artists param only', () => {
 			sut.filteredArtistIds = ['id-1', 'id-2']
-			sut.filteredArtistIdsChanged()
+			syncFilterUrl(sut)
 
 			expect(mockHistory.replaceState).toHaveBeenCalledWith(
 				null,
@@ -170,13 +271,44 @@ describe('DashboardRoute', () => {
 				'/dashboard?artists=id-1,id-2',
 			)
 		})
+
+		it('writes the journey param only', () => {
+			sut.filteredStatuses = ['applied', 'unpaid']
+			syncFilterUrl(sut)
+
+			expect(mockHistory.replaceState).toHaveBeenCalledWith(
+				null,
+				'',
+				'/dashboard?journey=applied,unpaid',
+			)
+		})
+
+		it('writes both params in a single replaceState', () => {
+			sut.filteredArtistIds = ['id-1']
+			sut.filteredStatuses = ['applied', 'unpaid']
+			syncFilterUrl(sut)
+
+			expect(mockHistory.replaceState).toHaveBeenCalledTimes(1)
+			expect(mockHistory.replaceState).toHaveBeenCalledWith(
+				null,
+				'',
+				'/dashboard?artists=id-1&journey=applied,unpaid',
+			)
+		})
 	})
 
 	describe('loading() — query param parsing', () => {
-		function makeRouteNode(artistsParam: string | null) {
+		function makeRouteNode(
+			artistsParam: string | null,
+			journeyParam: string | null = null,
+		) {
 			return {
 				queryParams: {
-					get: (key: string) => (key === 'artists' ? artistsParam : null),
+					get: (key: string) => {
+						if (key === 'artists') return artistsParam
+						if (key === 'journey') return journeyParam
+						return null
+					},
 				},
 			} as never
 		}
@@ -200,6 +332,33 @@ describe('DashboardRoute', () => {
 			await sut.loading({}, makeRouteNode('id-1,id-2'))
 
 			expect(sut.filteredArtistIds).toEqual([])
+		})
+
+		it('parses the ?journey param for authenticated users', async () => {
+			mockAuth.isAuthenticated = true
+			sut = new DashboardRoute()
+
+			await sut.loading({}, makeRouteNode(null, 'applied,unpaid'))
+
+			expect(sut.filteredStatuses).toEqual(['applied', 'unpaid'])
+		})
+
+		it('drops unknown journey tokens, keeping valid ones', async () => {
+			mockAuth.isAuthenticated = true
+			sut = new DashboardRoute()
+
+			await sut.loading({}, makeRouteNode(null, 'applied,bogus,paid'))
+
+			expect(sut.filteredStatuses).toEqual(['applied', 'paid'])
+		})
+
+		it('ignores the ?journey param for guests (no effect)', async () => {
+			mockAuth.isAuthenticated = false
+			sut = new DashboardRoute()
+
+			await sut.loading({}, makeRouteNode(null, 'applied,unpaid'))
+
+			expect(sut.filteredStatuses).toEqual([])
 		})
 	})
 

--- a/src/routes/dashboard/dashboard-route.ts
+++ b/src/routes/dashboard/dashboard-route.ts
@@ -1,6 +1,6 @@
 import { I18N } from '@aurelia/i18n'
 import type { Params, RouteNode } from '@aurelia/router'
-import { ILogger, observable, resolve } from 'aurelia'
+import { ILogger, observable, resolve, watch } from 'aurelia'
 import { IHistory } from '../../adapter/browser/history'
 import { ILocalStorage } from '../../adapter/storage/local-storage'
 import type { EventDetailSheet } from '../../components/live-highway/event-detail-sheet'
@@ -10,8 +10,9 @@ import type {
 } from '../../components/live-highway/live-event'
 import { UserHomeSelector } from '../../components/user-home-selector/user-home-selector'
 import { StorageKeys } from '../../constants/storage-keys'
-import type { Artist } from '../../entities/artist'
-import type { JourneyStatus } from '../../entities/concert'
+import type { Artist, CountedArtist } from '../../entities/artist'
+import type { Concert, JourneyStatus } from '../../entities/concert'
+import { isJourneyStatus } from '../../entities/ticket-journey'
 import { IAuthService } from '../../services/auth-service'
 import { IConcertStore } from '../../services/concert-store'
 import { IFollowStore } from '../../services/follow-store'
@@ -25,6 +26,7 @@ import { IUserStore } from '../../services/user-store'
 export class DashboardRoute {
 	public dateGroups: DateGroup[] = []
 	@observable public filteredArtistIds: string[] = []
+	@observable public filteredStatuses: JourneyStatus[] = []
 	public needsRegion = false
 	public isLoading = false
 	public loadError: unknown = null
@@ -66,53 +68,99 @@ export class DashboardRoute {
 	}
 
 	public get filteredDateGroups(): DateGroup[] {
-		// Always strip blank-artistId concerts before rendering. Post-v0.41.0
-		// `concertFrom` returns `artistId: ''` when no performer resolved
-		// against the user's artistMap (ID-namespace mismatch, schema-skew
-		// rollout window) — those rows have no usable artist context and
-		// would render as ghost cards with empty names. The active-filter
-		// branch below already excludes them naturally (Set.has('') is
-		// false); apply the same rule to the unfiltered branch so the
-		// authenticated dashboard never surfaces ghost cards.
-		const stripBlank = (g: DateGroup): DateGroup => ({
-			...g,
-			home: g.home.filter((c) => c.artistId),
-			nearby: g.nearby.filter((c) => c.artistId),
-			away: g.away.filter((c) => c.artistId),
-		})
-		if (this.filteredArtistIds.length === 0) {
-			return this.dateGroups
-				.map(stripBlank)
-				.filter((g) => g.home.length + g.nearby.length + g.away.length > 0)
-		}
 		const ids = new Set(this.filteredArtistIds)
+		const statuses = new Set(this.filteredStatuses)
+		const noArtist = ids.size === 0
+		const noStatus = statuses.size === 0
+
+		// One `keep` predicate combining both facets: artist (OR within) AND
+		// journey (OR within). The leading `!!c.artistId` guard always strips
+		// blank-artistId concerts before rendering. Post-v0.41.0 `concertFrom`
+		// returns `artistId: ''` when no performer resolved against the user's
+		// artistMap (ID-namespace mismatch, schema-skew rollout window) — those
+		// rows have no usable artist context and would render as ghost cards
+		// with empty names, so they never surface on the dashboard.
+		const keep = (c: Concert): boolean =>
+			!!c.artistId &&
+			(noArtist || ids.has(c.artistId)) &&
+			(noStatus ||
+				(c.journeyStatus !== undefined && statuses.has(c.journeyStatus)))
+
 		return this.dateGroups
 			.map((g) => ({
 				...g,
-				home: g.home.filter((c) => ids.has(c.artistId)),
-				nearby: g.nearby.filter((c) => ids.has(c.artistId)),
-				away: g.away.filter((c) => ids.has(c.artistId)),
+				home: g.home.filter(keep),
+				nearby: g.nearby.filter(keep),
+				away: g.away.filter(keep),
 			}))
 			.filter((g) => g.home.length + g.nearby.length + g.away.length > 0)
 	}
 
-	public filteredArtistIdsChanged(): void {
-		this.updateFilterUrl()
+	/**
+	 * Followed artists projected with their upcoming-concert count, computed over
+	 * the *unfiltered* `dateGroups` so counts stay stable as the user toggles
+	 * chips. Zero-concert artists are hidden; the rest are sorted by count
+	 * descending, ties broken by name ascending. A plain getter — Aurelia 2
+	 * auto-tracks the observable `dateGroups`/`followedArtists` it reads.
+	 */
+	public get countedArtists(): CountedArtist[] {
+		const counts = new Map<string, number>()
+		for (const group of this.dateGroups) {
+			for (const concert of [...group.home, ...group.nearby, ...group.away]) {
+				if (!concert.artistId) continue
+				counts.set(concert.artistId, (counts.get(concert.artistId) ?? 0) + 1)
+			}
+		}
+		return this.followedArtists
+			.map((artist) => ({
+				id: artist.id,
+				name: artist.name,
+				count: counts.get(artist.id) ?? 0,
+			}))
+			.filter((artist) => artist.count > 0)
+			.sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
 	}
 
-	private updateFilterUrl(): void {
+	/**
+	 * Single URL writer for both facets. Driven by one `@watch` keyed on a
+	 * composite of both arrays so two selections committed in the same tick
+	 * (e.g. on confirm) collapse into a single async-batched `replaceState`,
+	 * never a double write that drops one facet. Params are omitted when empty.
+	 */
+	@watch(
+		(vm: DashboardRoute) =>
+			`${vm.filteredArtistIds.join(',')}|${vm.filteredStatuses.join(',')}`,
+	)
+	protected syncFilterUrl(): void {
+		const parts: string[] = []
+		if (this.filteredArtistIds.length > 0) {
+			parts.push(`artists=${this.filteredArtistIds.join(',')}`)
+		}
+		if (this.filteredStatuses.length > 0) {
+			parts.push(`journey=${this.filteredStatuses.join(',')}`)
+		}
 		const url =
-			this.filteredArtistIds.length > 0
-				? `/dashboard?artists=${this.filteredArtistIds.join(',')}`
-				: '/dashboard'
+			parts.length > 0 ? `/dashboard?${parts.join('&')}` : '/dashboard'
 		this.history.replaceState(null, '', url)
 	}
 
 	public async loading(_params?: Params, next?: RouteNode): Promise<void> {
-		// Restore artist filter from URL query param (ignored during onboarding)
+		// Restore filters from URL query params (ignored during onboarding)
 		if (!this.isOnboarding && next) {
-			const raw = next.queryParams.get('artists')
-			this.filteredArtistIds = raw ? raw.split(',').filter(Boolean) : []
+			const rawArtists = next.queryParams.get('artists')
+			this.filteredArtistIds = rawArtists
+				? rawArtists.split(',').filter(Boolean)
+				: []
+
+			// Journey filter is authenticated-only: a guest's `journey` param has
+			// no effect, so it can never narrow their highway to an empty state.
+			// Unknown tokens are silently dropped; valid ones still apply.
+			const rawJourney = this.authService.isAuthenticated
+				? next.queryParams.get('journey')
+				: null
+			this.filteredStatuses = rawJourney
+				? rawJourney.split(',').filter(isJourneyStatus)
+				: []
 		}
 
 		if (this.authService.isAuthenticated) {


### PR DESCRIPTION
## Summary

Enhance the dashboard filter to be useful for high-volume followers and add ticket-journey status as a second, orthogonal filter dimension. Implements the `enhance-dashboard-filter` OpenSpec change. **Frontend-only — no proto / BSR / backend / infra change** (journey status is already delivered via `TicketJourneyService.ListByUser`).

## Changes

- **Artist facet** — each chip is prefixed with the artist's upcoming-concert count, the list is sorted by count descending (ties → name ascending), and zero-concert artists are hidden. Counts are computed over the *unfiltered* loaded set, so they stay stable while filtering.
- **Ticket-journey facet** — a second multi-select chip group (`TRACKING`, `APPLIED`, `UNPAID`, `PAID`, `LOST`) with **OR within a facet, AND across facets**. Reflected in a new `journey` URL query param, written together with `artists` in a single `history.replaceState`. Gated to **authenticated users only**; the `journey` param has no effect for guests (never an empty highway).
- **Guest availability** — the filter trigger and the artist facet remain available to unauthenticated users; only onboarding suppresses the filter.
- **Canonical journey-status presentation map** — single source of truth for each status's label, emoji icon, and hue token, consumed by the filter chips, the concert-card badge, and the concert-detail status control. `LOST` adopts 💔.

## Testing

- `make check` passes locally (1230 unit tests, lint/format/stylelint/typecheck/brand-vocabulary clean).
- `npm run build` succeeds (Aurelia templates compile).
- Added/updated unit tests (canonical map, combined filter predicate, count/sort/hide-zero, single-write URL sync, journey param parse incl. guest-ignore & unknown-token drop, two-facet sheet + guest gating) and an e2e URL round-trip check.

## Notes

- ⚠️ **Visual baselines** will need regenerating for the intentional UI changes (counted artist chips, journey chips, `LOST` 💔) per the baseline-refresh constraint — to be done at merge time.

Refs: #420
close: #420
