### PR TITLE
fix(layout): constrain app-shell grid column so routes fit the viewport

### DIFF
--- a/src/app-shell.css
+++ b/src/app-shell.css
@@ -1,12 +1,17 @@
 @layer block {
 	@scope (app-shell) {
-		/* Shell layout: viewport content + bottom nav */
+		/* Shell layout: viewport content (row 1) + bottom nav (row 2).
+		   The column track is `minmax(0, 1fr)`, not the implicit `auto`. An `auto`
+		   column has a `min-content` minimum, so a route with wide/unbreakable
+		   content (e.g. long scoped package names on /legal/licenses) would blow
+		   the column past the viewport and scroll the whole page horizontally.
+		   Capping the column min at 0 keeps every route within the viewport. */
 		:scope {
 			display: grid;
-			grid-template-areas:
-				"viewport"
-				"nav";
-			grid-template-rows: minmax(0, 1fr) auto;
+			grid-template:
+				"viewport" minmax(0, 1fr)
+				"nav" auto
+				/ minmax(0, 1fr);
 			block-size: 100dvh;
 		}
 

--- a/src/routes/legal/licenses-route.css
+++ b/src/routes/legal/licenses-route.css
@@ -44,6 +44,11 @@
 		.licenses-name {
 			font-weight: 600;
 			color: var(--color-text-primary);
+
+			/* Long scoped names (e.g. @buf/bufbuild_protovalidate.connectrpc_es)
+			   have no break opportunities; allow breaking anywhere so they wrap
+			   inside the card instead of overflowing it. */
+			overflow-wrap: anywhere;
 		}
 
 		.licenses-version {


### PR DESCRIPTION
## Summary

On mobile, `/legal/licenses` overflowed **horizontally** — the page scrolled sideways, the title was clipped at the left edge, and the side gutters disappeared.

### Root cause

The app-shell grid constrained only its **rows** (`minmax(0, 1fr)`), leaving the single **column implicit** (`auto`). An `auto` track's minimum is `min-content`, so a route whose content has a large min-content — the licenses page, full of long unbreakable scoped package names like `@buf/bufbuild_protovalidate.connectrpc_es` — blew the column **past the viewport** and scrolled the whole page. Other routes have breakable content, so they never tripped it.

Measured at 412px: column resolved to `457.6px`, `document.scrollWidth = 458`. Constraining the column → column `412px`, `scrollWidth = 412`.

### Fix

- **`app-shell.css`**: switch to the `grid-template` shorthand with an explicit `minmax(0, 1fr)` **column**, capping the column min at 0 (mirrors the rows). Keeps every route within the viewport width — a general fix, not legal-specific.
- **`licenses-route.css`**: `.licenses-name` gets `overflow-wrap: anywhere` so long scoped names wrap inside their card rather than overflowing it.

### Verified (Playwright, 412×915)

| page | scrollWidth | title left | vertical scroll | nav row |
|---|---|---|---|---|
| `/legal/licenses` | 412 (= viewport) | 16 (gutter) | preserved | intact (no overlap) |
| `/legal/terms` | 412 (= viewport) | 16 (gutter) | preserved | intact |

`make check` green (lint + boundaries + 1246 tests + bundle-isolation).

### Note

The previous mobile fix (#436) verified only the vertical axis (scrollHeight/nav overlap); this was the horizontal axis. Both are now checked.

Refs: #427