### PR TITLE
feat(admin): concert approval-queue screen

### DIFF
--- a/admin/admin-shell/admin-shell.ts
+++ b/admin/admin-shell/admin-shell.ts
@@ -23,6 +23,11 @@ import { route } from '@aurelia/router'
 			title: 'Welcome',
 		},
 		{
+			path: 'approval-queue',
+			component: import('../approval-queue/approval-queue-route'),
+			title: 'Approval Queue',
+		},
+		{
 			path: 'auth/callback',
 			component: import('../auth-callback/auth-callback-route'),
 			title: 'Signing In',

--- a/admin/approval-queue/approval-queue-route.css
+++ b/admin/approval-queue/approval-queue-route.css
@@ -1,0 +1,185 @@
+@layer block {
+	@scope (approval-queue-route) {
+		:scope {
+			--_radius: 0.5rem;
+			--_radius-round: 50%;
+			--_gap-xs: 0.25rem;
+			--_pad-input: 0.5rem;
+			--_pad-btn: 0.5rem 1rem;
+			--_spinner-size: 1.25rem;
+			--_border: color-mix(
+				in oklch,
+				var(--color-text-secondary) 25%,
+				transparent
+			);
+			--_surface-raised: oklch(24% 0.04 275deg);
+		}
+
+		.approval-queue {
+			--flow-space: var(--space-m);
+
+			max-inline-size: 80rem;
+			margin-inline: auto;
+			padding: var(--space-l) var(--space-m);
+		}
+
+		.approval-queue-brand {
+			font-size: var(--step--1);
+			font-weight: 700;
+			color: var(--color-brand-primary);
+			text-transform: uppercase;
+			letter-spacing: 0.08em;
+		}
+
+		.approval-queue-title {
+			font-size: var(--step-3);
+			color: var(--color-text-primary);
+		}
+
+		.approval-queue-subtitle {
+			color: var(--color-text-secondary);
+		}
+
+		.approval-queue-back-link {
+			display: inline-block;
+			color: var(--color-brand-primary);
+			text-decoration: underline;
+		}
+
+		.approval-queue-status {
+			display: flex;
+			gap: var(--space-s);
+			align-items: center;
+			color: var(--color-text-secondary);
+		}
+
+		.approval-queue-spinner {
+			inline-size: var(--_spinner-size);
+			block-size: var(--_spinner-size);
+			border: 2px solid var(--color-brand-primary);
+			border-block-start-color: transparent;
+			border-radius: var(--_radius-round);
+
+			animation: spin 1s linear infinite;
+		}
+
+		.approval-queue-state {
+			padding: var(--space-l);
+			border: 1px solid var(--_border);
+			border-radius: var(--_radius);
+
+			color: var(--color-text-secondary);
+			text-align: center;
+
+			&[data-state="error"] {
+				border-color: var(--color-error);
+				color: var(--color-error);
+			}
+		}
+
+		.approval-queue-error-detail {
+			font-size: var(--step--1);
+			white-space: pre-wrap;
+		}
+
+		.approval-queue-table {
+			border-collapse: collapse;
+			inline-size: 100%;
+
+			& th,
+			& td {
+				padding: var(--space-s);
+				border-block-end: 1px solid var(--_border);
+				text-align: start;
+				vertical-align: top;
+			}
+
+			& th {
+				font-size: var(--step--1);
+				color: var(--color-text-secondary);
+				text-transform: uppercase;
+				letter-spacing: 0.04em;
+			}
+
+			& tr[data-busy="true"] {
+				opacity: 0.6;
+			}
+		}
+
+		.approval-queue-admin-area {
+			display: block;
+			color: var(--color-text-secondary);
+		}
+
+		.approval-queue-unresolved {
+			font-weight: 700;
+			color: var(--color-error);
+		}
+
+		.approval-queue-source-link {
+			color: var(--color-brand-primary);
+			text-decoration: underline;
+		}
+
+		.approval-queue-reject-form {
+			--flow-space: var(--space-s);
+
+			min-inline-size: 16rem;
+		}
+
+		.approval-queue-reject-label {
+			display: flex;
+			flex-direction: column;
+			gap: var(--_gap-xs);
+
+			font-size: var(--step--1);
+			color: var(--color-text-secondary);
+		}
+
+		.approval-queue-reject-input {
+			padding: var(--_pad-input);
+			border: 1px solid var(--_border);
+			border-radius: var(--_radius);
+
+			font: inherit;
+			color: var(--color-text-primary);
+
+			background: var(--_surface-raised);
+		}
+
+		.approval-queue-btn {
+			cursor: pointer;
+
+			padding: var(--_pad-btn);
+			border: 1px solid var(--_border);
+			border-radius: var(--_radius);
+
+			font: inherit;
+			color: var(--color-text-primary);
+
+			background: var(--_surface-raised);
+
+			&:disabled {
+				cursor: not-allowed;
+				opacity: 0.5;
+			}
+
+			&[data-variant="approve"] {
+				border-color: var(--color-brand-primary);
+				color: var(--color-surface-base);
+				background: var(--color-brand-primary);
+			}
+
+			&[data-variant="reject"] {
+				border-color: var(--color-error);
+				color: var(--color-error);
+			}
+		}
+
+		.approval-queue-row-error {
+			margin-block-start: var(--space-s);
+			font-size: var(--step--1);
+			color: var(--color-error);
+		}
+	}
+}

--- a/admin/approval-queue/approval-queue-route.html
+++ b/admin/approval-queue/approval-queue-route.html
@@ -67,8 +67,8 @@
         </td>
         <td>
           <a
-            if.bind="row.sourceUrl"
-            href.bind="row.sourceUrl"
+            if.bind="sanitizeUrl(row.sourceUrl)"
+            href.bind="sanitizeUrl(row.sourceUrl)"
             target="_blank"
             rel="noopener noreferrer"
             class="approval-queue-source-link"

--- a/admin/approval-queue/approval-queue-route.html
+++ b/admin/approval-queue/approval-queue-route.html
@@ -1,0 +1,146 @@
+<main class="[ approval-queue ] [ flow ]">
+  <header class="approval-queue-header">
+    <p class="approval-queue-brand">Liverty Admin</p>
+    <h1 class="approval-queue-title">Concert approval queue</h1>
+    <p class="approval-queue-subtitle">
+      Review AI-discovered concerts before they are published to fans.
+    </p>
+    <a load="/welcome" class="approval-queue-back-link">← Back to console</a>
+  </header>
+
+  <output
+    if.bind="phase === 'loading'"
+    class="approval-queue-status"
+    role="status"
+    aria-busy="true"
+  >
+    <span class="approval-queue-spinner"></span>
+    <span>Loading the approval queue…</span>
+  </output>
+
+  <section
+    if.bind="phase === 'error'"
+    class="approval-queue-state"
+    role="alert"
+    data-state="error"
+  >
+    <p>Could not load the approval queue.</p>
+    <p class="approval-queue-error-detail">${loadError}</p>
+    <button type="button" class="approval-queue-btn" click.trigger="load()">
+      Retry
+    </button>
+  </section>
+
+  <section if.bind="isEmpty" class="approval-queue-state" data-state="empty">
+    <p>No concerts awaiting review.</p>
+  </section>
+
+  <table if.bind="phase === 'ready' && rows.length" class="approval-queue-table">
+    <thead>
+      <tr>
+        <th scope="col">Artist</th>
+        <th scope="col">Title</th>
+        <th scope="col">Local date</th>
+        <th scope="col">Start time</th>
+        <th scope="col">Listed venue</th>
+        <th scope="col">Resolved venue</th>
+        <th scope="col">Source</th>
+        <th scope="col">Discovered</th>
+        <th scope="col">Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr repeat.for="row of rows" data-busy.bind="row.busy">
+        <td>${row.performerName}</td>
+        <td>${row.title}</td>
+        <td>${row.localDate}</td>
+        <td>${row.startTime}</td>
+        <td>${row.listedVenueName}</td>
+        <td>
+          <span if.bind="row.hasResolvedVenue">
+            ${row.resolvedVenueName}
+            <small class="approval-queue-admin-area">${row.resolvedAdminArea}</small>
+          </span>
+          <span else class="approval-queue-unresolved" data-state="unresolved">
+            Unresolved venue — review
+          </span>
+        </td>
+        <td>
+          <a
+            if.bind="row.sourceUrl"
+            href.bind="row.sourceUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="approval-queue-source-link"
+          >
+            Open source
+          </a>
+          <span else>${'—'}</span>
+        </td>
+        <td>${row.discoveredTime}</td>
+        <td class="approval-queue-actions">
+          <div if.bind="!row.rejecting" class="[ approval-queue-action-bar ] [ cluster ]">
+            <button
+              type="button"
+              class="approval-queue-btn"
+              data-variant="approve"
+              disabled.bind="row.busy"
+              click.trigger="approve(row)"
+            >
+              Approve
+            </button>
+            <button
+              type="button"
+              class="approval-queue-btn"
+              data-variant="reject"
+              disabled.bind="row.busy"
+              click.trigger="startReject(row)"
+            >
+              Reject
+            </button>
+          </div>
+
+          <form
+            else
+            class="[ approval-queue-reject-form ] [ flow ]"
+            submit.trigger="confirmReject(row)"
+          >
+            <label class="approval-queue-reject-label">
+              Rejection reason
+              <input
+                type="text"
+                class="approval-queue-reject-input"
+                value.bind="row.rejectReason"
+                placeholder="Why is this concert being rejected?"
+                disabled.bind="row.busy"
+                aria-label="Rejection reason"
+              />
+            </label>
+            <div class="[ approval-queue-action-bar ] [ cluster ]">
+              <button
+                type="submit"
+                class="approval-queue-btn"
+                data-variant="reject"
+                disabled.bind="row.busy"
+              >
+                Confirm reject
+              </button>
+              <button
+                type="button"
+                class="approval-queue-btn"
+                disabled.bind="row.busy"
+                click.trigger="cancelReject(row)"
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+
+          <p if.bind="row.actionError" class="approval-queue-row-error" role="alert">
+            ${row.actionError}
+          </p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</main>

--- a/admin/approval-queue/approval-queue-route.ts
+++ b/admin/approval-queue/approval-queue-route.ts
@@ -1,0 +1,182 @@
+import type { PendingConcert } from '@buf/liverty-music_schema.bufbuild_es/liverty_music/rpc/admin/v1/concert_moderation_service_pb.js'
+import { ILogger, resolve } from 'aurelia'
+import { IConcertModerationClient } from '../services/concert-moderation-client'
+
+/** Coarse lifecycle phase for the initial list fetch. */
+type LoadPhase = 'loading' | 'ready' | 'error'
+
+/**
+ * One reviewable concert plus the per-row UI state the queue needs: whether an
+ * approve/reject request is in flight (to disable the row's buttons), whether
+ * the inline reject form is open, the bound reject reason, and any per-row
+ * action error. The raw {@link PendingConcert} is kept so the template renders
+ * the proto fields directly; the precomputed display strings flatten the proto
+ * wrapper types so the template stays free of optional-chaining noise.
+ */
+export interface QueueRow {
+	readonly concert: PendingConcert
+	readonly stagedId: string
+	readonly performerName: string
+	readonly title: string
+	readonly localDate: string
+	readonly startTime: string
+	readonly listedVenueName: string
+	readonly resolvedVenueName: string
+	readonly resolvedAdminArea: string
+	readonly hasResolvedVenue: boolean
+	readonly sourceUrl: string
+	readonly discoveredTime: string
+	busy: boolean
+	rejecting: boolean
+	rejectReason: string
+	actionError: string
+}
+
+const EMPTY = '—'
+
+function formatLocalDate(concert: PendingConcert): string {
+	const d = concert.localDate?.value
+	if (!d) return EMPTY
+	// google.type.Date is a plain Y/M/D triple (no timezone). Pad to ISO-ish
+	// YYYY-MM-DD so review rows sort/read consistently regardless of locale.
+	const mm = String(d.month).padStart(2, '0')
+	const dd = String(d.day).padStart(2, '0')
+	return `${d.year}-${mm}-${dd}`
+}
+
+function formatTimestamp(ts?: { toDate(): Date }): string {
+	if (!ts) return EMPTY
+	try {
+		return ts.toDate().toLocaleString()
+	} catch {
+		return EMPTY
+	}
+}
+
+function formatStartTime(concert: PendingConcert): string {
+	const ts = concert.startTime?.value
+	if (!ts) return EMPTY
+	try {
+		return ts.toDate().toLocaleTimeString([], {
+			hour: '2-digit',
+			minute: '2-digit',
+		})
+	} catch {
+		return EMPTY
+	}
+}
+
+function toRow(concert: PendingConcert): QueueRow {
+	const resolved = concert.resolvedVenue
+	return {
+		concert,
+		stagedId: concert.stagedId?.value ?? '',
+		performerName: concert.performer?.name?.value ?? EMPTY,
+		title: concert.title?.value ?? EMPTY,
+		localDate: formatLocalDate(concert),
+		startTime: formatStartTime(concert),
+		listedVenueName: concert.listedVenueName?.value ?? EMPTY,
+		resolvedVenueName: resolved?.name?.value ?? EMPTY,
+		resolvedAdminArea: resolved?.adminArea?.value ?? EMPTY,
+		hasResolvedVenue: resolved !== undefined,
+		sourceUrl: concert.sourceUrl?.value ?? '',
+		discoveredTime: formatTimestamp(concert.discoveredTime),
+		busy: false,
+		rejecting: false,
+		rejectReason: '',
+		actionError: '',
+	}
+}
+
+/**
+ * Concert approval-queue screen. Loads the pending queue on attach and lets a
+ * reviewer approve or reject each discovered concert. Approve/reject run
+ * against the admin-local {@link IConcertModerationClient}; on success the row
+ * is removed from the list, on failure a per-row error is surfaced and the row
+ * stays put so the action can be retried.
+ */
+export class ApprovalQueueRoute {
+	public phase: LoadPhase = 'loading'
+	public loadError = ''
+	public rows: QueueRow[] = []
+
+	private readonly client = resolve(IConcertModerationClient)
+	private readonly logger = resolve(ILogger).scopeTo('ApprovalQueueRoute')
+
+	public async attached(): Promise<void> {
+		await this.load()
+	}
+
+	public async load(): Promise<void> {
+		this.phase = 'loading'
+		this.loadError = ''
+		try {
+			const pending = await this.client.listPending()
+			this.rows = pending.map(toRow)
+			this.phase = 'ready'
+		} catch (err) {
+			this.loadError =
+				err instanceof Error
+					? err.message
+					: 'Failed to load the approval queue.'
+			this.phase = 'error'
+			this.logger.error('Failed to load pending concerts', err)
+		}
+	}
+
+	public async approve(row: QueueRow): Promise<void> {
+		if (row.busy) return
+		row.busy = true
+		row.actionError = ''
+		try {
+			await this.client.approve(row.stagedId)
+			this.removeRow(row)
+		} catch (err) {
+			row.actionError =
+				err instanceof Error ? err.message : 'Approval failed. Try again.'
+			row.busy = false
+			this.logger.error('Approve failed', { stagedId: row.stagedId, err })
+		}
+	}
+
+	/** Opens the inline reject form for a row. */
+	public startReject(row: QueueRow): void {
+		row.rejecting = true
+		row.actionError = ''
+	}
+
+	/** Cancels the inline reject form without dropping the concert. */
+	public cancelReject(row: QueueRow): void {
+		row.rejecting = false
+		row.rejectReason = ''
+	}
+
+	public async confirmReject(row: QueueRow): Promise<void> {
+		if (row.busy) return
+		const reason = row.rejectReason.trim()
+		if (reason.length === 0) {
+			row.actionError = 'A rejection reason is required.'
+			return
+		}
+		row.busy = true
+		row.actionError = ''
+		try {
+			await this.client.reject(row.stagedId, reason)
+			this.removeRow(row)
+		} catch (err) {
+			row.actionError =
+				err instanceof Error ? err.message : 'Rejection failed. Try again.'
+			row.busy = false
+			this.logger.error('Reject failed', { stagedId: row.stagedId, err })
+		}
+	}
+
+	public get isEmpty(): boolean {
+		return this.phase === 'ready' && this.rows.length === 0
+	}
+
+	private removeRow(row: QueueRow): void {
+		const idx = this.rows.indexOf(row)
+		if (idx !== -1) this.rows.splice(idx, 1)
+	}
+}

--- a/admin/approval-queue/approval-queue-route.ts
+++ b/admin/approval-queue/approval-queue-route.ts
@@ -1,5 +1,6 @@
 import type { PendingConcert } from '@buf/liverty-music_schema.bufbuild_es/liverty_music/rpc/admin/v1/concert_moderation_service_pb.js'
 import { ILogger, resolve } from 'aurelia'
+import { sanitizeUrl } from '../../shared/utils/sanitize-url'
 import { IConcertModerationClient } from '../services/concert-moderation-client'
 
 /** Coarse lifecycle phase for the initial list fetch. */
@@ -102,6 +103,14 @@ export class ApprovalQueueRoute {
 
 	private readonly client = resolve(IConcertModerationClient)
 	private readonly logger = resolve(ILogger).scopeTo('ApprovalQueueRoute')
+
+	/**
+	 * Allowlists a source URL to http(s) before it is bound to an anchor
+	 * `href`. The source URL is AI-discovered, so a `javascript:` value must be
+	 * neutralised — Aurelia does not sanitize attribute bindings. Exposed for
+	 * the template binding `href.bind="sanitizeUrl(row.sourceUrl)"`.
+	 */
+	public readonly sanitizeUrl = sanitizeUrl
 
 	public async attached(): Promise<void> {
 		await this.load()

--- a/admin/services/admin-transport.ts
+++ b/admin/services/admin-transport.ts
@@ -1,0 +1,66 @@
+import type { Interceptor } from '@connectrpc/connect'
+import { createConnectTransport } from '@connectrpc/connect-web'
+import type { ILogger } from 'aurelia'
+import type { AppConfig } from '../../shared/config/app-config'
+import type { IAuthService } from '../../shared/services/auth-service'
+
+/**
+ * Creates a Connect transport for the admin console with authentication and
+ * logging interceptors.
+ *
+ * Deliberately admin-local and minimal: it must NOT import the consumer's
+ * `src/services/grpc-transport.ts` (bundle-isolation / import-boundary rule —
+ * admin code may only cross into `shared/`). It therefore drops the consumer's
+ * OTEL and retry interceptors, keeping just the two an admin reviewer needs:
+ * bearer-token injection and request/response logging.
+ *
+ * Accepts `IAuthService`, `ILogger`, and `AppConfig` as parameters rather than
+ * calling `resolve()` internally so it can run outside a DI resolution context
+ * without triggering AUR0002 (mirrors the consumer transport's documented
+ * factory shape).
+ *
+ * @param auth - Shared AuthService used to read the OIDC access token
+ * @param logger - Logger scoped to the admin transport
+ * @param config - Resolved runtime AppConfig providing `apiBaseUrl`
+ * @returns A configured Connect transport with auth + logging interceptors
+ */
+export const createAdminTransport = (
+	auth: IAuthService,
+	logger: ILogger,
+	config: AppConfig,
+) => {
+	/** Injects the OIDC access token as a bearer token on every request. */
+	const authInterceptor: Interceptor = (next) => async (req) => {
+		try {
+			const user = await auth.getUserManager().getUser()
+			if (user?.access_token) {
+				req.header.set('Authorization', `Bearer ${user.access_token}`)
+			}
+		} catch (err) {
+			logger.error('Failed to get user from UserManager', err)
+		}
+		return await next(req)
+	}
+
+	/** Logs each Connect-RPC request/response with its wall-clock duration. */
+	const loggingInterceptor: Interceptor = (next) => async (req) => {
+		const method = `${req.service.typeName}/${req.method.name}`
+		const start = performance.now()
+		logger.debug('RPC request', method)
+		try {
+			const response = await next(req)
+			const durationMs = Math.round(performance.now() - start)
+			logger.debug('RPC response', method, `${durationMs}ms`)
+			return response
+		} catch (err) {
+			const durationMs = Math.round(performance.now() - start)
+			logger.error('RPC error', method, `${durationMs}ms`, err)
+			throw err
+		}
+	}
+
+	return createConnectTransport({
+		baseUrl: config.apiBaseUrl,
+		interceptors: [loggingInterceptor, authInterceptor],
+	})
+}

--- a/admin/services/concert-moderation-client.ts
+++ b/admin/services/concert-moderation-client.ts
@@ -1,0 +1,87 @@
+import { StagedConcertId } from '@buf/liverty-music_schema.bufbuild_es/liverty_music/entity/v1/staged_concert_pb.js'
+import type {
+	PendingConcert,
+	ResolvedVenue,
+} from '@buf/liverty-music_schema.bufbuild_es/liverty_music/rpc/admin/v1/concert_moderation_service_pb.js'
+import { ConcertModerationService } from '@buf/liverty-music_schema.connectrpc_es/liverty_music/rpc/admin/v1/concert_moderation_service_connect.js'
+import { createClient } from '@connectrpc/connect'
+import { DI, ILogger, resolve } from 'aurelia'
+import { IAppConfig } from '../../shared/config/app-config'
+import { IAuthService } from '../../shared/services/auth-service'
+import { createAdminTransport } from './admin-transport'
+
+export type { PendingConcert, ResolvedVenue }
+
+export const IConcertModerationClient =
+	DI.createInterface<IConcertModerationClient>(
+		'IConcertModerationClient',
+		(x) => x.singleton(ConcertModerationClient),
+	)
+
+export interface IConcertModerationClient extends ConcertModerationClient {}
+
+/**
+ * Admin-local wrapper around the generated `ConcertModerationService` client.
+ *
+ * Mirrors the shape of the consumer's `ConcertRpcClient` (DI-registered
+ * interface, logger-scoped, error propagation) but is built entirely from
+ * admin/shared modules — it never imports the consumer `src/`. Callers work
+ * with the generated `PendingConcert` messages directly; the wrapper only owns
+ * transport construction, request marshalling, logging, and error surfacing.
+ */
+export class ConcertModerationClient {
+	private readonly logger = resolve(ILogger).scopeTo('ConcertModerationClient')
+	private readonly authService = resolve(IAuthService)
+	private readonly client = createClient(
+		ConcertModerationService,
+		createAdminTransport(
+			this.authService,
+			resolve(ILogger).scopeTo('AdminTransport'),
+			resolve(IAppConfig),
+		),
+	)
+
+	/** Returns every concert currently awaiting review. */
+	public async listPending(signal?: AbortSignal): Promise<PendingConcert[]> {
+		this.logger.info('Listing pending concerts')
+		try {
+			const response = await this.client.listPendingConcerts({}, { signal })
+			return response.pendingConcerts
+		} catch (err) {
+			this.logger.warn('listPendingConcerts failed', { error: err })
+			throw err
+		}
+	}
+
+	/** Publishes a pending concert to fans. Idempotent server-side. */
+	public async approve(stagedId: string, signal?: AbortSignal): Promise<void> {
+		this.logger.info('Approving concert', { stagedId })
+		try {
+			await this.client.approveConcert(
+				{ stagedId: new StagedConcertId({ value: stagedId }) },
+				{ signal },
+			)
+		} catch (err) {
+			this.logger.warn('approveConcert failed', { stagedId, error: err })
+			throw err
+		}
+	}
+
+	/** Drops a pending concert, recording the reviewer's reason. */
+	public async reject(
+		stagedId: string,
+		reason: string,
+		signal?: AbortSignal,
+	): Promise<void> {
+		this.logger.info('Rejecting concert', { stagedId })
+		try {
+			await this.client.rejectConcert(
+				{ stagedId: new StagedConcertId({ value: stagedId }), reason },
+				{ signal },
+			)
+		} catch (err) {
+			this.logger.warn('rejectConcert failed', { stagedId, error: err })
+			throw err
+		}
+	}
+}

--- a/admin/styles/main.css
+++ b/admin/styles/main.css
@@ -6,7 +6,7 @@
  * the design tokens the admin views actually use. Token values are kept in sync
  * with `src/styles/tokens.css`.
  */
-@layer reset, tokens, global, block;
+@layer reset, tokens, global, composition, block;
 
 @layer reset {
 	:where(*, *::before, *::after) {
@@ -61,5 +61,20 @@
 		to {
 			transform: rotate(360deg);
 		}
+	}
+}
+
+@layer composition {
+	/* Every Layout: vertical rhythm via the owl selector. No visual treatment. */
+	.flow > * + * {
+		margin-block-start: var(--flow-space, var(--space-s));
+	}
+
+	/* Every Layout: cluster — wrap items with consistent gap, no width math. */
+	.cluster {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--cluster-space, var(--space-s));
+		align-items: center;
 	}
 }

--- a/admin/welcome/welcome-route.css
+++ b/admin/welcome/welcome-route.css
@@ -38,5 +38,11 @@
 			line-height: var(--leading-relaxed);
 			color: var(--color-text-secondary);
 		}
+
+		.admin-welcome-link {
+			font-weight: 700;
+			color: var(--color-brand-primary);
+			text-decoration: underline;
+		}
 	}
 }

