### PR TITLE
fix(legal): navigate to legal pages via root router from Settings

### DIFF
--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -91,6 +91,9 @@ import { IOnboardingService } from './services/onboarding-service'
 		// Legal documents. Public (`auth: false`) so guests can open them
 		// without an account, and so each has a stable, directly-linkable URL
 		// (the product ships as a PWA only — there is no app-store listing).
+		// Linked from Settings via the root router (SettingsRoute.openLegal),
+		// not a `load`/`href` attribute: the attribute would resolve relative to
+		// the Settings routing context (`/settings/legal/terms` → AUR3174).
 		{
 			path: 'legal/terms',
 			component: import('./routes/legal/terms-route'),

--- a/src/routes/settings/settings-route.html
+++ b/src/routes/settings/settings-route.html
@@ -193,28 +193,29 @@
   <section>
     <h2 t="settings.about" class="settings-section-title"></h2>
     <ul class="settings-card" role="list">
-      <!-- Terms of Service -->
+      <!-- Terms of Service. Navigates via the VM's root router (openLegal), not
+           a load/href attribute — see SettingsRoute.openLegal for why. -->
       <li class="settings-list-item">
-        <a href="legal/terms" class="settings-row">
+        <button type="button" click.trigger="openLegal('/legal/terms')" class="settings-row">
           <span t="settings.termsOfService" class="settings-row-label"></span>
           <svg-icon name="chevron-right" class="settings-chevron"></svg-icon>
-        </a>
+        </button>
       </li>
 
       <!-- Privacy Policy -->
       <li class="settings-list-item">
-        <a href="legal/privacy" class="settings-row">
+        <button type="button" click.trigger="openLegal('/legal/privacy')" class="settings-row">
           <span t="settings.privacyPolicy" class="settings-row-label"></span>
           <svg-icon name="chevron-right" class="settings-chevron"></svg-icon>
-        </a>
+        </button>
       </li>
 
       <!-- OSS Licenses -->
       <li class="settings-list-item">
-        <a href="legal/licenses" class="settings-row">
+        <button type="button" click.trigger="openLegal('/legal/licenses')" class="settings-row">
           <span t="settings.ossLicenses" class="settings-row-label"></span>
           <svg-icon name="chevron-right" class="settings-chevron"></svg-icon>
-        </a>
+        </button>
       </li>
     </ul>
   </section>

--- a/src/routes/settings/settings-route.ts
+++ b/src/routes/settings/settings-route.ts
@@ -1,4 +1,5 @@
 import { I18N } from '@aurelia/i18n'
+import { IRouter } from '@aurelia/router'
 import { Code, ConnectError } from '@connectrpc/connect'
 import { IEventAggregator, ILogger, resolve } from 'aurelia'
 import { Snack } from '../../components/snack-bar/snack'
@@ -24,6 +25,7 @@ export class SettingsRoute {
 	private readonly logger = resolve(ILogger).scopeTo('SettingsRoute')
 	private readonly ea = resolve(IEventAggregator)
 	private readonly i18n = resolve(I18N)
+	private readonly router = resolve(IRouter)
 	private readonly audio = resolve(IAudioEngine)
 	// Public so the template binds the consent toggles to the service's
 	// `@observable` state directly (`consent.analytics` /
@@ -336,6 +338,19 @@ export class SettingsRoute {
 	/** Persist the volume once when the user releases the slider. */
 	public onSoundVolumePersist(): void {
 		this.audio.persistVolume()
+	}
+
+	/**
+	 * Navigate to a legal document page (Terms / Privacy / OSS Licenses).
+	 *
+	 * Uses the injected root `IRouter` rather than a `load`/`href` attribute:
+	 * the attribute resolves its instruction relative to the Settings route's
+	 * own routing context, turning `legal/terms` into `/settings/legal/terms`
+	 * (no such route → AUR3174). `router.load` resolves from the root context,
+	 * so the absolute `/legal/*` path matches the top-level route.
+	 */
+	public async openLegal(path: string): Promise<void> {
+		await this.router.load(path)
 	}
 
 	/** Guest auth entry — start the OIDC sign-in flow from Settings. */

--- a/test/app-shell.spec.ts
+++ b/test/app-shell.spec.ts
@@ -34,6 +34,21 @@ vi.mock('../src/routes/tickets/tickets-route', () => ({
 vi.mock('../src/routes/settings/settings-route', () => ({
 	SettingsRoute: class SettingsRoute {},
 }))
+vi.mock('../src/routes/consent/consent-route', () => ({
+	ConsentRoute: class ConsentRoute {},
+}))
+vi.mock('../src/routes/import-ticket-email/import-ticket-email-route', () => ({
+	ImportTicketEmailRoute: class ImportTicketEmailRoute {},
+}))
+vi.mock('../src/routes/legal/terms-route', () => ({
+	TermsRoute: class TermsRoute {},
+}))
+vi.mock('../src/routes/legal/privacy-route', () => ({
+	PrivacyRoute: class PrivacyRoute {},
+}))
+vi.mock('../src/routes/legal/licenses-route', () => ({
+	LicensesRoute: class LicensesRoute {},
+}))
 vi.mock('../src/routes/not-found/not-found-route', () => ({
 	NotFoundRoute: class NotFoundRoute {},
 }))

--- a/test/routes/settings-route.spec.ts
+++ b/test/routes/settings-route.spec.ts
@@ -1,3 +1,4 @@
+import { IRouter } from '@aurelia/router'
 import { Code, ConnectError } from '@connectrpc/connect'
 import { DI, IEventAggregator, Registration } from 'aurelia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -33,6 +34,7 @@ const { SettingsRoute } = await import(
 
 describe('SettingsRoute', () => {
 	let sut: InstanceType<typeof SettingsRoute>
+	let mockRouter: { load: ReturnType<typeof vi.fn> }
 	let mockAuth: {
 		isAuthenticated: boolean
 		user: { profile: Record<string, unknown> } | null
@@ -128,6 +130,7 @@ describe('SettingsRoute', () => {
 			delete: vi.fn().mockResolvedValue(undefined),
 		}
 		mockEa = { publish: vi.fn() }
+		mockRouter = { load: vi.fn().mockResolvedValue(undefined) }
 
 		const container = createTestContainer(
 			Registration.instance(mockIAuthService, mockAuth),
@@ -135,6 +138,7 @@ describe('SettingsRoute', () => {
 			Registration.instance(mockINotificationManager, mockNotification),
 			Registration.instance(mockIPushService, mockPush),
 			Registration.instance(IEventAggregator, mockEa),
+			Registration.instance(IRouter, mockRouter),
 		)
 		container.register(SettingsRoute)
 		sut = container.get(SettingsRoute)
@@ -403,6 +407,24 @@ describe('SettingsRoute', () => {
 		})
 	})
 
+	describe('openLegal', () => {
+		// Regression guard for AUR3174: linking to the legal pages from the
+		// Settings routing context must go through the root router with an
+		// ABSOLUTE path. A relative instruction or a `load`/`href` attribute
+		// resolves against `/settings` (→ `/settings/legal/terms`), which has no
+		// route and fails. See SettingsRoute.openLegal.
+		it.each([
+			'/legal/terms',
+			'/legal/privacy',
+			'/legal/licenses',
+		])('navigates to %s via the root router', async (path) => {
+			await sut.openLegal(path)
+
+			expect(mockRouter.load).toHaveBeenCalledWith(path)
+			expect(path.startsWith('/legal/')).toBe(true)
+		})
+	})
+
 	describe('guest mode', () => {
 		function buildGuestSut() {
 			mockAuth.isAuthenticated = false
@@ -413,6 +435,7 @@ describe('SettingsRoute', () => {
 				Registration.instance(mockINotificationManager, mockNotification),
 				Registration.instance(mockIPushService, mockPush),
 				Registration.instance(IEventAggregator, mockEa),
+				Registration.instance(IRouter, mockRouter),
 			)
 			container.register(SettingsRoute)
 			return container.get(SettingsRoute)


### PR DESCRIPTION
## Summary

Production bug (reported on `liverty-music.app/settings`): tapping **利用規約 / プライバシーポリシー / OSSライセンス** threw `AUR3174: Failed to resolve VR(component:'not-found-route')` and stayed on Settings.

### Root cause

The About-section links used `href="legal/terms"`. Aurelia's router parses a `load`/`href` value as a **hierarchical instruction relative to the current routing context**, so from `/settings` it became `/settings/legal/terms` (component `legal` → child `terms`) — a path with no matching route. It fell back to `not-found-route`, which then also failed to resolve, producing the error chain. Direct URL visits to `/legal/*` always worked (URL matcher handles the flat path); only the in-context link was broken. The original component-mount test didn't exercise routing, so it slipped through.

### Fix

Navigate through the injected **root `IRouter`** (`SettingsRoute.openLegal`), matching the app's existing cross-route pattern (`consent`/`discovery` → `router.load('/dashboard')`). The root context resolves the absolute `/legal/*` path against the top-level routes.

### Verified

Reproduced and fixed locally with the dev server + Playwright — Terms, Privacy, and Licenses all navigate to `/legal/*` with **zero console errors**.

## Changes

- `settings-route.ts` / `.html`: `openLegal(path)` + About rows as buttons that call it (was `<a href>`).
- `app-shell.ts`: clarify the legal-routes comment.
- `test/routes/settings-route.spec.ts`: register a mock `IRouter`; add an `openLegal` regression guard (absolute path via the root router) — the coverage gap that let this ship.
- `test/app-shell.spec.ts`: mock the `legal/*`, `consent`, and `import-ticket-email` route modules so their real dynamic imports don't resolve after teardown (flaky unhandled rejections that appeared once the legal routes existed).

`make check` green (1239 tests).

Refs: #427