### PR TITLE
style(live-highway): compact ticket-status outcome into a horizontal row

### DIFF
--- a/src/components/live-highway/event-detail-sheet.css
+++ b/src/components/live-highway/event-detail-sheet.css
@@ -152,10 +152,13 @@
 			align-items: stretch;
 		}
 
+		/* Outcome routes sit side by side in one horizontal row so the control
+		   stays compact; wraps on very narrow viewports instead of overflowing. */
 		.journey-outcome {
 			display: flex;
-			flex-direction: column;
+			flex-wrap: wrap;
 			gap: var(--space-2xs);
+			align-items: center;
 		}
 
 		/* Outcome phase is de-emphasized until a result is reached */
@@ -163,11 +166,25 @@
 			opacity: 0.55;
 		}
 
-		/* Both outcome routes share the same card framing */
+		/* Card chrome dropped (D2): each route is a horizontal node row, and the
+		   win/lose routes are told apart by the divider below plus the dimming and
+		   per-status hue rather than a bordered card. */
 		.journey-route {
-			padding: var(--space-2xs);
-			border: 1px solid var(--_border-light);
-			border-radius: var(--radius-card);
+			display: flex;
+			flex: 1 1 auto;
+			gap: var(--space-3xs);
+			align-items: center;
+		}
+
+		/* The win route holds two nodes, so it takes the larger share of the row. */
+		.journey-route-success {
+			flex-grow: 2;
+		}
+
+		/* Lightweight separator between the win and lose routes (D2). */
+		.journey-route + .journey-route {
+			padding-inline-start: var(--space-2xs);
+			border-inline-start: 1px solid var(--_border-light);
 		}
 
 		/* Mutually exclusive routes: the unchosen route is dimmed */
@@ -175,31 +192,21 @@
 			opacity: 0.4;
 		}
 
-		.journey-route-success {
-			display: flex;
-			flex-direction: column;
-			gap: var(--space-3xs);
-		}
-
+		/* Redundant in the compact row: the node labels (e.g. "当選・未入金") are
+		   self-describing, so the per-route header label is hidden. */
 		.journey-route-label {
-			font-size: var(--step--2);
-			font-weight: 500;
-			color: var(--color-text-secondary);
-			text-transform: uppercase;
-			letter-spacing: 0.05em;
+			display: none;
 		}
 
 		.journey-arrow {
 			align-self: center;
+			margin-inline: var(--space-2xs);
+			font-size: var(--step-0);
 			color: var(--color-text-muted);
 
 			&::before {
 				content: "\203a"; /* > */
 			}
-		}
-
-		.journey-arrow-down::before {
-			content: "\2193"; /* down */
 		}
 
 		/* Node: contrast comes from fill (current) vs outline (others) */

--- a/src/components/live-highway/event-detail-sheet.html
+++ b/src/components/live-highway/event-detail-sheet.html
@@ -140,7 +140,7 @@
                   <span class="journey-node-cue" aria-hidden="true">${journeyConfig.unpaid.icon}</span>
                   <span class="journey-node-label" t.bind="journeyConfig.unpaid.labelKey"></span>
                 </button>
-                <span class="journey-arrow journey-arrow-down" aria-hidden="true"></span>
+                <span class="journey-arrow" aria-hidden="true"></span>
                 <button
                   class="journey-node"
                   role="radio"


### PR DESCRIPTION
## Summary

Compacts the ticket-status (チケット状況) control on the concert detail sheet by laying its outcome (結果) phase out **horizontally** in a single row, halving the control's vertical footprint so the sheet's primary actions are no longer pushed far down the mobile scroll.

Previously the outcome phase stacked the win route (`当選・未入金 → ↓ → 入金済み`) in one bordered card and the lose route (`落選`) in a second card below — ~two-thirds of a ~330px control.

## Changes

- `.journey-outcome` → horizontal wrapping `flex` row; win route and lose route sit side by side.
- `.journey-route` → flattened to a horizontal node row; bordered-card chrome (border + padding) removed, replaced by a lightweight `border-inline-start` divider between routes. `data-dimmed` route dimming and per-status hues retained for win/lose distinction.
- `.journey-route-success` takes the larger row share (two nodes vs one).
- Unified both phases on the horizontal `›` connector; removed the vertical `↓` (`journey-arrow-down` rule + template modifier).
- `.journey-arrow` gets dedicated `margin-inline` and a larger glyph (`--step-0`) so it is no longer cramped — applies to both the process and outcome rows.
- Redundant per-route header label hidden (node labels like `当選・未入金` are self-describing).

DOM structure, radiogroup roles, `data-testid` hooks (`journey-btn`, `journey-remove-btn`), and the `onJourneyKeydown` binding are unchanged. `onJourneyKeydown` already drives selection along a linear order treating Left/Right ≡ Up/Down, so keyboard navigation works in the new horizontal arrangement with no handler change. The 44px tap target (`min-block-size: 2.75rem`) and the canonical per-status label/icon/hue map are preserved.

Frontend-only — no specification/proto, backend, or BSR impact.

## Testing

- `make check` (Biome lint + format + stylelint + typecheck + brand-vocabulary + Vitest) — green.
- `event-detail-sheet.spec.ts` — 33/33 component tests pass.
- Journey visual specs are `describe.fixme` (auth fixture pending), so no active visual baseline captures this sheet — nothing to regenerate.

close: #424