--- a/admin/welcome/welcome-route.html
+++ b/admin/welcome/welcome-route.html
@@ -3,8 +3,10 @@
     <p class="admin-welcome-brand">Liverty Admin</p>
     <h1 class="admin-welcome-title">Welcome, ${username}</h1>
     <p class="admin-welcome-subtitle">
-      You are signed in. This is the foundation of the internal admin console —
-      no operational features are available yet.
+      You are signed in to the internal admin console.
     </p>
+    <a load="/approval-queue" class="admin-welcome-link">
+      Open concert approval queue →
+    </a>
   </section>
 </main>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
 			"dependencies": {
 				"@aurelia/i18n": "^2.0.0-rc.1",
 				"@aurelia/router": "^2.0.0-rc.1",
-				"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260603024137-cbe7ee103c78.1",
-				"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260603024137-cbe7ee103c78.2",
+				"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260607083432-e011217d6596.1",
+				"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260607083432-e011217d6596.2",
 				"@bufbuild/protobuf": "^1.10.1",
 				"@connectrpc/connect": "^1.7.0",
 				"@connectrpc/connect-web": "^1.7.0",
@@ -2163,8 +2163,8 @@
 			}
 		},
 		"node_modules/@buf/liverty-music_schema.bufbuild_es": {
-			"version": "1.10.0-20260603024137-cbe7ee103c78.1",
-			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.bufbuild_es/-/liverty-music_schema.bufbuild_es-1.10.0-20260603024137-cbe7ee103c78.1.tgz",
+			"version": "1.10.0-20260607083432-e011217d6596.1",
+			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.bufbuild_es/-/liverty-music_schema.bufbuild_es-1.10.0-20260607083432-e011217d6596.1.tgz",
 			"dependencies": {
 				"@buf/bufbuild_protovalidate.bufbuild_es": "1.10.0-20250717185734-6c6e0d3c608e.1",
 				"@buf/googleapis_googleapis.bufbuild_es": "1.10.0-20250411203938-61b203b9a916.1"
@@ -2174,12 +2174,12 @@
 			}
 		},
 		"node_modules/@buf/liverty-music_schema.connectrpc_es": {
-			"version": "1.6.1-20260603024137-cbe7ee103c78.2",
-			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.connectrpc_es/-/liverty-music_schema.connectrpc_es-1.6.1-20260603024137-cbe7ee103c78.2.tgz",
+			"version": "1.6.1-20260607083432-e011217d6596.2",
+			"resolved": "https://buf.build/gen/npm/v1/@buf/liverty-music_schema.connectrpc_es/-/liverty-music_schema.connectrpc_es-1.6.1-20260607083432-e011217d6596.2.tgz",
 			"dependencies": {
 				"@buf/bufbuild_protovalidate.connectrpc_es": "1.6.1-20250717185734-6c6e0d3c608e.2",
 				"@buf/googleapis_googleapis.connectrpc_es": "1.6.1-20250411203938-61b203b9a916.2",
-				"@buf/liverty-music_schema.bufbuild_es": "1.10.0-20260603024137-cbe7ee103c78.1"
+				"@buf/liverty-music_schema.bufbuild_es": "1.10.0-20260607083432-e011217d6596.1"
 			},
 			"peerDependencies": {
 				"@connectrpc/connect": "^1.6.1"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
 	"dependencies": {
 		"@aurelia/i18n": "^2.0.0-rc.1",
 		"@aurelia/router": "^2.0.0-rc.1",
-		"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260603024137-cbe7ee103c78.1",
-		"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260603024137-cbe7ee103c78.2",
+		"@buf/liverty-music_schema.bufbuild_es": "^1.10.0-20260607083432-e011217d6596.1",
+		"@buf/liverty-music_schema.connectrpc_es": "^1.6.1-20260607083432-e011217d6596.2",
 		"@bufbuild/protobuf": "^1.10.1",
 		"@connectrpc/connect": "^1.7.0",
 		"@connectrpc/connect-web": "^1.7.0",

--- a/shared/utils/sanitize-url.ts
+++ b/shared/utils/sanitize-url.ts
@@ -1,0 +1,22 @@
+/**
+ * Returns the URL unchanged only when it is an `http:`/`https:` URL; otherwise
+ * returns an empty string.
+ *
+ * Aurelia HTML-escapes text interpolation but does NOT sanitize attribute
+ * bindings, so any externally-sourced URL bound to an anchor `href` must pass
+ * through this allowlist first. Without it a value like `javascript:<payload>`
+ * — which can reach us via AI-discovered / user-imported data — would execute
+ * script in the user's session when the link is clicked.
+ */
+export function sanitizeUrl(url: string | undefined): string {
+	if (!url) return ''
+	try {
+		const parsed = new URL(url)
+		if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+			return url
+		}
+	} catch {
+		// Invalid URL — fall through to empty.
+	}
+	return ''
+}

--- a/test/admin/approval-queue/approval-queue-route.spec.ts
+++ b/test/admin/approval-queue/approval-queue-route.spec.ts
@@ -1,0 +1,227 @@
+import {
+	Artist,
+	ArtistName,
+} from '@buf/liverty-music_schema.bufbuild_es/liverty_music/entity/v1/artist_pb.js'
+import {
+	ListedVenueName,
+	LocalDate,
+	Title,
+	Url,
+} from '@buf/liverty-music_schema.bufbuild_es/liverty_music/entity/v1/entity_pb.js'
+import { StagedConcertId } from '@buf/liverty-music_schema.bufbuild_es/liverty_music/entity/v1/staged_concert_pb.js'
+import {
+	AdminArea,
+	VenueName,
+} from '@buf/liverty-music_schema.bufbuild_es/liverty_music/entity/v1/venue_pb.js'
+import {
+	PendingConcert,
+	ResolvedVenue,
+} from '@buf/liverty-music_schema.bufbuild_es/liverty_music/rpc/admin/v1/concert_moderation_service_pb.js'
+import { Date as GoogleDate } from '@buf/googleapis_googleapis.bufbuild_es/google/type/date_pb.js'
+import { Timestamp } from '@bufbuild/protobuf'
+import { createFixture } from '@aurelia/testing'
+import { DI, Registration } from 'aurelia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The route resolves IConcertModerationClient. Replace the real module (which
+// would build a Connect transport over the generated client) with a fresh
+// interface token + a no-op class so the fixture binds to the test double.
+const IConcertModerationClient = DI.createInterface('IConcertModerationClient')
+
+vi.mock('../../../admin/services/concert-moderation-client', () => ({
+	IConcertModerationClient,
+}))
+
+const { ApprovalQueueRoute } = await import(
+	'../../../admin/approval-queue/approval-queue-route'
+)
+
+interface MockClient {
+	listPending: ReturnType<typeof vi.fn>
+	approve: ReturnType<typeof vi.fn>
+	reject: ReturnType<typeof vi.fn>
+}
+
+function createMockClient(overrides: Partial<MockClient> = {}): MockClient {
+	return {
+		listPending: vi.fn().mockResolvedValue([]),
+		approve: vi.fn().mockResolvedValue(undefined),
+		reject: vi.fn().mockResolvedValue(undefined),
+		...overrides,
+	}
+}
+
+function resolvedConcert(): PendingConcert {
+	return new PendingConcert({
+		stagedId: new StagedConcertId({ value: 'staged-1' }),
+		performer: new Artist({
+			name: new ArtistName({ value: 'The Resolved Band' }),
+		}),
+		title: new Title({ value: 'Summer Tour' }),
+		localDate: new LocalDate({
+			value: new GoogleDate({ year: 2026, month: 7, day: 4 }),
+		}),
+		startTime: undefined,
+		listedVenueName: new ListedVenueName({ value: 'budokan hall' }),
+		resolvedVenue: new ResolvedVenue({
+			name: new VenueName({ value: 'Nippon Budokan' }),
+			adminArea: new AdminArea({ value: 'JP-13' }),
+		}),
+		sourceUrl: new Url({ value: 'https://example.com/show/1' }),
+		discoveredTime: Timestamp.fromDate(new Date('2026-06-01T12:00:00Z')),
+	})
+}
+
+function unresolvedConcert(): PendingConcert {
+	return new PendingConcert({
+		stagedId: new StagedConcertId({ value: 'staged-2' }),
+		performer: new Artist({ name: new ArtistName({ value: 'No Venue Act' }) }),
+		title: new Title({ value: 'Mystery Gig' }),
+		localDate: new LocalDate({
+			value: new GoogleDate({ year: 2026, month: 8, day: 9 }),
+		}),
+		listedVenueName: new ListedVenueName({ value: 'some unknown place' }),
+		resolvedVenue: undefined,
+		sourceUrl: new Url({ value: 'https://example.com/show/2' }),
+		discoveredTime: Timestamp.fromDate(new Date('2026-06-02T12:00:00Z')),
+	})
+}
+
+async function build(client: MockClient) {
+	const fixture = createFixture
+		.html('<approval-queue-route component.ref="route"></approval-queue-route>')
+		.deps(
+			ApprovalQueueRoute,
+			Registration.instance(IConcertModerationClient, client),
+		)
+		.build()
+	await fixture.started
+	return fixture
+}
+
+function routeOf(
+	fixture: Awaited<ReturnType<typeof build>>,
+): InstanceType<typeof ApprovalQueueRoute> {
+	return (
+		fixture.component as { route: InstanceType<typeof ApprovalQueueRoute> }
+	).route
+}
+
+describe('ApprovalQueueRoute', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('renders reviewable fields for resolved and unresolved rows', async () => {
+		const client = createMockClient({
+			listPending: vi
+				.fn()
+				.mockResolvedValue([resolvedConcert(), unresolvedConcert()]),
+		})
+		const fixture = await build(client)
+
+		const text = fixture.appHost.textContent ?? ''
+		// Resolved row: performer, title, local date, listed + resolved venue, area.
+		expect(text).toContain('The Resolved Band')
+		expect(text).toContain('Summer Tour')
+		expect(text).toContain('2026-07-04')
+		expect(text).toContain('budokan hall')
+		expect(text).toContain('Nippon Budokan')
+		expect(text).toContain('JP-13')
+		// Unresolved row is clearly flagged for review.
+		expect(text).toContain('Unresolved venue — review')
+		// Source link renders with the raw URL.
+		const links = Array.from(
+			fixture.appHost.querySelectorAll<HTMLAnchorElement>(
+				'a.approval-queue-source-link',
+			),
+		)
+		expect(links.map((a) => a.href)).toContain('https://example.com/show/1')
+	})
+
+	it('renders the empty state when no concerts are pending', async () => {
+		const client = createMockClient({
+			listPending: vi.fn().mockResolvedValue([]),
+		})
+		const fixture = await build(client)
+
+		expect(fixture.appHost.textContent).toContain('No concerts awaiting review')
+	})
+
+	it('shows the error state when the initial list fails', async () => {
+		const client = createMockClient({
+			listPending: vi.fn().mockRejectedValue(new Error('boom')),
+		})
+		const fixture = await build(client)
+		const vm = routeOf(fixture)
+
+		expect(vm.phase).toBe('error')
+		expect(fixture.appHost.textContent).toContain(
+			'Could not load the approval queue',
+		)
+		expect(fixture.appHost.textContent).toContain('boom')
+	})
+
+	it('approve calls approve(id) and removes the row', async () => {
+		const client = createMockClient({
+			listPending: vi.fn().mockResolvedValue([resolvedConcert()]),
+		})
+		const fixture = await build(client)
+		const vm = routeOf(fixture)
+
+		expect(vm.rows).toHaveLength(1)
+		await vm.approve(vm.rows[0])
+
+		expect(client.approve).toHaveBeenCalledWith('staged-1')
+		expect(vm.rows).toHaveLength(0)
+	})
+
+	it('reject requires a reason before calling reject', async () => {
+		const client = createMockClient({
+			listPending: vi.fn().mockResolvedValue([resolvedConcert()]),
+		})
+		const fixture = await build(client)
+		const vm = routeOf(fixture)
+
+		const row = vm.rows[0]
+		vm.startReject(row)
+		row.rejectReason = '   '
+		await vm.confirmReject(row)
+
+		expect(client.reject).not.toHaveBeenCalled()
+		expect(row.actionError).toContain('reason is required')
+		expect(vm.rows).toHaveLength(1)
+	})
+
+	it('reject with a reason calls reject(id, reason) and removes the row', async () => {
+		const client = createMockClient({
+			listPending: vi.fn().mockResolvedValue([resolvedConcert()]),
+		})
+		const fixture = await build(client)
+		const vm = routeOf(fixture)
+
+		const row = vm.rows[0]
+		vm.startReject(row)
+		row.rejectReason = 'wrong date'
+		await vm.confirmReject(row)
+
+		expect(client.reject).toHaveBeenCalledWith('staged-1', 'wrong date')
+		expect(vm.rows).toHaveLength(0)
+	})
+
+	it('surfaces a per-row error and keeps the row when approve fails', async () => {
+		const client = createMockClient({
+			listPending: vi.fn().mockResolvedValue([resolvedConcert()]),
+			approve: vi.fn().mockRejectedValue(new Error('approve failed')),
+		})
+		const fixture = await build(client)
+		const vm = routeOf(fixture)
+
+		const row = vm.rows[0]
+		await vm.approve(row)
+
+		expect(row.actionError).toContain('approve failed')
+		expect(row.busy).toBe(false)
+		expect(vm.rows).toHaveLength(1)
+	})
+})

--- a/test/admin/approval-queue/approval-queue-route.spec.ts
+++ b/test/admin/approval-queue/approval-queue-route.spec.ts
@@ -1,3 +1,5 @@
+import { createFixture } from '@aurelia/testing'
+import { Date as GoogleDate } from '@buf/googleapis_googleapis.bufbuild_es/google/type/date_pb.js'
 import {
 	Artist,
 	ArtistName,
@@ -17,9 +19,7 @@ import {
 	PendingConcert,
 	ResolvedVenue,
 } from '@buf/liverty-music_schema.bufbuild_es/liverty_music/rpc/admin/v1/concert_moderation_service_pb.js'
-import { Date as GoogleDate } from '@buf/googleapis_googleapis.bufbuild_es/google/type/date_pb.js'
 import { Timestamp } from '@bufbuild/protobuf'
-import { createFixture } from '@aurelia/testing'
 import { DI, Registration } from 'aurelia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -137,6 +137,32 @@ describe('ApprovalQueueRoute', () => {
 			),
 		)
 		expect(links.map((a) => a.href)).toContain('https://example.com/show/1')
