### PR TITLE
fix(admin): navigate sibling routes via parent-relative path (AUR3401)

### DIFF
--- a/admin/approval-queue/approval-queue-route.html
+++ b/admin/approval-queue/approval-queue-route.html
@@ -5,7 +5,7 @@
     <p class="approval-queue-subtitle">
       Review AI-discovered concerts before they are published to fans.
     </p>
-    <a load="/welcome" class="approval-queue-back-link">← Back to console</a>
+    <a load="../welcome" class="approval-queue-back-link">← Back to console</a>
   </header>
 
   <output

--- a/admin/auth-callback/auth-callback-route.html
+++ b/admin/auth-callback/auth-callback-route.html
@@ -4,5 +4,5 @@
     <p class="admin-callback-status">Verifying authentication…</p>
   </output>
   <section if.bind="error" class="admin-callback-error">${error}</section>
-  <a if.bind="error" load="/welcome" class="admin-callback-home-link">Return to console</a>
+  <a if.bind="error" load="../welcome" class="admin-callback-home-link">Return to console</a>
 </main>

--- a/admin/welcome/welcome-route.html
+++ b/admin/welcome/welcome-route.html
@@ -5,7 +5,7 @@
     <p class="admin-welcome-subtitle">
       You are signed in to the internal admin console.
     </p>
-    <a load="/approval-queue" class="admin-welcome-link">
+    <a load="../approval-queue" class="admin-welcome-link">
       Open concert approval queue →
     </a>
   </section>

--- a/test/admin/navigation-links.spec.ts
+++ b/test/admin/navigation-links.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import approvalQueueHtml from '../../admin/approval-queue/approval-queue-route.html?raw'
+import authCallbackHtml from '../../admin/auth-callback/auth-callback-route.html?raw'
+import welcomeHtml from '../../admin/welcome/welcome-route.html?raw'
+
+/**
+ * Regression guard for AUR3401. The admin routes (welcome, approval-queue,
+ * auth/callback) are all SIBLINGS under `admin-shell`. A `load="/route"`
+ * (root-absolute) inside a child component resolves against that child's own
+ * routing context — Aurelia looks for the target as a CHILD route and fails:
+ *
+ *   AUR3401: Neither the route 'approval-queue' matched any configured route
+ *   at 'admin-shell/welcome-route' ...
+ *
+ * Per the Aurelia 2 router docs, sibling navigation from a child uses the
+ * parent-context `../` prefix. These assertions pin every admin nav link to
+ * that form so the leading-slash variant cannot be reintroduced.
+ */
+describe('admin sibling navigation uses parent-relative paths', () => {
+	const cases: ReadonlyArray<[name: string, html: string, target: string]> = [
+		['welcome-route', welcomeHtml, '../approval-queue'],
+		['approval-queue-route', approvalQueueHtml, '../welcome'],
+		['auth-callback-route', authCallbackHtml, '../welcome'],
+	]
+
+	for (const [name, html, expectedTarget] of cases) {
+		it(`${name} navigates to a sibling via ${expectedTarget}`, () => {
+			// The intended sibling-nav target is present...
+			expect(html).toContain(`load="${expectedTarget}"`)
+			// ...and no root-absolute load (the AUR3401 trap) remains.
+			expect(html).not.toMatch(/load="\/[a-z]/)
+		})
+	}
+})


### PR DESCRIPTION
## Summary

Hotfix: the admin console's **"Open concert approval queue →"** link did nothing — clicking it threw `AUR3401` and the route never loaded.

```
[ERR Router] AUR3271: Transition failed with error: AUR3401: Neither the route
'approval-queue' matched any configured route at 'admin-shell/welcome-route' nor
a fallback is configured for the viewport 'default'
```

## Cause

The links used `load="/approval-queue"` (root-absolute). Aurelia 2 resolves a `load` instruction against the **current child's** routing context, so from inside `welcome-route` it searched for `approval-queue` as a *child* of `welcome-route` — which doesn't exist. `welcome`, `approval-queue`, and `auth/callback` are all **siblings** under `admin-shell`.

## Fix

Per the [Aurelia 2 router docs](https://github.com/aurelia/aurelia/blob/master/docs/user-docs/router/navigating.md), sibling navigation from a child uses the parent-context `../` prefix. Switched all three admin nav links:

| File | Before | After |
|---|---|---|
| `welcome-route.html` | `load="/approval-queue"` | `load="../approval-queue"` |
| `approval-queue-route.html` | `load="/welcome"` | `load="../welcome"` |
| `auth-callback-route.html` | `load="/welcome"` | `load="../welcome"` |

Added `test/admin/navigation-links.spec.ts` pinning every admin sibling link to the `../` form so the leading-slash trap cannot return.

## Testing

- New regression test + existing admin suite: 18/18 pass · `make lint` clean · `npm run build` OK.

Refs: #611
