### PR TITLE
fix(deps): bump posthog-js to resolve DOMPurify advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
 				"i18next-browser-languagedetector": "^8.2.1",
 				"matter-js": "^0.20.0",
 				"oidc-client-ts": "^3.4.1",
-				"posthog-js": "^1.376.4",
+				"posthog-js": "^1.390.2",
 				"qrcode": "^1.5.4",
 				"workbox-background-sync": "^7.4.0"
 			},
@@ -3254,18 +3254,18 @@
 			}
 		},
 		"node_modules/@posthog/core": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.33.0.tgz",
-			"integrity": "sha512-Xk5O4g70SlsodD941j5GJTto2DgteKslmuhQ1kH5nR03JVOgdOw7rBesyWGhYkEdkxr8Vhvx33f1NTEZgejL2A==",
+			"version": "1.35.2",
+			"resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.35.2.tgz",
+			"integrity": "sha512-aV6nkkKCF//NnR9SyQD00+sPg0A4v1m3Xk/fcsnYs+z3qCRXgjwOhfQX2lceAKWlru3o5l9Yn/480GovLOnqKA==",
 			"license": "MIT",
 			"dependencies": {
-				"@posthog/types": "^1.387.0"
+				"@posthog/types": "^1.390.0"
 			}
 		},
 		"node_modules/@posthog/types": {
-			"version": "1.387.0",
-			"resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.387.0.tgz",
-			"integrity": "sha512-XR0B1geABbnUlSNv4RuFWvk19D870B668C/XzcKDctAZ+xCH5gmGM0oltGbA9yj+2ia9Y65nOrDYKN6Whu1oBw==",
+			"version": "1.390.0",
+			"resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.390.0.tgz",
+			"integrity": "sha512-zMjK6nrUWhAlL8ECrM4WldvgawqdoAE5B0ys7eA0lCoWuyzfFoSyh6zYtEuBSDRyN7fQLSfNCK+mQH4ngOl7Zw==",
 			"license": "MIT"
 		},
 		"node_modules/@rollup/plugin-babel": {
@@ -5859,9 +5859,9 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.4.10",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-			"integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+			"version": "3.4.11",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+			"integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
@@ -8994,13 +8994,13 @@
 			"license": "MIT"
 		},
 		"node_modules/posthog-js": {
-			"version": "1.387.0",
-			"resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.387.0.tgz",
-			"integrity": "sha512-Pv1jUMySMN62zoAxdJBJPV8n62lkHdjuWhpeU7izczc5Dqbx3hhqO2hkrNTI8Yx1ezmWk2qUHZs03FuOBubdFQ==",
+			"version": "1.390.2",
+			"resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.390.2.tgz",
+			"integrity": "sha512-z1zh0mMokecCILXxabmo5Xag6uCVYEDhP2JnMYLNxwmKN7d7u1S94XYmhUTF3iyAo2JOg6c7n86mGaTXliz4MA==",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
-				"@posthog/core": "^1.33.0",
-				"@posthog/types": "^1.387.0",
+				"@posthog/core": "^1.35.1",
+				"@posthog/types": "^1.390.0",
 				"core-js": "^3.38.1",
 				"dompurify": "^3.3.2",
 				"fflate": "^0.4.8",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"i18next-browser-languagedetector": "^8.2.1",
 		"matter-js": "^0.20.0",
 		"oidc-client-ts": "^3.4.1",
-		"posthog-js": "^1.376.4",
+		"posthog-js": "^1.390.2",
 		"qrcode": "^1.5.4",
 		"workbox-background-sync": "^7.4.0"
 	},


### PR DESCRIPTION
## Summary

The `Security Audit` CI gate fails repo-wide on a new moderate advisory, blocking the required `CI Success` check on every open PR (including changes with no dependency edits). This dedicated deps PR clears it.

## Changes

- Bump `posthog-js` `^1.376.4` → `^1.390.2`, which resolves the transitive `dompurify` to the patched `3.4.11` (was `3.4.7`).
- Lockfile-only effect on the vulnerable package; no application code change.

Fixes **GHSA-cmwh-pvxp-8882** (DOMPurify `ALLOWED_ATTR` pollution via `setConfig()`).

## Testing

- `npm audit --omit=dev --audit-level=moderate` → `found 0 vulnerabilities`.
- `npm ls dompurify` → `dompurify@3.4.11`.

close: #457
