### PR TITLE
feat: unify async button feedback with busy-on-click attribute

### DIFF
--- a/src/components/auth-status.html
+++ b/src/components/auth-status.html
@@ -1,12 +1,12 @@
 <nav aria-label="Account" class="[ auth-status-bar ]">
   <div if.bind="auth.isAuthenticated" class="auth-status-bar">
     <span class="auth-user-name">${auth.user.profile.name || auth.user.profile.preferred_username || 'User'}</span>
-    <button click.trigger="signOut()" class="auth-sign-out-btn">
+    <button busy-on-click.bind="() => signOut()" class="auth-sign-out-btn">
       Sign Out
     </button>
   </div>
   <div if.bind="!auth.isAuthenticated">
-    <button click.trigger="signIn()" class="auth-sign-in-btn">
+    <button busy-on-click.bind="() => signIn()" class="auth-sign-in-btn">
       Sign In
     </button>
   </div>

--- a/src/components/notification-prompt/notification-prompt.html
+++ b/src/components/notification-prompt/notification-prompt.html
@@ -12,10 +12,9 @@
             t="notification.notNow"
             class="prompt-btn-secondary">
           </button>
-          <button click.trigger="enable()" disabled.bind="isLoading"
-            class="prompt-btn-primary">
-            <span if.bind="isLoading" t="notification.enabling"></span>
-            <span if.bind="!isLoading" t="notification.enable"></span>
+          <button busy-on-click.bind="() => enable()"
+            class="prompt-btn-primary"
+            t="notification.enable">
           </button>
         </footer>
       </div>