+	})
+
+	it('does not render a source link for a javascript: URL (XSS guard)', async () => {
+		const malicious = new PendingConcert({
+			stagedId: new StagedConcertId({ value: 'staged-xss' }),
+			performer: new Artist({ name: new ArtistName({ value: 'Sketchy Act' }) }),
+			title: new Title({ value: 'Suspicious Show' }),
+			localDate: new LocalDate({
+				value: new GoogleDate({ year: 2026, month: 9, day: 1 }),
+			}),
+			listedVenueName: new ListedVenueName({ value: 'somewhere' }),
+			// AI-sourced URL carrying a script payload — must be neutralised.
+			sourceUrl: new Url({ value: 'javascript:alert(document.cookie)' }),
+			discoveredTime: Timestamp.fromDate(new Date('2026-06-03T12:00:00Z')),
+		})
+		const client = createMockClient({
+			listPending: vi.fn().mockResolvedValue([malicious]),
+		})
+		const fixture = await build(client)
+
+		// sanitizeUrl() reduces the javascript: scheme to '', so if.bind hides
+		// the anchor entirely — no dangerous href reaches the DOM.
+		const links = fixture.appHost.querySelectorAll(
+			'a.approval-queue-source-link',
+		)
+		expect(links).toHaveLength(0)
 	})
 
 	it('renders the empty state when no concerts are pending', async () => {

--- a/test/shared/utils/sanitize-url.spec.ts
+++ b/test/shared/utils/sanitize-url.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeUrl } from '../../../shared/utils/sanitize-url'
+
+describe('sanitizeUrl', () => {
+	it('passes through http and https URLs unchanged', () => {
+		expect(sanitizeUrl('http://example.com/a')).toBe('http://example.com/a')
+		expect(sanitizeUrl('https://example.com/b?q=1')).toBe(
+			'https://example.com/b?q=1',
+		)
+	})
+
+	it('neutralises dangerous schemes to an empty string', () => {
+		expect(sanitizeUrl('javascript:alert(1)')).toBe('')
+		expect(sanitizeUrl('data:text/html,<script>1</script>')).toBe('')
+		expect(sanitizeUrl('vbscript:msgbox(1)')).toBe('')
+		expect(sanitizeUrl('file:///etc/passwd')).toBe('')
+	})
+
+	it('returns empty for unparseable or absent input', () => {
+		expect(sanitizeUrl('not a url')).toBe('')
+		expect(sanitizeUrl('')).toBe('')
+		expect(sanitizeUrl(undefined)).toBe('')
+	})
+})


### PR DESCRIPTION
## Summary

Admin console **concert approval-queue** screen — the reviewer UI for the developer approval gate over AI-discovered concerts. Depends on specification v0.44.0 (BSR-published) and the backend `ConcertModerationService`.

## Changes

- **Admin RPC client** (`admin/services/`): an admin-local Connect transport (bearer token from the shared `AuthService`, `baseUrl` from runtime config) + a `ConcertModerationService` client wrapper (`listPending` / `approve` / `reject`). Bundle-isolated — never imports the consumer `src/` tree (verified by depcruise + the production `verify-bundle-isolation` check).
- **Approval-queue route** (`admin/approval-queue/`): lists pending concerts with all reviewable fields (artist, title, date, start time, raw listed venue name, resolved venue + admin_area or an "unresolved venue" flag, source link, discovered time); per-row **Approve** and **Reject (with mandatory reason)** actions; in-flight/error state per row; loading / empty / error states. Reachable from the welcome route.
- Generated `@buf` schema package upgraded to the v0.44.0 build (stays on the protobuf-es v1 line).

## Testing
`make lint` + `make test` green (7 new specs, mocked client); production `npm run build` succeeds; bundle isolation verified.

## Cross-repo
Pairs with the backend (handler + RBAC) and cloud-provisioning (Zitadel role + CORS) PRs.

Refs: #611
