### PR TITLE
docs(legal): correct stale store reference in legal route comment

### DIFF
--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -88,9 +88,9 @@ import { IOnboardingService } from './services/onboarding-service'
 			title: 'Import Ticket Email',
 			data: { auth: false },
 		},
-		// Legal documents. Public (`auth: false`) so guests and App Store /
-		// Play Console reviewers can open them directly without an account —
-		// the `/legal/privacy` URL is the store-registered Privacy Policy URL.
+		// Legal documents. Public (`auth: false`) so guests can open them
+		// without an account, and so each has a stable, directly-linkable URL
+		// (the product ships as a PWA only — there is no app-store listing).
 		{
 			path: 'legal/terms',
 			component: import('./routes/legal/terms-route'),


### PR DESCRIPTION
## Summary

Follow-up to #428 / v1.9.0. The verification pass flagged that the `/legal/*` route comment in `app-shell.ts` still referenced App Store / Play Console review, but the product ships as a PWA only with no store listing. Reword the comment to explain the public (`auth: false`) rationale in PWA terms — guest access plus stable, directly-linkable URLs.

Comment-only change; no runtime/bundle impact, so no production release is needed.

Refs: #427