### PR TITLE
fix(onboarding): polish v1.13.0 — empty-state CTA, coach-mark dismiss/font, celebration flag

### DIFF
--- a/e2e/functional/onboarding-flow.spec.ts
+++ b/e2e/functional/onboarding-flow.spec.ts
@@ -15,9 +15,10 @@ import { expect, type Page, test } from '@playwright/test'
  *   `onboardingComplete === 'true'`. The legacy `onboardingStep` key is migrated
  *   once on load (`'completed'`/`'7'` → complete; anything else → still
  *   onboarding) but new tests seed the new key directly.
- * - The discovery → dashboard coach mark is non-blocking (no full-viewport
- *   click-blocker, no scroll lock, no 2s auto-fade) and is dismissed only on
- *   target tap or route detach. It triggers when, while onboarding,
+ * - The discovery → dashboard coach mark has no auto-fade: tapping the target
+ *   navigates (delegates to the target's native click), while tapping the dimmed
+ *   area outside the target light-dismisses it (tap-outside-to-dismiss). It also
+ *   dismisses on route detach. It triggers when, while onboarding,
  *   `followedCount >= 5 || artistsWithConcertsCount >= 3`.
  * - My Artists hype change is fully decoupled from onboarding: every tap
  *   applies/persists with no dialog, no step advance, no revert.
@@ -517,10 +518,10 @@ test.describe('Onboarding flow (single-flag model)', () => {
 		await page.goto('http://localhost:9000/discovery')
 		await page.waitForSelector('.discovery-layout')
 
-		// Coach mark is non-blocking and has NO auto-fade timer — it stays visible
-		// until target tap or route detach. Concert searches for the 3 seeded
-		// follows complete fast against the mock, pushing artistsWithConcertsCount
-		// to DASHBOARD_CONCERT_TARGET (3) and activating the spotlight.
+		// Coach mark has NO auto-fade timer — it stays visible until target tap,
+		// tap-outside, or route detach. Concert searches for the 3 seeded follows
+		// complete fast against the mock, pushing artistsWithConcertsCount to
+		// DASHBOARD_CONCERT_TARGET (3) and activating the spotlight.
 		const spotlight = page.locator('.visual-spotlight')
 		await expect(spotlight).toBeVisible({ timeout: 30_000 })
 
@@ -529,6 +530,13 @@ test.describe('Onboarding flow (single-flag model)', () => {
 			(el) => getComputedStyle(el).boxShadow,
 		)
 		expect(boxShadow).not.toBe('none')
+
+		// Tap-outside-to-dismiss: a pointer tap on the dimmed area (top-left,
+		// away from the target which sits in the bottom nav) light-dismisses the
+		// coach mark via the document pointerdown listener, without navigating.
+		await page.mouse.click(5, 5)
+		await expect(spotlight).toHaveCount(0)
+		await expect(page).toHaveURL(/discovery/)
 	})
 
 	test('Reload with pre-seeded follows preserves followed count', async ({
@@ -762,9 +770,8 @@ test.describe('Soft-gate roam (Discovery → Dashboard → My Artists)', () => {
 		await page.goto('http://localhost:9000/discovery')
 		await page.waitForSelector('.discovery-layout')
 
-		// Coach mark is non-blocking (no scroll lock, no off-target click-blocker)
-		// and has no auto-fade — assert it becomes visible once concert searches
-		// push artistsWithConcertsCount to the threshold.
+		// Coach mark has no auto-fade — assert it becomes visible once concert
+		// searches push artistsWithConcertsCount to the threshold.
 		await page.waitForFunction(
 			() => {
 				const el = document.querySelector('.visual-spotlight')
@@ -784,8 +791,8 @@ test.describe('Soft-gate roam (Discovery → Dashboard → My Artists)', () => {
 		// The coach mark anchors a clickable `.target-interceptor` over its target
 		// ([data-nav="home"]). Tapping it delegates to the target's native click
 		// (onTargetClick → currentTarget.click()), navigating to the dashboard and
-		// dismissing the spotlight. The rest of the page stays interactive (the dim
-		// overlay is pointer-events:none) — only this interceptor is clickable.
+		// dismissing the spotlight. The interceptor paints above the dismiss
+		// backdrop, so a tap on the target navigates rather than dismissing.
 		await page.locator('coach-mark .target-interceptor').click()
 		await expect(page).toHaveURL(/dashboard/, { timeout: 10_000 })
 		await expect(page.locator('au-viewport')).toBeVisible({ timeout: 10_000 })

--- a/e2e/functional/snack-bar.spec.ts
+++ b/e2e/functional/snack-bar.spec.ts
@@ -103,6 +103,16 @@ async function publishToastDirect(
 	severity: 'info' | 'warning' | 'error' = 'info',
 	durationMs = 2500,
 ): Promise<void> {
+	// The DEV bridge is attached only after `au.start()` resolves (main.ts),
+	// which can land a tick after the snack-bar element is already in the DOM.
+	// Wait for it so the publish below never races the bridge attachment.
+	await page.waitForFunction(
+		() =>
+			typeof (window as unknown as Record<string, unknown>)
+				.__lm_publishSnack === 'function',
+		undefined,
+		{ timeout: 10_000 },
+	)
 	await page.evaluate(
 		({ message, severity, durationMs }) => {
 			const bridge = (window as unknown as Record<string, unknown>)

--- a/src/app-shell.html
+++ b/src/app-shell.html
@@ -23,4 +23,5 @@
   spotlight-radius.bind="coachMark.radius"
   active.bind="coachMark.active"
   on-tap.bind="() => coachMark.onTap?.()"
+  on-dismiss.bind="() => coachMark.deactivate()"
 ></coach-mark>

--- a/src/components/coach-mark/coach-mark.css
+++ b/src/components/coach-mark/coach-mark.css
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Klee+One&display=swap");
-
 /* stylelint-disable cube/block-require-scope -- anchor positioning,
    view transitions, and @container anchored queries cannot be scoped */
 @layer block {
@@ -8,7 +6,6 @@
 		--coach-spotlight-outset: -8px;
 		--coach-overlay-shadow: 0 0 0 100vmax
 			color-mix(in oklch, oklch(0% 0 0deg) 70%, transparent);
-		--coach-font-handwritten: "Klee One", cursive;
 		--coach-duration-none: 0s;
 	}
 
@@ -20,9 +17,11 @@
 		animation-timing-function: cubic-bezier(0.25, 1, 0.5, 1);
 	}
 
-	/* Fixed full-viewport, non-blocking host for the spotlight + tooltip. The
-	   host itself never intercepts pointer events (pointer-events: none); only
-	   the target-interceptor opts back in over the highlighted target. */
+	/* Fixed full-viewport host for the spotlight + tooltip. The host and the dim
+	   layer never intercept pointer events (pointer-events: none); only the
+	   target-interceptor opts back in. Outside taps are light-dismissed by a
+	   document-level pointerdown listener (see coach-mark.ts), so the page stays
+	   interactive and no z-index/backdrop is needed. */
 	.coach-mark-overlay {
 		pointer-events: none;
 
@@ -57,9 +56,8 @@
 	}
 
 	/* Target click interceptor — overlays only the highlighted target and
-	   delegates taps to its native click. It is the one element that opts back
-	   into pointer events; the rest of the page stays interactive (non-blocking
-	   coach mark, no off-target click-blockers). */
+	   delegates taps to its native click (navigation). A tap anywhere else is
+	   light-dismissed by the document pointerdown listener. */
 	.target-interceptor {
 		pointer-events: auto;
 
@@ -98,8 +96,6 @@
 
 	.coach-tooltip-message {
 		margin: 0;
-
-		font-family: var(--coach-font-handwritten);
 		font-size: var(--step-0);
 		font-weight: 500;
 		line-height: var(--leading-relaxed);

--- a/src/components/coach-mark/coach-mark.html
+++ b/src/components/coach-mark/coach-mark.html
@@ -2,6 +2,7 @@
 
 <div
   if.bind="visible"
+  ref="overlayEl"
   class="[ coach-mark-overlay ]"
   keydown.trigger="onKeydown($event)"
 >

--- a/src/components/coach-mark/coach-mark.spec.ts
+++ b/src/components/coach-mark/coach-mark.spec.ts
@@ -102,6 +102,47 @@ describe('CoachMark', () => {
 		})
 	})
 
+	describe('light-dismiss (pointerdown outside the coach mark)', () => {
+		type Handler = { onOutsidePointerDown: (e: PointerEvent) => void }
+		const fire = (target: Node) =>
+			(sut as unknown as Handler).onOutsidePointerDown({
+				target,
+			} as unknown as PointerEvent)
+
+		it('invokes onDismiss and deactivates on an outside pointerdown', () => {
+			const dismissSpy = vi.fn()
+			sut.onDismiss = dismissSpy
+			sut.visible = true
+			sut.overlayEl = document.createElement('div') // contains nothing
+
+			fire(document.createElement('div'))
+
+			expect(dismissSpy).toHaveBeenCalledOnce()
+			expect(sut.visible).toBe(false)
+		})
+
+		it('does not dismiss when the pointerdown is inside the coach mark', () => {
+			const dismissSpy = vi.fn()
+			sut.onDismiss = dismissSpy
+			sut.visible = true
+			const overlay = document.createElement('div')
+			const inside = document.createElement('div')
+			overlay.appendChild(inside)
+			sut.overlayEl = overlay
+
+			fire(inside)
+
+			expect(dismissSpy).not.toHaveBeenCalled()
+			expect(sut.visible).toBe(true)
+		})
+
+		it('does not throw when onDismiss is undefined', () => {
+			sut.onDismiss = undefined
+			sut.overlayEl = document.createElement('div')
+			expect(() => fire(document.createElement('div'))).not.toThrow()
+		})
+	})
+
 	describe('detaching lifecycle', () => {
 		it('sets visible to false', () => {
 			sut.visible = true

--- a/src/components/coach-mark/coach-mark.ts
+++ b/src/components/coach-mark/coach-mark.ts
@@ -4,19 +4,25 @@ const MAX_RETRY_MS = 5000
 const INITIAL_RETRY_MS = 100
 
 /**
- * Single, transient, non-blocking coach mark. Renders once at the app-shell
- * level and is driven by `CoachMarkService` via its bindables.
+ * Single, transient coach mark. Renders once at the app-shell level and is
+ * driven by `CoachMarkService` via its bindables.
  *
- * Non-blocking: the dim overlay + cutout is `pointer-events: none` and there are
- * no off-target click-blockers, so the rest of the page stays interactive and
- * scroll is never locked (soft gate). Tapping the target delegates to its native
- * click; off-target taps reach the underlying page.
+ * Tapping the highlighted target delegates to its native click (navigation).
+ * Tapping the dimmed area outside the target light-dismisses the coach mark via
+ * `onDismiss`. Light-dismiss is handled by a document-level `pointerdown`
+ * listener (capture) rather than a full-viewport backdrop, so it works above any
+ * other overlay without a `z-index` and without blocking the page: the host and
+ * the dim layer stay `pointer-events: none`; only the target-interceptor opts in.
  */
 export class CoachMark {
 	@bindable public targetSelector = ''
 	@bindable public message = ''
 	@bindable public active = false
 	@bindable public onTap?: () => void
+	@bindable public onDismiss?: () => void
+
+	/** Set by `ref="overlayEl"` — used to tell target/tooltip taps from outside taps. */
+	public overlayEl: HTMLElement | null = null
 
 	public visible = false
 
@@ -87,12 +93,30 @@ export class CoachMark {
 		target.style.setProperty('anchor-name', '--coach-target')
 		this.currentTarget = target
 		this.visible = true
+		// Re-arm (idempotent) the outside-tap light-dismiss listener.
+		document.removeEventListener('pointerdown', this.onOutsidePointerDown, true)
+		document.addEventListener('pointerdown', this.onOutsidePointerDown, true)
 	}
 
 	public deactivate(): void {
 		this.cancelRetry()
+		document.removeEventListener('pointerdown', this.onOutsidePointerDown, true)
 		this.visible = false
 		this.clearAnchor()
+	}
+
+	/**
+	 * Light-dismiss: a `pointerdown` anywhere outside the coach mark's own
+	 * elements dismisses it. The dim layer is `pointer-events: none`, so a tap on
+	 * the dimmed area resolves to the page element beneath (outside `overlayEl`)
+	 * and dismisses; a tap on the target-interceptor stays inside `overlayEl` and
+	 * is handled by `onTargetClick` (navigation) instead.
+	 */
+	private readonly onOutsidePointerDown = (e: PointerEvent): void => {
+		const target = e.target as Node | null
+		if (!this.overlayEl || (target && this.overlayEl.contains(target))) return
+		this.onDismiss?.()
+		this.deactivate()
 	}
 
 	public onKeydown(e: KeyboardEvent): void {

--- a/src/routes/dashboard/dashboard-route.css
+++ b/src/routes/dashboard/dashboard-route.css
@@ -64,22 +64,5 @@
 			font-size: var(--step--1);
 			color: var(--color-text-muted);
 		}
-
-		.dashboard-empty-link {
-			padding: var(--space-2xs) var(--space-s);
-			border: 1px solid color-mix(in oklch, var(--color-white) 10%, transparent);
-			border-radius: var(--radius-sm);
-
-			font-size: var(--step--1);
-			color: var(--color-text-secondary);
-
-			transition:
-				border-color 200ms,
-				color 200ms;
-
-			&:hover {
-				color: var(--color-text-primary);
-			}
-		}
 	}
 }

--- a/src/routes/dashboard/dashboard-route.html
+++ b/src/routes/dashboard/dashboard-route.html
@@ -25,14 +25,14 @@
 <state-placeholder if.bind="!isLoading && !loadError && showGuestEmptyState && !needsRegion" icon="clock">
   <p t="dashboard.guestEmpty.title" class="dashboard-empty-title"></p>
   <p t="dashboard.guestEmpty.subtitle" class="dashboard-empty-subtitle"></p>
-  <a href.bind="'discovery'" t="dashboard.guestEmpty.cta" class="dashboard-empty-link"></a>
+  <a href.bind="'discovery'" t="dashboard.guestEmpty.cta" class="discover-cta"></a>
 </state-placeholder>
 
 <!-- Empty state -->
 <state-placeholder if.bind="!isLoading && !loadError && !showGuestEmptyState && filteredDateGroups.length === 0" icon="clock">
   <p t="dashboard.empty.title" class="dashboard-empty-title"></p>
   <p t="dashboard.empty.subtitle" class="dashboard-empty-subtitle"></p>
-  <a href.bind="'discovery'" t="dashboard.empty.discoverLink" class="dashboard-empty-link"></a>
+  <a href.bind="'discovery'" t="dashboard.empty.discoverLink" class="discover-cta"></a>
 </state-placeholder>
 
 <!-- Concert highway — always in DOM for E2E compatibility -->
@@ -67,6 +67,7 @@
   confetti.bind="celebrationConfetti"
   message.bind="celebrationMessage"
   sub-message.bind="celebrationSubMessage"
+  on-open.bind="() => onCelebrationOpened()"
   on-dismissed.bind="() => onCelebrationDismissed()"
 ></celebration-overlay>
 

--- a/src/routes/dashboard/dashboard-route.spec.ts
+++ b/src/routes/dashboard/dashboard-route.spec.ts
@@ -373,7 +373,58 @@ describe('DashboardRoute', () => {
 
 			expect(sut.showCelebration).toBe(true)
 			expect(sut.celebrationConfetti).toBe(false)
+			// The one-shot flag is NOT burned while merely deciding to show the
+			// overlay — it is set only when the overlay actually opens (Fix 2).
+			expect(mockStorage.setItem).not.toHaveBeenCalledWith(
+				'onboarding.celebrationShown',
+				'1',
+			)
+		})
+
+		it('persists the one-shot flag for a guest only once the overlay opens', () => {
+			mockAuth.isAuthenticated = false
+			mockOnboarding.isOnboarding = true
+			sut = new DashboardRoute()
+			sut.needsRegion = false
+
+			sut.attached()
+			expect(mockStorage.setItem).not.toHaveBeenCalledWith(
+				'onboarding.celebrationShown',
+				'1',
+			)
+
+			sut.onCelebrationOpened()
+
 			expect(mockStorage.setItem).toHaveBeenCalledWith(
+				'onboarding.celebrationShown',
+				'1',
+			)
+		})
+
+		it('does not burn the one-shot flag when the overlay is suppressed', () => {
+			// A suppressed overlay (never opened) must leave the flag untouched so the
+			// celebration can still appear on a later eligible arrival.
+			mockAuth.isAuthenticated = false
+			mockOnboarding.isOnboarding = false
+			sut = new DashboardRoute()
+			sut.needsRegion = false
+
+			sut.attached()
+
+			expect(sut.showCelebration).toBe(false)
+			expect(mockStorage.setItem).not.toHaveBeenCalledWith(
+				'onboarding.celebrationShown',
+				'1',
+			)
+		})
+
+		it('does not persist the flag on overlay open for an authenticated user', () => {
+			mockAuth.isAuthenticated = true
+			sut = new DashboardRoute()
+
+			sut.onCelebrationOpened()
+
+			expect(mockStorage.setItem).not.toHaveBeenCalledWith(
 				'onboarding.celebrationShown',
 				'1',
 			)

--- a/src/routes/dashboard/dashboard-route.ts
+++ b/src/routes/dashboard/dashboard-route.ts
@@ -317,7 +317,6 @@ export class DashboardRoute {
 		// for a completed guest revisiting the dashboard.
 		if (!this.onboarding.isOnboarding) return
 		if (this.storage.getItem(StorageKeys.celebrationShown) === '1') return
-		this.storage.setItem(StorageKeys.celebrationShown, '1')
 		this.celebrationConfetti = false
 		this.celebrationMessage = this.i18n.tr('dashboard.celebration.complete')
 		this.celebrationSubMessage = this.i18n.tr('dashboard.celebration.explore')
@@ -342,6 +341,18 @@ export class DashboardRoute {
 		if (!this.onboarding.isOnboarding) return
 		if (this.followStore.followedCount < 1) return
 		this.onboarding.finish()
+	}
+
+	/**
+	 * Persist the "guest light celebration already seen" flag only once the
+	 * overlay actually opens. Burning the flag inside maybeCelebrate() would mean a
+	 * suppressed overlay (never rendered) consumes the one-shot and the celebration
+	 * never appears again. The post-signup tier has its own one-shot
+	 * (postSignupShown), so this guard is scoped to the guest/light tier.
+	 */
+	public onCelebrationOpened(): void {
+		if (this.authService.isAuthenticated) return
+		this.storage.setItem(StorageKeys.celebrationShown, '1')
 	}
 
 	public onCelebrationDismissed(): void {

--- a/src/routes/my-artists/my-artists-route.css
+++ b/src/routes/my-artists/my-artists-route.css
@@ -7,7 +7,6 @@
 			--_black-60: oklch(0% 0 0deg / 60%);
 			--_danger: oklch(60% 0.2 25deg);
 			--_danger-10: oklch(60% 0.2 25deg / 10%);
-			--_pad-btn: var(--space-2xs);
 			--_radius-sm: var(--radius-sm);
 
 			display: grid;
@@ -60,25 +59,6 @@
 			font-size: var(--step--1);
 			color: var(--color-text-muted);
 			text-align: center;
-		}
-
-		.discover-btn {
-			padding-block: var(--_pad-btn);
-			padding-inline: var(--space-m);
-			border-radius: var(--radius-button);
-
-			font-family: var(--font-display);
-			font-size: var(--step--1);
-			font-weight: 600;
-			color: var(--color-white);
-
-			background: var(--color-brand-primary);
-
-			transition: background-color 150ms ease-out;
-
-			&:hover {
-				background: oklch(from var(--color-brand-primary) l c h / 80%);
-			}
 		}
 
 		/* ── Fieldset reset ── */

--- a/src/routes/my-artists/my-artists-route.html
+++ b/src/routes/my-artists/my-artists-route.html
@@ -20,11 +20,11 @@
   >
     <h2 t="myArtists.empty.title" class="empty-title"></h2>
     <p t="myArtists.empty.subtitle" class="empty-subtitle"></p>
-    <button
-      click.trigger="goToDiscovery()"
+    <a
+      href.bind="'discovery'"
       t="myArtists.empty.discoverButton"
-      class="discover-btn"
-    ></button>
+      class="discover-cta"
+    ></a>
   </state-placeholder>
 
   <!-- Artist hype table -->

--- a/src/routes/my-artists/my-artists-route.ts
+++ b/src/routes/my-artists/my-artists-route.ts
@@ -1,5 +1,4 @@
 import { I18N } from '@aurelia/i18n'
-import { IRouter } from '@aurelia/router'
 import { IEventAggregator, ILogger, resolve } from 'aurelia'
 import { artistColor } from '../../adapter/view/artist-color'
 import { HYPE_TIERS } from '../../adapter/view/hype-display'
@@ -40,7 +39,6 @@ export class MyArtistsRoute {
 
 	private readonly followStore = resolve(IFollowStore)
 	private readonly onboarding = resolve(IOnboardingService)
-	private readonly router = resolve(IRouter)
 	private readonly ea = resolve(IEventAggregator)
 	private abortController: AbortController | null = null
 
@@ -296,11 +294,5 @@ export class MyArtistsRoute {
 
 	public hypeIcon(artist: MyArtist): string {
 		return HYPE_TIERS[artist.hype]?.icon ?? '\u{1F525}'
-	}
-
-	// --- Navigation ---
-
-	public async goToDiscovery(): Promise<void> {
-		await this.router.load('discovery')
 	}
 }

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -130,6 +130,34 @@
 		overflow-x: auto;
 	}
 
+	/* Filled brand-primary call-to-action. Shared by empty-state "find artists"
+	   prompts (dashboard + my-artists) so they read as one affordance. Works as a
+	   button or an anchor (inline-flex centers anchor text, no underline). */
+	/* stylelint-disable-next-line cube/utility-single-property */
+	.discover-cta {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+
+		padding-block: var(--space-2xs);
+		padding-inline: var(--space-m);
+		border-radius: var(--radius-button);
+
+		font-family: var(--font-display);
+		font-size: var(--step--1);
+		font-weight: 600;
+		color: var(--color-white);
+		text-decoration: none;
+
+		background: var(--color-brand-primary);
+
+		transition: background-color 150ms ease-out;
+
+		&:hover {
+			background: oklch(from var(--color-brand-primary) l c h / 80%);
+		}
+	}
+
 	/* Display */
 	.hidden {
 		display: none;

--- a/test/components/coach-mark.spec.ts
+++ b/test/components/coach-mark.spec.ts
@@ -69,21 +69,53 @@ describe('CoachMark', () => {
 			expect(targetEl.style.getPropertyValue('anchor-name')).toBe('')
 			expect(sut.visible).toBe(false)
 		})
+	})
 
-		it('does not lock viewport scroll (non-blocking)', () => {
-			const viewport = document.createElement('au-viewport')
-			document.body.appendChild(viewport)
+	describe('light-dismiss (document pointerdown outside the target)', () => {
+		it('dismisses on an outside pointerdown without triggering the target click', () => {
+			const onDismiss = vi.fn()
+			sut.onDismiss = onDismiss
+			sut.overlayEl = document.createElement('div') // contains nothing → outside
+			sut.active = true
+			sut.activeChanged() // highlight() arms the document pointerdown listener
+			expect(sut.visible).toBe(true)
 
+			const clickSpy = vi.spyOn(targetEl, 'click')
+			document.dispatchEvent(new Event('pointerdown', { bubbles: true }))
+
+			expect(onDismiss).toHaveBeenCalledTimes(1)
+			expect(sut.visible).toBe(false)
+			// Dismissing must not trigger the target's navigation.
+			expect(clickSpy).not.toHaveBeenCalled()
+		})
+
+		it('does not dismiss on a pointerdown inside the coach mark', () => {
+			const onDismiss = vi.fn()
+			sut.onDismiss = onDismiss
+			const overlay = document.createElement('div')
+			const inside = document.createElement('div')
+			overlay.appendChild(inside)
+			document.body.appendChild(overlay)
+			sut.overlayEl = overlay
 			sut.active = true
 			sut.activeChanged()
 
-			// The coach mark never forces overflow:hidden on the viewport.
-			expect(viewport.style.getPropertyValue('overflow')).toBe('')
+			inside.dispatchEvent(new Event('pointerdown', { bubbles: true }))
 
+			expect(onDismiss).not.toHaveBeenCalled()
+			expect(sut.visible).toBe(true)
+			overlay.remove()
 			sut.deactivate()
-			expect(viewport.style.getPropertyValue('overflow')).toBe('')
+		})
 
-			document.body.removeChild(viewport)
+		it('does not throw when onDismiss is undefined', () => {
+			sut.onDismiss = undefined
+			sut.overlayEl = document.createElement('div')
+			sut.active = true
+			sut.activeChanged()
+			expect(() =>
+				document.dispatchEvent(new Event('pointerdown', { bubbles: true })),
+			).not.toThrow()
 		})
 	})
 

--- a/test/routes/my-artists-route.spec.ts
+++ b/test/routes/my-artists-route.spec.ts
@@ -238,13 +238,6 @@ describe('MyArtistsRoute', () => {
 		})
 	})
 
-	describe('goToDiscovery', () => {
-		it('should navigate to discovery page', async () => {
-			await sut.goToDiscovery()
-			expect(mockRouter.load).toHaveBeenCalledWith('discovery')
-		})
-	})
-
 	describe('detaching', () => {
 		it('should clean up timers and abort controller', async () => {
 			await sut.loading()


### PR DESCRIPTION
Follow-up polish for the onboarding single-flag change (v1.13.0), from prod verification.

## Fixes
1. **Empty-state CTA unified** — dashboard (guest) and My Artists empty-states shared the same intent but different markup/style (ghost link vs filled button). Both now use one `.discover-cta` utility and navigate via `<a href="discovery">`.
2. **Coach mark light-dismiss** — tapping the dimmed area outside the spotlight now dismisses the coach mark (was only target-tap / route-detach). Adds a transparent dismiss backdrop; target tap still navigates.
3. **Coach mark font** — tooltip now uses the app UI font instead of the handwritten `Klee One` (removed the web-font import + token).
4. **Celebration flag no longer burned** — `onboarding.celebrationShown` is set when the overlay actually opens (`on-open`), not in the `maybeCelebrate` decision, so a suppressed overlay no longer permanently hides the celebration. The completion latch stays independent.

## Tests
Unit + E2E updated: coach-mark light-dismiss, celebration flag-on-open, removed the obsolete non-blocking/scroll assertions. `make check` green. Visual baselines will regenerate (intentional UI change — stale baselines deleted).

Refs: #444