### PR TITLE
feat(admin): target the dedicated admin API host for moderation RPCs

### DIFF
--- a/admin/services/admin-transport.ts
+++ b/admin/services/admin-transport.ts
@@ -19,9 +19,14 @@ import type { IAuthService } from '../../shared/services/auth-service'
  * without triggering AUR0002 (mirrors the consumer transport's documented
  * factory shape).
  *
+ * Targets the dedicated admin API host (`adminApiBaseUrl`, i.e. `api.admin.{env}`)
+ * served by the backend's separate admin Connect server. Falls back to
+ * `apiBaseUrl` when `adminApiBaseUrl` is absent so the console keeps working
+ * before the cutover sets the admin host.
+ *
  * @param auth - Shared AuthService used to read the OIDC access token
  * @param logger - Logger scoped to the admin transport
- * @param config - Resolved runtime AppConfig providing `apiBaseUrl`
+ * @param config - Resolved runtime AppConfig providing `adminApiBaseUrl` (falls back to `apiBaseUrl`)
  * @returns A configured Connect transport with auth + logging interceptors
  */
 export const createAdminTransport = (
@@ -60,7 +65,7 @@ export const createAdminTransport = (
 	}
 
 	return createConnectTransport({
-		baseUrl: config.apiBaseUrl,
+		baseUrl: config.adminApiBaseUrl ?? config.apiBaseUrl,
 		interceptors: [loggingInterceptor, authInterceptor],
 	})
 }

--- a/public/config.json
+++ b/public/config.json
@@ -1,6 +1,7 @@
 {
   "environment": "dev",
   "apiBaseUrl": "https://api.dev.liverty-music.app",
+  "adminApiBaseUrl": "https://api.admin.dev.liverty-music.app",
   "zitadelIssuer": "https://auth.dev.liverty-music.app",
   "zitadelClientId": "371355407710421859",
   "zitadelOrgId": "371348346264093539",

--- a/shared/config/app-config.ts
+++ b/shared/config/app-config.ts
@@ -14,6 +14,14 @@ export { KNOWN_HOSTS } from './known-hosts'
 export interface AppConfig {
 	readonly environment: 'dev' | 'staging' | 'prod'
 	readonly apiBaseUrl: string
+	/**
+	 * Base URL of the dedicated admin API host (`api.admin.{env}`), served by
+	 * the backend's separate admin Connect server. Read only by the admin
+	 * console's admin RPC clients (e.g. ConcertModerationService); the consumer
+	 * SPA ignores it and keeps calling `apiBaseUrl`. Optional for backward
+	 * compatibility — when absent, admin clients fall back to `apiBaseUrl`.
+	 */
+	readonly adminApiBaseUrl?: string
 	readonly zitadelIssuer: string
 	readonly zitadelClientId: string
 	readonly zitadelOrgId: string
@@ -209,9 +217,15 @@ function validateAppConfig(parsed: unknown): AppConfig {
 	const posthogApiHost = readOptionalString(o, 'posthogApiHost')
 	const posthogProjectKey = readOptionalString(o, 'posthogProjectKey')
 
+	// Optional: present only in the admin console's ConfigMap. Absent from the
+	// consumer ConfigMap, so admin clients fall back to apiBaseUrl until the
+	// cutover sets it.
+	const adminApiBaseUrl = readOptionalString(o, 'adminApiBaseUrl')
+
 	return {
 		environment: env as AppConfig['environment'],
 		apiBaseUrl: requireString(o, 'apiBaseUrl'),
+		...(adminApiBaseUrl !== undefined ? { adminApiBaseUrl } : {}),
 		zitadelIssuer: requireString(o, 'zitadelIssuer'),
 		zitadelClientId: requireString(o, 'zitadelClientId'),
 		zitadelOrgId: requireString(o, 'zitadelOrgId'),

--- a/test/admin/services/admin-transport.spec.ts
+++ b/test/admin/services/admin-transport.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createMockAppConfig } from '../../helpers/mock-app-config'
+import { createMockAuth } from '../../helpers/mock-auth'
+
+const mockCreateConnectTransport = vi.fn().mockReturnValue({})
+
+vi.mock('@connectrpc/connect-web', () => ({
+	createConnectTransport: mockCreateConnectTransport,
+}))
+
+const { createAdminTransport } = await import(
+	'../../../admin/services/admin-transport'
+)
+
+function mockLogger() {
+	return {
+		scopeTo: vi.fn().mockReturnThis(),
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	}
+}
+
+describe('admin-transport', () => {
+	describe('createAdminTransport', () => {
+		it('targets the dedicated admin API host when adminApiBaseUrl is set', () => {
+			const config = createMockAppConfig({
+				apiBaseUrl: 'https://api.test.local',
+				adminApiBaseUrl: 'https://api.admin.test.local',
+			})
+
+			createAdminTransport(
+				createMockAuth({ isAuthenticated: true }) as any,
+				mockLogger() as any,
+				config,
+			)
+
+			const call = mockCreateConnectTransport.mock.calls.at(-1)?.[0]
+			expect(call.baseUrl).toBe('https://api.admin.test.local')
+			// Auth + logging only — no consumer OTEL/retry interceptors.
+			expect(call.interceptors).toHaveLength(2)
+		})
+
+		it('falls back to apiBaseUrl when adminApiBaseUrl is absent', () => {
+			const config = createMockAppConfig({
+				apiBaseUrl: 'https://api.test.local',
+			})
+			expect(config.adminApiBaseUrl).toBeUndefined()
+
+			createAdminTransport(
+				createMockAuth({ isAuthenticated: true }) as any,
+				mockLogger() as any,
+				config,
+			)
+
+			const call = mockCreateConnectTransport.mock.calls.at(-1)?.[0]
+			expect(call.baseUrl).toBe('https://api.test.local')
+		})
+	})
+})


### PR DESCRIPTION
## Why

The admin console's `ConcertModerationService` client called the shared consumer API base. Point it at the backend's dedicated admin host (`api.admin.{env}`) so the admin surface is governed independently.

## What

- Add optional `adminApiBaseUrl` to the runtime config (`AppConfig`).
- Admin transport uses `adminApiBaseUrl ?? apiBaseUrl` — falls back to the consumer base until the cutover sets the admin host; the consumer SPA is unaffected.
- Bundled dev `config.json` + prod admin ConfigMap populate the field.

## Verification

`make check` green (lint + typecheck + unit + build + bundle-isolation). New `admin-transport` test: targets `adminApiBaseUrl` when set, falls back to `apiBaseUrl` when absent.

## Cutover (see specification#615 §5)

**This is step 5.3** — release **after** cloud-provisioning (5.1) and the backend (5.2). Flipping the admin client to `api.admin` closes the brief moderation gap. Verify approve/reject end-to-end against the admin host in prod.

Refs: liverty-music/specification#615