--- a/src/components/notification-prompt/notification-prompt.ts
+++ b/src/components/notification-prompt/notification-prompt.ts
@@ -12,7 +12,6 @@ import { IPushService } from '../../services/push-service'
 
 export class NotificationPrompt {
 	public isVisible = false
-	public isLoading = false
 
 	private readonly logger = resolve(ILogger).scopeTo('NotificationPrompt')
 	public readonly notificationManager = resolve(INotificationManager)
@@ -58,7 +57,7 @@ export class NotificationPrompt {
 		this.analytics.capture(Events.NotificationRequested, {
 			source: 'page',
 		})
-		this.isLoading = true
+		// The busy/disabled state while this runs is handled by `busy-on-click`.
 		try {
 			await this.pushService.create()
 			if (this.notificationManager.permission === 'granted') {
@@ -67,8 +66,6 @@ export class NotificationPrompt {
 			}
 		} catch (err) {
 			this.logger.error('Failed to enable push notifications', err)
-		} finally {
-			this.isLoading = false
 		}
 	}
 

--- a/src/components/post-signup-dialog/post-signup-dialog.html
+++ b/src/components/post-signup-dialog/post-signup-dialog.html
@@ -13,14 +13,11 @@
         <button
           type="button"
           class="post-signup-btn"
-          click.trigger="onEnableNotifications()"
-          disabled.bind="notificationLoading || notificationDone"
+          busy-on-click.bind="() => onEnableNotifications()"
+          disabled.bind="notificationDone"
         >
-          <span if.bind="notificationLoading" t="postSignup.notificationEnabling"></span>
-          <template else>
-            <span if.bind="notificationDone" t="postSignup.notificationEnabled"></span>
-            <span else t="postSignup.notificationEnable"></span>
-          </template>
+          <span if.bind="notificationDone" t="postSignup.notificationEnabled"></span>
+          <span else t="postSignup.notificationEnable"></span>
         </button>
         <p if.bind="notificationError" class="post-signup-error" t="postSignup.notificationError"></p>
       </div>
@@ -42,7 +39,7 @@
         <button
           type="button"
           class="post-signup-btn"
-          click.trigger="onInstallPwa()"
+          busy-on-click.bind="() => onInstallPwa()"
           t="postSignup.pwaInstall"
         ></button>
       </div>

--- a/src/components/post-signup-dialog/post-signup-dialog.spec.ts
+++ b/src/components/post-signup-dialog/post-signup-dialog.spec.ts
@@ -125,7 +125,6 @@ describe('PostSignupDialog', () => {
 			await sut.onEnableNotifications()
 
 			expect(sut.notificationDone).toBe(true)
-			expect(sut.notificationLoading).toBe(false)
 		})
 
 		it('keeps notificationDone false when permission is denied (create returns null)', async () => {
@@ -135,7 +134,6 @@ describe('PostSignupDialog', () => {
 
 			expect(sut.notificationDone).toBe(false)
 			expect(sut.notificationError).toBe(false)
-			expect(sut.notificationLoading).toBe(false)
 		})
 
 		it('sets notificationError on failure', async () => {
@@ -144,7 +142,6 @@ describe('PostSignupDialog', () => {
 			await sut.onEnableNotifications()
 
 			expect(sut.notificationError).toBe(true)
-			expect(sut.notificationLoading).toBe(false)
 		})
 	})
 

--- a/src/components/post-signup-dialog/post-signup-dialog.ts
+++ b/src/components/post-signup-dialog/post-signup-dialog.ts
@@ -8,7 +8,6 @@ export class PostSignupDialog {
 	@bindable public active = false
 
 	public isOpen = false
-	public notificationLoading = false
 	public notificationDone = false
 	public notificationError = false
 
@@ -40,7 +39,7 @@ export class PostSignupDialog {
 	}
 
 	public async onEnableNotifications(): Promise<void> {
-		this.notificationLoading = true
+		// The busy/disabled state while this runs is handled by `busy-on-click`.
 		this.notificationError = false
 		try {
 			const endpoint = await this.pushService.create()
@@ -54,8 +53,6 @@ export class PostSignupDialog {
 		} catch (err) {
 			this.logger.error('PostSignupDialog: failed to enable notifications', err)
 			this.notificationError = true
-		} finally {
-			this.notificationLoading = false
 		}
 	}
 

--- a/src/components/pwa-install-fab/pwa-install-fab.html
+++ b/src/components/pwa-install-fab/pwa-install-fab.html
@@ -13,7 +13,7 @@
     tabindex.bind="isVisible ? '0' : '-1'"
     type="button"
     class="pwa-fab"
-    click.trigger="handleTap()"
+    busy-on-click.bind="() => handleTap()"
     t="[aria-label]pwaFab.ariaLabel"
     data-testid="pwa-install-fab"
   >

--- a/src/components/pwa-install-fab/pwa-install-fab.ts
+++ b/src/components/pwa-install-fab/pwa-install-fab.ts
@@ -21,12 +21,14 @@ export class PwaInstallFab {
 		this.isVisible = newValue
 	}
 
-	public handleTap(): void {
+	public handleTap(): void | Promise<void> {
 		if (this.isIos) {
 			this.isSheetOpen = true
-		} else {
-			void this.pwaInstall.install()
+			return
 		}
+		// Return the promise so `busy-on-click` shows a busy state on the FAB
+		// while the browser install prompt is open.
+		return this.pwaInstall.install()
 	}
 
 	public closeSheet(): void {

--- a/src/components/user-home-selector/user-home-selector.html
+++ b/src/components/user-home-selector/user-home-selector.html
@@ -16,7 +16,7 @@
         <div class="selector-grid">
           <button
             repeat.for="city of quickCities; key.bind: city.code"
-            click.trigger="selectQuickCity(city.code)"
+            busy-on-click.bind="() => selectQuickCity(city.code)"
             class="selector-btn"
             data-selected.bind="city.code === currentHomeCode"
             aria-current.bind="city.code === currentHomeCode"
@@ -62,7 +62,7 @@
       <div class="selector-grid">
         <button
           repeat.for="pref of selectedRegion.prefectures; key.bind: pref.code"
-          click.trigger="selectPrefecture(pref.code)"
+          busy-on-click.bind="() => selectPrefecture(pref.code)"
           class="selector-btn"
           data-selected.bind="pref.code === currentHomeCode"
           aria-current.bind="pref.code === currentHomeCode"

--- a/src/custom-attributes/busy-on-click.spec.ts
+++ b/src/custom-attributes/busy-on-click.spec.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fakeLogger = { warn: vi.fn(), scopeTo: vi.fn() }
+fakeLogger.scopeTo.mockReturnValue(fakeLogger)
+
+// A real DOM element so the attribute can attach listeners and toggle attributes.
+let element: HTMLButtonElement
+
+vi.mock('aurelia', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('aurelia')>()
+	return {
+		...actual,
+		resolve: vi.fn((token) => {
+			const name = String(token)
+			if (name.includes('Logger')) return fakeLogger
+			// The only other dependency the attribute resolves is INode.
+			return element
+		}),
+	}
+})
+
+import { BusyOnClickCustomAttribute } from './busy-on-click'
+
+/** Resolves on the next microtask so awaited promises inside the handler settle. */
+const flush = (): Promise<void> => Promise.resolve()
+
+describe('BusyOnClickCustomAttribute', () => {
+	let sut: BusyOnClickCustomAttribute
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		fakeLogger.scopeTo.mockReturnValue(fakeLogger)
+		element = document.createElement('button')
+		sut = new BusyOnClickCustomAttribute()
+		sut.attached()
+	})
+
+	afterEach(() => {
+		sut.detaching()
+	})
+
+	it('marks the element busy while the handler promise is in flight, then clears it', async () => {
+		let resolveHandler: () => void = () => {}
+		const handler = vi.fn(
+			() =>
+				new Promise<void>((res) => {
+					resolveHandler = res
+				}),
+		)
+		sut.value = handler
+
+		element.click()
+		await flush()
+
+		expect(handler).toHaveBeenCalledOnce()
+		expect(element.hasAttribute('data-busy')).toBe(true)
+		expect(element.getAttribute('aria-busy')).toBe('true')
+
+		resolveHandler()
+		await flush()
+		await flush()
+
+		expect(element.hasAttribute('data-busy')).toBe(false)
+		expect(element.hasAttribute('aria-busy')).toBe(false)
+	})
+
+	it('ignores re-entrant clicks while busy (double-tap guard)', async () => {
+		const handler = vi.fn(() => new Promise<void>(() => {}))
+		sut.value = handler
+
+		element.click()
+		element.click()
+		element.click()
+		await flush()
+
+		expect(handler).toHaveBeenCalledOnce()
+	})
+
+	it('does not enter busy state for a synchronous / non-thenable handler', async () => {
+		const handler = vi.fn(() => undefined)
+		sut.value = handler
+
+		element.click()
+		await flush()
+
+		expect(handler).toHaveBeenCalledOnce()
+		expect(element.hasAttribute('data-busy')).toBe(false)
+		expect(element.hasAttribute('aria-busy')).toBe(false)
+	})
+
+	it('clears busy state and logs a warning when the handler rejects', async () => {
+		const error = new Error('boom')
+		const handler = vi.fn(() => Promise.reject(error))
+		sut.value = handler
+
+		element.click()
+		await flush()
+		await flush()
+
+		expect(element.hasAttribute('data-busy')).toBe(false)
+		expect(element.hasAttribute('aria-busy')).toBe(false)
+		expect(fakeLogger.warn).toHaveBeenCalledWith(
+			'busy-on-click handler rejected',
+			{ error },
+		)
+	})
+
+	it('removes the click listener on detach', async () => {
+		const handler = vi.fn(() => Promise.resolve())
+		sut.value = handler
+		sut.detaching()
+
+		element.click()
+		await flush()
+
+		expect(handler).not.toHaveBeenCalled()
+	})
+
+	it('does nothing when no handler is bound', async () => {
+		sut.value = null
+
+		expect(() => element.click()).not.toThrow()
+		await flush()
+		expect(element.hasAttribute('data-busy')).toBe(false)
+	})
+})

--- a/src/custom-attributes/busy-on-click.ts
+++ b/src/custom-attributes/busy-on-click.ts
@@ -1,0 +1,59 @@
+import { bindable, customAttribute, ILogger, INode, resolve } from 'aurelia'
+
+/**
+ * Marks a control busy while the bound click handler's promise is in flight and
+ * guards against double-activation. While busy the element gets a `data-busy`
+ * attribute (styled globally with a spinner + dim) and `aria-busy="true"`.
+ *
+ * The element's `disabled` property is intentionally never touched so this can
+ * compose with an existing `disabled.bind` (e.g. a success state).
+ *
+ * Usage: <button busy-on-click.bind="() => handleLogin()">…</button>
+ */
+@customAttribute('busy-on-click')
+export class BusyOnClickCustomAttribute {
+	@bindable() public value: (() => unknown) | null = null
+
+	private readonly element = resolve(INode) as HTMLElement
+	private readonly logger = resolve(ILogger).scopeTo('BusyOnClick')
+	private busy = false
+
+	private readonly onClick = async (e: Event): Promise<void> => {
+		if (this.busy) {
+			e.preventDefault()
+			e.stopImmediatePropagation()
+			return
+		}
+
+		const result = this.value?.()
+		// Sync / no-op handlers (e.g. a ternary returning undefined) skip the
+		// busy state entirely and behave like a plain click.
+		if (
+			!result ||
+			typeof (result as PromiseLike<unknown>).then !== 'function'
+		) {
+			return
+		}
+
+		this.busy = true
+		this.element.setAttribute('data-busy', '')
+		this.element.setAttribute('aria-busy', 'true')
+		try {
+			await result
+		} catch (err) {
+			this.logger.warn('busy-on-click handler rejected', { error: err })
+		} finally {
+			this.busy = false
+			this.element.removeAttribute('data-busy')
+			this.element.removeAttribute('aria-busy')
+		}
+	}
+
+	public attached(): void {
+		this.element.addEventListener('click', this.onClick)
+	}
+
+	public detaching(): void {
+		this.element.removeEventListener('click', this.onClick)
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,6 +51,7 @@ import {
 } from './constants/storage-keys'
 import { ArtistColorCustomAttribute } from './custom-attributes/artist-color'
 import { BeamVarsCustomAttribute } from './custom-attributes/beam-vars'
+import { BusyOnClickCustomAttribute } from './custom-attributes/busy-on-click'
 import { DotColorCustomAttribute } from './custom-attributes/dot-color'
 import { LongPressCustomAttribute } from './custom-attributes/long-press'
 import { SpotlightRadiusCustomAttribute } from './custom-attributes/spotlight-radius'
@@ -256,6 +257,7 @@ async function bootstrap(): Promise<void> {
 	au.register(AuthHook)
 	au.register(ArtistColorCustomAttribute)
 	au.register(LongPressCustomAttribute)
+	au.register(BusyOnClickCustomAttribute)
 	au.register(BeamVarsCustomAttribute)
 	au.register(DotColorCustomAttribute)
 	au.register(SpotlightRadiusCustomAttribute)

--- a/src/routes/consent/consent-route.html
+++ b/src/routes/consent/consent-route.html
@@ -61,17 +61,17 @@
 
   <footer class="[ consent-actions ]">
     <button
-      click.trigger="acceptSelected()"
+      busy-on-click.bind="() => acceptSelected()"
       class="consent-btn-primary"
       t="onboarding.consent.actions.accept"
     ></button>
     <button
-      click.trigger="declineAll()"
+      busy-on-click.bind="() => declineAll()"
       class="consent-btn-secondary"
       t="onboarding.consent.actions.decline"
     ></button>
     <button
-      click.trigger="setUpLater()"
+      busy-on-click.bind="() => setUpLater()"
       class="consent-btn-text"
       t="onboarding.consent.actions.later"
     ></button>

--- a/src/routes/discovery/discovery-route.html
+++ b/src/routes/discovery/discovery-route.html
@@ -79,7 +79,7 @@
           repeat.for="artist of search.searchResults; key.bind: artist.id"
           class="result-item"
           data-followed.bind="followedIds.has(artist.id)"
-          click.trigger="followedIds.has(artist.id) ? undefined : onFollowFromSearch(artist)"
+          busy-on-click.bind="() => followedIds.has(artist.id) ? undefined : onFollowFromSearch(artist)"
           role="button"
           aria-disabled.bind="followedIds.has(artist.id)"
           aria-label.bind="followedIds.has(artist.id) ? ($this.i18n?.tr('discovery.alreadyFollowing', { name: artist.name }) ?? '') : ($this.i18n?.tr('discovery.followArtist', { name: artist.name }) ?? '')"

--- a/src/routes/import-ticket-email/import-ticket-email-route.html
+++ b/src/routes/import-ticket-email/import-ticket-email-route.html
@@ -34,9 +34,8 @@
           ${fa.artist.name ?? ''}
         </option>
       </select>
-      <button click.trigger="selectArtist()" disabled.bind="!selectedArtistId || isLoading">
-        <loading-spinner if.bind="isLoading"></loading-spinner>
-        <span else>次へ</span>
+      <button busy-on-click.bind="() => selectArtist()" disabled.bind="!selectedArtistId">
+        次へ
       </button>
     </div>
   </template>
@@ -84,9 +83,8 @@
         検出タイプ: ${detectedEmailType === 'lottery_result' ? '抽選結果通知' : '抽選受付情報'}
       </p>
       <div if.bind="error" class="wizard-error"><p>${error}</p></div>
-      <button click.trigger="submitForParsing()" disabled.bind="isLoading">
-        <loading-spinner if.bind="isLoading"></loading-spinner>
-        <span else>解析する</span>
+      <button busy-on-click.bind="() => submitForParsing()">
+        解析する
       </button>
     </div>
   </template>
@@ -128,9 +126,8 @@
         </dl>
       </div>
       <div if.bind="error" class="wizard-error"><p>${error}</p></div>
-      <button click.trigger="confirmResults()" disabled.bind="isLoading">
-        <loading-spinner if.bind="isLoading"></loading-spinner>
-        <span else>確定する</span>
+      <button busy-on-click.bind="() => confirmResults()">
+        確定する
       </button>
     </div>
   </template>

--- a/src/routes/import-ticket-email/import-ticket-email-route.ts
+++ b/src/routes/import-ticket-email/import-ticket-email-route.ts
@@ -36,7 +36,6 @@ export class ImportTicketEmailRoute {
 	// initial step to 'validation' (plus drop the early return in `loading`).
 	public step: WizardStep = 'unavailable'
 	public error = ''
-	public isLoading = false
 
 	// Shared data from Gmail
 	public emailTitle = ''
@@ -126,7 +125,6 @@ export class ImportTicketEmailRoute {
 	// Step 3: Artist selected → load concerts.
 	public async selectArtist(): Promise<void> {
 		if (!this.selectedArtistId) return
-		this.isLoading = true
 		try {
 			this.concerts = await this.concertService.listConcerts(
 				this.selectedArtistId,
@@ -138,8 +136,6 @@ export class ImportTicketEmailRoute {
 				this.logger.error('Failed to load concerts', { error: err })
 				this.error = 'コンサートの読み込みに失敗しました。'
 			}
-		} finally {
-			this.isLoading = false
 		}
 	}
 
@@ -172,7 +168,6 @@ export class ImportTicketEmailRoute {
 	// Step 5 → 6: Submit to backend for parsing.
 	public async submitForParsing(): Promise<void> {
 		this.step = 'parsing'
-		this.isLoading = true
 		this.error = ''
 
 		try {
@@ -189,14 +184,11 @@ export class ImportTicketEmailRoute {
 				this.error = 'メールの解析に失敗しました。もう一度お試しください。'
 				this.step = 'body'
 			}
-		} finally {
-			this.isLoading = false
 		}
 	}
 
 	// Step 7: Confirm parsed results.
 	public async confirmResults(): Promise<void> {
-		this.isLoading = true
 		this.error = ''
 
 		try {
@@ -215,8 +207,6 @@ export class ImportTicketEmailRoute {
 				this.logger.error('Failed to confirm email', { error: err })
 				this.error = '確認に失敗しました。もう一度お試しください。'
 			}
-		} finally {
-			this.isLoading = false
 		}
 	}
 

--- a/src/routes/settings/settings-route.html
+++ b/src/routes/settings/settings-route.html
@@ -55,7 +55,7 @@
            via `aria-describedby`. -->
       <li class="settings-list-item">
         <button
-          click.trigger="toggleNotifications()"
+          busy-on-click.bind="() => toggleNotifications()"
           role="switch"
           aria-checked.bind="notificationsEnabled"
           aria-disabled.bind="!vapidAvailable"
@@ -249,20 +249,19 @@
           </div>
           <button
             if.bind="!emailVerified"
-            click.trigger="resendVerification()"
-            disabled.bind="isResendingVerification || resendSuccess"
+            busy-on-click.bind="() => resendVerification()"
+            disabled.bind="resendSuccess"
             aria-live="polite"
             class="settings-resend-btn"
           >
             <span if.bind="resendSuccess" t="settings.resendSent"></span>
-            <span if.bind="isResendingVerification" t="settings.resending"></span>
-            <span if.bind="!isResendingVerification && !resendSuccess" t="settings.resendVerification"></span>
+            <span if.bind="!resendSuccess" t="settings.resendVerification"></span>
           </button>
         </div>
       </li>
 
       <li class="settings-list-item">
-        <button click.trigger="signOut()" class="settings-row settings-sign-out">
+        <button busy-on-click.bind="() => signOut()" class="settings-row settings-sign-out">
           <span t="settings.signOut" class="settings-sign-out-text"></span>
         </button>
       </li>
@@ -286,7 +285,7 @@
     <div class="[ language-list ] [ stack ]" role="radiogroup" aria-labelledby="language-selector-title">
       <button
         repeat.for="lang of supportedLanguages"
-        click.trigger="selectLanguage(lang)"
+        busy-on-click.bind="() => selectLanguage(lang)"
         role="radio"
         aria-checked.bind="currentLocale === lang"
         class="language-option"

--- a/src/routes/settings/settings-route.ts
+++ b/src/routes/settings/settings-route.ts
@@ -40,7 +40,6 @@ export class SettingsRoute {
 	public homeSelector!: UserHomeSelector
 	public languageSelectorOpen = false
 	public readonly supportedLanguages = SUPPORTED_LANGUAGES
-	private isToggling = false
 
 	/**
 	 * Per-row disclosure state for the Privacy & Analytics consent
@@ -53,7 +52,6 @@ export class SettingsRoute {
 	public analyticsDescExpanded = false
 	public marketingDescExpanded = false
 
-	public isResendingVerification = false
 	public resendSuccess = false
 
 	/**
@@ -264,8 +262,7 @@ export class SettingsRoute {
 		// The push row uses `aria-disabled` (not native `disabled`) when the
 		// VAPID key is absent, so it stays AT-discoverable but must no-op here.
 		if (!this.vapidAvailable) return
-		if (this.isToggling) return
-		this.isToggling = true
+		// Re-entrancy is guarded by the `busy-on-click` attribute on the row.
 
 		try {
 			const newValue = !this.notificationsEnabled
@@ -295,14 +292,11 @@ export class SettingsRoute {
 			}
 		} catch (err) {
 			this.logger.error('Failed to toggle push notifications', err)
-		} finally {
-			this.isToggling = false
 		}
 	}
 
 	public async resendVerification(): Promise<void> {
-		if (this.isResendingVerification) return
-		this.isResendingVerification = true
+		// Re-entrancy and the in-flight busy state are handled by `busy-on-click`.
 		this.resendSuccess = false
 
 		try {
@@ -319,8 +313,6 @@ export class SettingsRoute {
 					new Snack(this.i18n.tr('settings.resendError'), 'error'),
 				)
 			}
-		} finally {
-			this.isResendingVerification = false
 		}
 	}
 

--- a/src/routes/settings/settings-route.ts
+++ b/src/routes/settings/settings-route.ts
@@ -40,6 +40,7 @@ export class SettingsRoute {
 	public homeSelector!: UserHomeSelector
 	public languageSelectorOpen = false
 	public readonly supportedLanguages = SUPPORTED_LANGUAGES
+	private isToggling = false
 
 	/**
 	 * Per-row disclosure state for the Privacy & Analytics consent
@@ -262,7 +263,10 @@ export class SettingsRoute {
 		// The push row uses `aria-disabled` (not native `disabled`) when the
 		// VAPID key is absent, so it stays AT-discoverable but must no-op here.
 		if (!this.vapidAvailable) return
-		// Re-entrancy is guarded by the `busy-on-click` attribute on the row.
+		// `busy-on-click` guards DOM re-taps; this guard additionally protects
+		// against concurrent programmatic calls (push subscription idempotency).
+		if (this.isToggling) return
+		this.isToggling = true
 
 		try {
 			const newValue = !this.notificationsEnabled
@@ -292,6 +296,8 @@ export class SettingsRoute {
 			}
 		} catch (err) {
 			this.logger.error('Failed to toggle push notifications', err)
+		} finally {
+			this.isToggling = false
 		}
 	}
 

--- a/src/routes/welcome/welcome-route.html
+++ b/src/routes/welcome/welcome-route.html
@@ -38,12 +38,12 @@
     <p t="welcome.guestFriendly" class="welcome-guest-friendly"></p>
     <div class="[ welcome-cta-group welcome-hero-fallback-cta-group ]">
       <button
-        click.trigger="handleGetStarted()"
+        busy-on-click.bind="() => handleGetStarted()"
         class="welcome-btn-primary"
         t="welcome.cta.getStarted"
       ></button>
       <button
-        click.trigger="handleLogin()"
+        busy-on-click.bind="() => handleLogin()"
         class="welcome-btn-secondary"
         t="welcome.cta.login"
       ></button>
@@ -67,13 +67,13 @@
 
     <div class="welcome-cta-group">
       <button
-        click.trigger="handleGetStarted()"
+        busy-on-click.bind="() => handleGetStarted()"
         class="welcome-btn-primary"
         t="welcome.cta.getStarted"
       ></button>
 
       <button
-        click.trigger="handleLogin()"
+        busy-on-click.bind="() => handleLogin()"
         class="welcome-btn-secondary"
         t="welcome.cta.login"
       ></button>

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -64,6 +64,13 @@
 		}
 	}
 
+	/* Like `spin` but preserves the centering translate of the busy overlay. */
+	@keyframes busy-spin {
+		to {
+			transform: translate(-50%, -50%) rotate(1turn);
+		}
+	}
+
 	@keyframes pulse {
 		0%,
 		100% {
@@ -133,33 +140,27 @@
 	   and overlays a spinner. Multi-property by nature (state, not a token). */
 	/* stylelint-disable-next-line cube/utility-single-property */
 	[data-busy] {
-		position: relative;
-
 		pointer-events: none;
-
+		position: relative;
 		cursor: progress;
-
 		opacity: 0.65;
 	}
 
+	/* Centered with transform (no negative margins, which the token rule forbids);
+	   the spin keyframe keeps the translate so it stays centered while rotating. */
 	/* stylelint-disable-next-line cube/utility-single-property */
 	[data-busy]::after {
 		content: "";
-
 		position: absolute;
 		inset-block-start: 50%;
 		inset-inline-start: 50%;
-
 		inline-size: 1rem;
 		block-size: 1rem;
-		margin-block-start: -0.5rem;
-		margin-inline-start: -0.5rem;
-
 		border: 1.5px solid oklch(from var(--color-brand-accent) l c h / 30%);
 		border-block-start-color: var(--color-brand-accent);
 		border-radius: var(--radius-full);
-
-		animation: spin 0.8s linear infinite;
+		transform: translate(-50%, -50%);
+		animation: busy-spin 0.8s linear infinite;
 	}
 
 	/* Accessibility — multi-property utility required for screen-reader-only pattern */

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -128,6 +128,40 @@
 		display: none;
 	}
 
+	/* Busy state — applied by the `busy-on-click` custom attribute while an async
+	   click handler is in flight. Dims the control, blocks further interaction,
+	   and overlays a spinner. Multi-property by nature (state, not a token). */
+	/* stylelint-disable-next-line cube/utility-single-property */
+	[data-busy] {
+		position: relative;
+
+		pointer-events: none;
+
+		cursor: progress;
+
+		opacity: 0.65;
+	}
+
+	/* stylelint-disable-next-line cube/utility-single-property */
+	[data-busy]::after {
+		content: "";
+
+		position: absolute;
+		inset-block-start: 50%;
+		inset-inline-start: 50%;
+
+		inline-size: 1rem;
+		block-size: 1rem;
+		margin-block-start: -0.5rem;
+		margin-inline-start: -0.5rem;
+
+		border: 1.5px solid oklch(from var(--color-brand-accent) l c h / 30%);
+		border-block-start-color: var(--color-brand-accent);
+		border-radius: var(--radius-full);
+
+		animation: spin 0.8s linear infinite;
+	}
+
 	/* Accessibility — multi-property utility required for screen-reader-only pattern */
 	/* stylelint-disable-next-line cube/utility-single-property */
 	.visually-hidden {
@@ -148,6 +182,10 @@
 	/* Reduced motion override */
 	@media (prefers-reduced-motion: reduce) {
 		[class*="animate-"] {
+			animation: none;
+		}
+
+		[data-busy]::after {
 			animation: none;
 		}
 

--- a/test/components/post-signup-dialog.spec.ts
+++ b/test/components/post-signup-dialog.spec.ts
@@ -91,7 +91,6 @@ describe('PostSignupDialog', () => {
 
 			expect(mockPush.create).toHaveBeenCalledOnce()
 			expect(sut.notificationDone).toBe(true)
-			expect(sut.notificationLoading).toBe(false)
 		})
 
 		it('keeps notificationDone false when permission is denied (create returns null)', async () => {
@@ -102,7 +101,6 @@ describe('PostSignupDialog', () => {
 			expect(mockPush.create).toHaveBeenCalledOnce()
 			expect(sut.notificationDone).toBe(false)
 			expect(sut.notificationError).toBe(false)
-			expect(sut.notificationLoading).toBe(false)
 		})
 
 		it('sets error on failure', async () => {
@@ -112,7 +110,6 @@ describe('PostSignupDialog', () => {
 
 			expect(sut.notificationError).toBe(true)
 			expect(sut.notificationDone).toBe(false)
-			expect(sut.notificationLoading).toBe(false)
 		})
 	})
 


### PR DESCRIPTION
Add a reusable `busy-on-click` custom attribute that, on click, marks the
control busy while the bound handler's promise is in flight and guards
against double-activation. While busy the element gets `data-busy` +
`aria-busy="true"`; global CSS dims it, blocks interaction, and overlays a
spinner. The element's `disabled` property is never touched, so it composes
with existing `disabled.bind` success states.

Apply it to controls that previously fired async work (navigation, auth,
RPC, locale change, PWA install) with no disabled/loading/double-tap
feedback: welcome CTAs, auth-status sign in/out, settings sign out /
language / push toggle, discovery follow-from-search, home selector,
consent actions, PWA install FAB.

Migrate the already-compliant components to the same primitive, removing
their per-view busy flags and bespoke loading text while keeping
domain-specific success/error states: post-signup-dialog,
notification-prompt, settings email resend, import-ticket-email.

Left as-is (richer feedback that a single-button busy state would regress):
tickets progress sheet, event-detail journey group-dim, discovery genre
group-dim, my-artists optimistic unfollow.

https://claude.ai/code/session_01GB2FZjYpzgxqjpFeJprMnB