### PR TITLE
fix(legal): scroll legal pages within the viewport instead of over the nav

### DIFF
--- a/src/routes/legal/licenses-route.css
+++ b/src/routes/legal/licenses-route.css
@@ -1,9 +1,14 @@
 @layer block {
 	@scope (licenses-route) {
+		/* Route host owns the scroll within the app-shell viewport grid row, so
+		   tall content scrolls instead of overflowing onto the bottom nav. */
 		:scope {
+			overflow-y: auto;
 			display: block;
 
 			max-inline-size: 70ch;
+			block-size: 100%;
+			min-block-size: 0;
 			margin-inline: auto;
 			padding: var(--space-s);
 			padding-block-end: var(--space-2xl);

--- a/src/routes/legal/privacy-route.css
+++ b/src/routes/legal/privacy-route.css
@@ -1,0 +1,13 @@
+@layer block {
+	@scope (privacy-route) {
+		/* Route host owns the scroll within the app-shell viewport grid row, so
+		   the document scrolls instead of overflowing onto the bottom nav. The
+		   inner <legal-document> stays a natural-height centered content column. */
+		:scope {
+			overflow-y: auto;
+			display: block;
+			block-size: 100%;
+			min-block-size: 0;
+		}
+	}
+}

--- a/src/routes/legal/privacy-route.html
+++ b/src/routes/legal/privacy-route.html
@@ -1,1 +1,3 @@
+<import from="./privacy-route.css"></import>
+
 <legal-document doc-key="privacy"></legal-document>

--- a/src/routes/legal/terms-route.css
+++ b/src/routes/legal/terms-route.css
@@ -1,0 +1,13 @@
+@layer block {
+	@scope (terms-route) {
+		/* Route host owns the scroll within the app-shell viewport grid row, so
+		   the document scrolls instead of overflowing onto the bottom nav. The
+		   inner <legal-document> stays a natural-height centered content column. */
+		:scope {
+			overflow-y: auto;
+			display: block;
+			block-size: 100%;
+			min-block-size: 0;
+		}
+	}
+}

--- a/src/routes/legal/terms-route.html
+++ b/src/routes/legal/terms-route.html
@@ -1,1 +1,3 @@
+<import from="./terms-route.css"></import>
+
 <legal-document doc-key="terms"></legal-document>


### PR DESCRIPTION
## Summary

On mobile, the legal document pages (Terms / Privacy / OSS Licenses) overflowed the app-shell viewport grid row and painted **over the fixed bottom navigation**, hiding the lower content.

### Root cause

The shell is a CSS grid (`viewport` row `minmax(0,1fr)` + `nav` row). Every route makes its host a scroll container within the viewport row so tall content scrolls. The legal routes — added later — skipped this, so their content grew past the grid cell and spilled onto the nav row.

### Fix

Each legal route host now owns the scroll (`block-size: 100%` + `overflow-y: auto`), matching the settings/dashboard/discovery pattern. The inner `<legal-document>` stays a natural-height, centered (`max-inline-size: 70ch`) content column with bottom padding.

- `terms-route.css` / `privacy-route.css` (new) + their `<import>`: route host as scroll container.
- `licenses-route.css`: same on the existing host scope.

### Verified

At 412×915 (the reported device): Terms, Privacy, and Licenses all scroll cleanly within the viewport, the bottom nav sits in its own row with **no overlap**, and the last content has breathing room (verified scrollHeight > clientHeight with clientHeight = viewport − nav).

`make check` green (lint + boundaries + 1246 tests + bundle-isolation).

Refs: #427