### PR TITLE
fix(onboarding): coach mark dismiss-only + celebration text wrapping/spacing

### DIFF
--- a/src/components/celebration-overlay/celebration-overlay.css
+++ b/src/components/celebration-overlay/celebration-overlay.css
@@ -22,7 +22,13 @@
 			inset: 0;
 
 			display: grid;
+			row-gap: var(--space-s);
 			place-items: center;
+
+			/* Pack the heading and sub text to the centre as a single group.
+			   Without this the auto rows stretch to fill the viewport, pushing
+			   the sub text far below the heading. */
+			align-content: center;
 
 			background: var(--_overlay-bg);
 			backdrop-filter: blur(8px);
@@ -48,13 +54,18 @@
 			font-family: var(--font-display);
 			font-size: var(--step-4);
 			font-weight: bold;
-			line-height: var(--leading-normal);
+			line-height: var(--leading-snug);
 			color: var(--color-white);
 			text-align: center;
 			text-shadow:
 				0 0 24px var(--_glow-a),
 				0 0 48px var(--_glow-a),
 				0 0 80px var(--_glow-b);
+
+			/* Balance line lengths and break Japanese at natural phrase
+			   boundaries instead of mid-word (graceful no-op where unsupported). */
+			text-wrap: balance;
+			word-break: auto-phrase;
 
 			animation: text-enter 600ms cubic-bezier(0.16, 1, 0.3, 1) both;
 		}
@@ -63,7 +74,7 @@
 			isolation: isolate;
 			position: relative;
 
-			margin-block-start: var(--space-m);
+			margin: 0;
 			padding: 0 var(--space-l);
 
 			font-family: var(--font-display);

--- a/src/routes/discovery/discovery-route.ts
+++ b/src/routes/discovery/discovery-route.ts
@@ -1,5 +1,4 @@
 import { I18N } from '@aurelia/i18n'
-import { IRouter } from '@aurelia/router'
 import { IEventAggregator, ILogger, resolve, watch } from 'aurelia'
 import type { DnaOrbCanvas } from '../../components/dna-orb/dna-orb-canvas'
 import { Snack } from '../../components/snack-bar/snack'
@@ -15,7 +14,6 @@ import {
 	DASHBOARD_CONCERT_TARGET,
 	DASHBOARD_FOLLOW_TARGET,
 	IOnboardingService,
-	OnboardingStep,
 } from '../../services/onboarding-service'
 import { detectCountryFromTimezone } from '../../util/detect-country'
 import { BubbleManager } from './bubble-manager'
@@ -26,7 +24,6 @@ export class DiscoveryRoute {
 	private readonly artistClient = resolve(IArtistStore)
 	private readonly followStore = resolve(IFollowStore)
 	private readonly onboarding = resolve(IOnboardingService)
-	private readonly router = resolve(IRouter)
 	private readonly ea = resolve(IEventAggregator)
 	private readonly concertService = resolve(IConcertStore)
 	private readonly analytics = resolve(IAnalyticsService)
@@ -364,12 +361,13 @@ export class DiscoveryRoute {
 	}
 
 	public onCoachMarkTap(): void {
-		this.logger.info('Onboarding: coach mark tapped, advancing to dashboard', {
+		// Dismiss the spotlight only — do not navigate. The user advances to the
+		// dashboard by tapping the timetable nav themselves, which AuthHook then
+		// allows (readyForDashboard) and where the step transition happens.
+		this.logger.info('Onboarding: dashboard coach mark dismissed', {
 			followedCount: this.followedCount,
 		})
 		this.onboarding.deactivateSpotlight()
-		this.onboarding.setStep(OnboardingStep.DASHBOARD)
-		void this.router.load('/dashboard')
 	}
 
 	/**

--- a/test/routes/discovery-route.spec.ts
+++ b/test/routes/discovery-route.spec.ts
@@ -261,14 +261,15 @@ describe('DiscoveryRoute', () => {
 	})
 
 	describe('onCoachMarkTap', () => {
-		it('should set step to DASHBOARD and navigate to /dashboard', async () => {
+		it('should only dismiss the spotlight without advancing step or navigating', async () => {
 			mockOnboarding.isOnboarding = true
 			mockOnboarding.currentStep = 'discovery'
 
 			sut.onCoachMarkTap()
 
-			expect(mockOnboarding.setStep).toHaveBeenCalledWith('dashboard') // DASHBOARD
-			expect(mockRouter.load).toHaveBeenCalledWith('/dashboard')
+			expect(mockOnboarding.deactivateSpotlight).toHaveBeenCalledTimes(1)
+			expect(mockOnboarding.setStep).not.toHaveBeenCalled()
+			expect(mockRouter.load).not.toHaveBeenCalled()
 		})
 	})
 
@@ -700,16 +701,19 @@ describe('DiscoveryRoute', () => {
 		})
 	})
 
-	describe('onCoachMarkTap (Home nav step advancement)', () => {
-		it('should deactivate spotlight, advance step to DASHBOARD, and navigate', () => {
+	describe('onCoachMarkTap (Home nav coach mark)', () => {
+		it('should dismiss the spotlight without advancing step or navigating', () => {
 			mockOnboarding.isOnboarding = true
 			mockOnboarding.currentStep = 'discovery' // DISCOVERY
 
 			sut.onCoachMarkTap()
 
+			// Tapping the coach mark only clears the spotlight. The user advances
+			// to the dashboard by tapping the timetable nav themselves, where
+			// AuthHook performs the step transition.
 			expect(mockOnboarding.deactivateSpotlight).toHaveBeenCalledTimes(1)
-			expect(mockOnboarding.setStep).toHaveBeenCalledWith('dashboard') // DASHBOARD
-			expect(mockRouter.load).toHaveBeenCalledWith('/dashboard')
+			expect(mockOnboarding.setStep).not.toHaveBeenCalled()
+			expect(mockRouter.load).not.toHaveBeenCalled()
 		})
 
 		it('should not advance step when showDashboardCoachMark is false (fewer than 3 artistsWithConcerts)', () => {


### PR DESCRIPTION
## Summary

Fixes two onboarding UX issues on the Discovery page.

## Changes

### Coach mark no longer auto-navigates
Tapping the dashboard coach mark now only dismisses the spotlight. The user reaches the timetable by tapping the bottom nav themselves, where `AuthHook` already allows the dashboard route (`readyForDashboard`) and performs the onboarding step transition — so no step is lost. The now-unused `IRouter` / `OnboardingStep` dependencies are removed from the route.

### Celebration text wrapping and spacing
The celebration overlay heading wrapped mid-word and showed an oversized gap between the heading and sub text (the grid auto rows stretched to fill the viewport, splitting the two paragraphs to the top and bottom halves). Now the rows are packed to the centre as a single group (`align-content` + fixed `row-gap`), the heading uses a tighter line-height, and Japanese wraps at natural phrase boundaries with balanced line lengths (`text-wrap: balance` + `word-break: auto-phrase`, a graceful no-op where unsupported).

## Testing

- `make lint` — pass (remaining warning is a pre-existing unrelated file)
- `make test` — 112 + 2 test files pass
- Updated `discovery-route.spec.ts` to assert the coach mark tap dismisses the spotlight without advancing the step or navigating.

close: #442
