### PR TITLE
test(settings): guard against header-overlap layout regression

### DIFF
--- a/e2e/functional/settings-layout.spec.ts
+++ b/e2e/functional/settings-layout.spec.ts
@@ -1,0 +1,68 @@
+import { expect, type Page, test } from '@playwright/test'
+
+/**
+ * CI layout-regression guard for the fix-settings-layout change.
+ *
+ * The original bug: Settings `main` was itself the scroll container but omitted
+ * `min-block-size: 0`, so its `1fr` grid track grew to full content height, the
+ * route grid overflowed its `100%` box, and the content slid *upward behind* the
+ * fixed `page-header` (PREFERENCES title + first rows ended up under the header).
+ * The fix re-aligned Settings with the house scroll pattern: `main` is an
+ * `overflow: hidden; min-block-size: 0` shell wrapping an inner `.settings-scroll`
+ * container that owns the overflow.
+ *
+ * This test runs in the `functional` CI project (no auth needed — AuthHook gives
+ * guests free roam, so `/settings` is reachable unauthenticated). It forces the
+ * regression condition with a short viewport (content taller than the viewport ⇒
+ * the scroll container engages) and asserts the scroll container's top edge stays
+ * at or below the header's bottom edge — i.e. the content never slides behind the
+ * pinned header. RPC is mocked so the assertion never depends on a live backend.
+ *
+ * The authenticated-context screenshot + geometry assertions live in
+ * `e2e/visual/settings.auth.visual.spec.ts` (run locally / in the authenticated
+ * suite); this spec is the always-on PR gate for the same CSS mechanism.
+ */
+
+// A viewport short enough that the settings content overflows it, so the inner
+// scroll container is actually engaged (the regression only manifests when the
+// content exceeds the available height).
+test.use({ viewport: { width: 390, height: 540 } })
+
+async function mockRpcRoutes(page: Page): Promise<void> {
+	await page.route('**/liverty_music.rpc.**', (route) =>
+		route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({}),
+		}),
+	)
+}
+
+test.describe('Settings layout (guest)', () => {
+	test('content does not slide behind the fixed header', async ({ page }) => {
+		await mockRpcRoutes(page)
+
+		await page.goto('/settings')
+		await page.waitForSelector('settings-route', { timeout: 10_000 })
+
+		const header = page.getByTestId('settings-header')
+		const scroll = page.getByTestId('settings-scroll')
+
+		await expect(header).toBeVisible()
+		await expect(scroll).toBeVisible()
+
+		const headerBox = await header.boundingBox()
+		const scrollBox = await scroll.boundingBox()
+		expect(headerBox).not.toBeNull()
+		expect(scrollBox).not.toBeNull()
+		if (!headerBox || !scrollBox) return
+
+		// In the regressed layout the overflowing grid track pushes the scroll
+		// container (and its content) up behind the header, so its top edge would
+		// sit above the header's bottom. The fix keeps it at or below. A 1px
+		// tolerance absorbs sub-pixel rounding.
+		expect(scrollBox.y).toBeGreaterThanOrEqual(
+			headerBox.y + headerBox.height - 1,
+		)
+	})
+})

--- a/e2e/visual/settings.auth.visual.spec.ts
+++ b/e2e/visual/settings.auth.visual.spec.ts
@@ -7,4 +7,42 @@ test.describe('Settings page visual regression (authenticated)', () => {
 
 		await expect(page).toHaveScreenshot('settings-layout.png')
 	})
