### PR TITLE
fix(dashboard): render journey badge as bare corner emoji

### DIFF
--- a/src/components/live-highway/event-card.css
+++ b/src/components/live-highway/event-card.css
@@ -19,7 +19,10 @@
 
 			position: relative;
 
-			overflow: hidden;
+			/* No overflow clip: the gradient is rounded by border-radius, the
+			   noise ::after self-rounds via border-radius:inherit, and the
+			   matched beam ::before is hidden at the corners by its mask — so
+			   the journey badge can bleed past the corner without a wrapper. */
 			display: flex;
 			flex-direction: column;
 			align-items: center;
@@ -74,63 +77,19 @@
 			color: var(--_label-color);
 		}
 
-		/* --- Journey status badge --- */
+		/* --- Journey status badge ---
+		   The status emoji alone, sitting on the top-right corner and bleeding
+		   half outside the card (notification-badge convention) so it never
+		   collides with the bottom-aligned artist name regardless of name
+		   length. No background/hue: the emoji is the sole, self-coloured cue. */
 		.journey-badge {
 			position: absolute;
 			inset-block-start: var(--space-3xs);
 			inset-inline-end: var(--space-3xs);
+			translate: 40% -40%;
 
-			display: inline-flex;
-			gap: var(--space-3xs);
-			align-items: center;
-
-			/* stylelint-disable-next-line cube/require-token-variables -- badge pill needs tighter padding than any token */
-			padding-block: 1px;
-			padding-inline: var(--space-3xs);
-			border-radius: var(--radius-button);
-
-			font-size: var(--step--1);
-			font-weight: 600;
-			line-height: var(--leading-snug);
-			color: var(--_journey-text);
-			text-transform: uppercase;
-			letter-spacing: 0.03em;
-
-			background: var(--_journey-bg);
-		}
-
-		/* Emoji keeps its own colour — exempt it from the badge text tint. */
-		.journey-badge-icon {
 			font-size: var(--step--1);
 			line-height: var(--leading-none);
-		}
-
-		/* Hues sourced from shared journey-hue tokens; the badge keeps its own
-		   translucent-pill lightness/chroma. Single source of semantic identity
-		   shared with the detail-sheet flow nodes. */
-		.journey-badge[data-journey-status="tracking"] {
-			--_journey-bg: oklch(65% 0.18 var(--journey-hue-tracking) / 85%);
-			--_journey-text: oklch(95% 0.02 var(--journey-hue-tracking));
-		}
-
-		.journey-badge[data-journey-status="applied"] {
-			--_journey-bg: oklch(65% 0.15 var(--journey-hue-applied) / 85%);
-			--_journey-text: oklch(95% 0.02 var(--journey-hue-applied));
-		}
-
-		.journey-badge[data-journey-status="lost"] {
-			--_journey-bg: oklch(45% 0.08 var(--journey-hue-lost) / 85%);
-			--_journey-text: oklch(75% 0.05 var(--journey-hue-lost));
-		}
-
-		.journey-badge[data-journey-status="unpaid"] {
-			--_journey-bg: oklch(65% 0.18 var(--journey-hue-unpaid) / 85%);
-			--_journey-text: oklch(95% 0.02 var(--journey-hue-unpaid));
-		}
-
-		.journey-badge[data-journey-status="paid"] {
-			--_journey-bg: oklch(65% 0.18 var(--journey-hue-paid) / 85%);
-			--_journey-text: oklch(95% 0.02 var(--journey-hue-paid));
 		}
 
 		/* =============================================

--- a/src/components/live-highway/event-card.html
+++ b/src/components/live-highway/event-card.html
@@ -24,6 +24,7 @@ class="[ event-card ]"
       data-journey-status.bind="event.journeyStatus"
       class="journey-badge"
       data-testid="journey-badge"
+      role="img"
       aria-label.bind="journeyConfig.labelKey | t"
     >${journeyConfig.icon}</span>
   </article>

--- a/src/components/live-highway/event-card.html
+++ b/src/components/live-highway/event-card.html
@@ -22,10 +22,9 @@ class="[ event-card ]"
     <span
       if.bind="journeyConfig"
       data-journey-status.bind="event.journeyStatus"
-      class="journey-badge" data-testid="journey-badge"
-    >
-      <span class="journey-badge-icon" aria-hidden="true">${journeyConfig.icon}</span>
-      <span t.bind="journeyConfig.labelKey"></span>
-    </span>
+      class="journey-badge"
+      data-testid="journey-badge"
+      aria-label.bind="journeyConfig.labelKey | t"
+    >${journeyConfig.icon}</span>
   </article>
 </template>


### PR DESCRIPTION
## Summary

On the dashboard timetable, the concert-card journey badge rendered the status icon **plus its full text label** (e.g. `👀 追跡中`) as a pill anchored to the card's top-right corner. On the dense lanes the wide pill overlapped the artist name and broke the card layout.

This renders the badge as the **bare status emoji**, placed on the **top-right corner and bleeding half outside the card** (notification-badge convention), so it never collides with the bottom-aligned artist name regardless of name length or lane.

## Changes

- `event-card.html`: badge renders the emoji only; `aria-label` (translated label) preserves the accessible name.
- `event-card.css`:
  - Badge anchored to the top-right corner with `translate: 40% -40%` to bleed past the corner.
  - Removed the redundant `overflow: hidden` from the card — corner rounding, the noise `::after`, and the matched beam `::before` are already clipped by `border-radius` / mask, so the badge can bleed without a wrapper element.
  - Dropped the label-only rules and the now-dead per-status `--_journey-text` (label tint) and `--_journey-bg` (pill hue) custom properties. The bare emoji is the sole, self-coloured cue.
- The dashboard filter chips and the concert-detail status control are unchanged (icon + label + hue).

## Testing

- `stylelint` + `tsc --noEmit` clean for the changed files (admin-area TS errors are pre-existing local env, unrelated).
- Verified locally with Playwright (authenticated, mocked RPCs) across HOME (no venue label) and AWAY (rightmost) lanes with short/medium/very-long artist names: emojis 👀📝💔💰🎟️ sit on the top-right corner with no artist-name overlap, AWAY-lane badges are not clipped by `concert-scroll`, and removing `overflow: hidden` left the card corners, gradient, noise, and matched glow/beam visually intact.

OpenSpec change: `icon-only-journey-badge` (modifies `journey-status-presentation`) — separate PR in the specification repo.

close: #455