+
+	/**
+	 * Layout regression guard for the fix-settings-layout change.
+	 *
+	 * The original bug: Settings `main` was itself the scroll container but
+	 * omitted `min-block-size: 0`, so its `1fr` grid track grew to full content
+	 * height, the grid overflowed, and the first PREFERENCES row slid up *behind*
+	 * the fixed `page-header`. The fix re-aligned Settings with the house scroll
+	 * pattern (shell `main` + inner `.settings-scroll`). The screenshot baseline
+	 * above catches pixel drift; this assertion locks in the specific geometry
+	 * (first row below the header bottom) so a future edit that reintroduces the
+	 * overlap fails loudly even if the screenshot tolerance would absorb it.
+	 */
+	test('first preferences row is not clipped by the fixed header', async ({
+		page,
+	}) => {
+		await page.goto('/settings')
+		await page.waitForSelector('settings-route', { timeout: 10_000 })
+
+		const header = page.getByTestId('settings-header')
+		const firstRow = page.getByTestId('settings-first-row')
+
+		await expect(header).toBeVisible()
+		await expect(firstRow).toBeVisible()
+
+		const headerBox = await header.boundingBox()
+		const firstRowBox = await firstRow.boundingBox()
+		expect(headerBox).not.toBeNull()
+		expect(firstRowBox).not.toBeNull()
+		if (!headerBox || !firstRowBox) return
+
+		// The first row's top edge must sit at or below the header's bottom edge —
+		// i.e. the row is rendered inside the scroll area, not underneath the
+		// pinned header. A 1px tolerance absorbs sub-pixel rounding.
+		expect(firstRowBox.y).toBeGreaterThanOrEqual(
+			headerBox.y + headerBox.height - 1,
+		)
+	})
 })

--- a/src/routes/settings/settings-route.html
+++ b/src/routes/settings/settings-route.html
@@ -1,9 +1,9 @@
 <import from="./language-selector.css"></import>
 
-<page-header title-key="settings.title"></page-header>
+<page-header title-key="settings.title" data-testid="settings-header"></page-header>
 
 <main>
-  <div class="[ settings-scroll ] [ stack ]">
+  <div class="[ settings-scroll ] [ stack ]" data-testid="settings-scroll">
   <!-- Guest sign-in / sign-up hero. Top-of-page, guest-only: the most
        important action for an unauthenticated user, lifted out of the
        bottom ACCOUNT list so it reads as a primary CTA rather than a link. -->
@@ -27,7 +27,7 @@
     <ul class="settings-card" role="list">
       <!-- My Home Area -->
       <li class="settings-list-item">
-        <button click.trigger="openHomeSelector()" class="settings-row">
+        <button click.trigger="openHomeSelector()" class="settings-row" data-testid="settings-first-row">
           <svg-icon name="map-pin" class="settings-icon"></svg-icon>
           <span t="settings.myHomeArea" class="settings-row-label"></span>
           <div class="settings-row-end">


### PR DESCRIPTION
## Why

The `fix-settings-layout` change ([#390](https://github.com/liverty-music/frontend/issues/390), shipped via #391) re-aligned the Settings page with the house scroll pattern (`main` shell + inner `.settings-scroll`) so the first PREFERENCES row no longer renders behind the fixed `page-header`. The fix shipped, but the regression had **no automated guard** — OpenSpec task `3.2` of the change was left open. This adds that guard.

## What

- **New CI-gated functional spec** `e2e/functional/settings-layout.spec.ts` (guest, mocked RPC). `AuthHook` gives guests free roam, so `/settings` is reachable unauthenticated and the spec runs in the PR `functional` project. It forces the overflow condition with a short viewport and asserts the inner scroll container never slides behind the pinned header — the exact CSS mechanism the original bug broke.
- **Complementary authenticated geometry assertion** added to the existing `e2e/visual/settings.auth.visual.spec.ts` (first preferences row top ≥ header bottom). This is the faithful authenticated repro; it runs in the local / authenticated suite (the `authenticated-visual` project is not exercised in PR CI).
- **`data-testid` hooks** on the header, scroll container, and first preferences row to back both specs.

No runtime/behaviour change — markup gains only `data-testid` attributes (no pixel change, so the screenshot baseline is unaffected).

## Verification

- `make check` green (lint + 1259 unit tests).
- New functional spec passes locally against `npm start` (mocked RPC, guest).

Refs: #390