### PR TITLE
fix(pwa): show PostSignupDialog install row for all PWA-capable browsers

### DIFF
--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -5,6 +5,7 @@ import { IAuthService } from './services/auth-service'
 import { ICoachMarkService } from './services/coach-mark-service'
 import { IErrorBoundaryService } from './services/error-boundary-service'
 import { IOnboardingService } from './services/onboarding-service'
+import { IPwaInstallService } from './services/pwa-install-service'
 @route({
 	title: 'Liverty Music',
 	routes: [
@@ -114,6 +115,13 @@ export class AppShell {
 	private readonly errorBoundary = resolve(IErrorBoundaryService)
 	private readonly analytics = resolve(IAnalyticsService)
 	private readonly logger = resolve(ILogger).scopeTo('AppShell')
+
+	// Eagerly construct PwaInstallService so its `beforeinstallprompt` listener
+	// is registered before any routing begins. AppShell activates ahead of the
+	// first navigation, so this captures the event Chrome fires during the
+	// `/auth/callback` page load — otherwise the prompt is silently lost.
+	// biome-ignore lint/correctness/noUnusedPrivateClassMembers: held only for its DI construction side-effect (listener registration)
+	private readonly _pwaInstall = resolve(IPwaInstallService)
 
 	private readonly subscriptions: IDisposable[] = []
 

--- a/src/components/post-signup-dialog/post-signup-dialog.css
+++ b/src/components/post-signup-dialog/post-signup-dialog.css
@@ -67,6 +67,22 @@
 			color: var(--color-error);
 		}
 
+		/* Render the disclosure trigger as a text button matching .post-signup-btn,
+		   dropping the default ▸ marker so it reads as an action, not a list item. */
+		.post-signup-install-guide summary {
+			font-family: var(--font-display);
+			list-style: none;
+		}
+
+		.post-signup-install-steps {
+			margin-block: var(--space-2xs) 0;
+			padding-inline-start: var(--space-m);
+
+			font-size: var(--step-0);
+			line-height: var(--leading-relaxed);
+			list-style: decimal;
+		}
+
 		.post-signup-footer {
 			display: flex;
 			justify-content: center;

--- a/src/components/post-signup-dialog/post-signup-dialog.html
+++ b/src/components/post-signup-dialog/post-signup-dialog.html
@@ -31,17 +31,28 @@
       </div>
     </div>
 
-    <!-- PWA install row (only if installable) -->
+    <!-- PWA install row (shown whenever the browser supports PWA install) -->
     <div class="post-signup-row" if.bind="canInstallPwa">
       <span class="post-signup-row-icon">📱</span>
       <div class="post-signup-row-body">
         <p class="post-signup-row-label" t="postSignup.pwaLabel"></p>
+        <!-- Native one-tap install when the deferred prompt is available -->
         <button
+          if.bind="canInstallNatively"
           type="button"
           class="post-signup-btn"
           busy-on-click.bind="() => onInstallPwa()"
           t="postSignup.pwaInstall"
         ></button>
+        <!-- Fallback: native disclosure of manual install steps (no JS state) -->
+        <details if.bind="!canInstallNatively" class="post-signup-install-guide">
+          <summary class="post-signup-btn" t="postSignup.pwaInstallGuide"></summary>
+          <ol class="post-signup-install-steps">
+            <li t="postSignup.pwaGuideStep1"></li>
+            <li t="postSignup.pwaGuideStep2"></li>
+            <li t="postSignup.pwaGuideStep3"></li>
+          </ol>
+        </details>
       </div>
     </div>
 

--- a/src/components/post-signup-dialog/post-signup-dialog.spec.ts
+++ b/src/components/post-signup-dialog/post-signup-dialog.spec.ts
@@ -5,12 +5,16 @@ fakeLogger.scopeTo.mockReturnValue(fakeLogger)
 
 let fakeCanShowFab = true
 let fakeIsIos = false
+let fakeCanShowInstallOption = true
 const fakePwaInstall = {
 	get canShowFab() {
 		return fakeCanShowFab
 	},
 	get isIos() {
 		return fakeIsIos
+	},
+	get canShowInstallOption() {
+		return fakeCanShowInstallOption
 	},
 	install: vi.fn().mockResolvedValue(undefined),
 }
@@ -47,6 +51,7 @@ describe('PostSignupDialog', () => {
 	beforeEach(() => {
 		fakeCanShowFab = true
 		fakeIsIos = false
+		fakeCanShowInstallOption = true
 		fakeNotificationManager.permission = 'default'
 		vi.clearAllMocks()
 		// Restore default mock implementations after clearAllMocks resets them.
@@ -62,25 +67,54 @@ describe('PostSignupDialog', () => {
 	})
 
 	describe('canInstallPwa', () => {
-		it('returns true when canShowFab is true and not iOS', () => {
-			fakeCanShowFab = true
-			fakeIsIos = false
+		it('returns true when canShowInstallOption is true', () => {
+			fakeCanShowInstallOption = true
 
 			expect(sut.canInstallPwa).toBe(true)
 		})
 
-		it('returns false on iOS regardless of canShowFab', () => {
-			fakeCanShowFab = true
-			fakeIsIos = true
+		it('returns true when canShowInstallOption is true but canShowFab is false', () => {
+			fakeCanShowInstallOption = true
+			fakeCanShowFab = false
+
+			expect(sut.canInstallPwa).toBe(true)
+		})
+
+		it('returns false when canShowInstallOption is false (installed or unsupported)', () => {
+			fakeCanShowInstallOption = false
 
 			expect(sut.canInstallPwa).toBe(false)
 		})
+	})
 
-		it('returns false when canShowFab is false', () => {
-			fakeCanShowFab = false
+	describe('canInstallNatively (watcher)', () => {
+		it('starts false before binding', () => {
+			expect(sut.canInstallNatively).toBe(false)
+		})
+
+		it('initialises from canShowFab && !isIos in binding()', () => {
+			fakeCanShowFab = true
 			fakeIsIos = false
+			sut.binding()
 
-			expect(sut.canInstallPwa).toBe(false)
+			expect(sut.canInstallNatively).toBe(true)
+		})
+
+		it('stays false in binding() on iOS even when canShowFab is true', () => {
+			fakeCanShowFab = true
+			fakeIsIos = true
+			sut.binding()
+
+			expect(sut.canInstallNatively).toBe(false)
+		})
+
+		it('becomes true when canShowFab changes to true', () => {
+			expect(sut.canInstallNatively).toBe(false)
+
+			fakeCanShowFab = true
+			sut.canShowFabChanged()
+
+			expect(sut.canInstallNatively).toBe(true)
 		})
 	})
 
@@ -157,9 +191,8 @@ describe('PostSignupDialog', () => {
 	})
 
 	describe('isAllDone', () => {
-		it('is false when canInstallPwa is true', () => {
-			fakeCanShowFab = true
-			fakeIsIos = false
+		it('is false when canShowInstallOption is true', () => {
+			fakeCanShowInstallOption = true
 			fakeNotificationManager.permission = 'granted'
 			sut = new PostSignupDialog()
 
@@ -167,25 +200,23 @@ describe('PostSignupDialog', () => {
 		})
 
 		it('is false when permission is not granted', () => {
-			fakeCanShowFab = false
-			fakeIsIos = false
+			fakeCanShowInstallOption = false
 			fakeNotificationManager.permission = 'default'
 			sut = new PostSignupDialog()
 
 			expect(sut.isAllDone).toBe(false)
 		})
 
-		it('is true when PWA installed and notification granted', () => {
-			fakeCanShowFab = false
-			fakeIsIos = false
+		it('is true when PWA install option unavailable and notification granted', () => {
+			fakeCanShowInstallOption = false
 			fakeNotificationManager.permission = 'granted'
 			sut = new PostSignupDialog()
 
 			expect(sut.isAllDone).toBe(true)
 		})
 
-		it('is true when iOS (canInstallPwa always false) and notification granted', () => {
-			fakeCanShowFab = true
+		it('is true when iOS (canShowInstallOption always false) and notification granted', () => {
+			fakeCanShowInstallOption = false
 			fakeIsIos = true
 			fakeNotificationManager.permission = 'granted'
 			sut = new PostSignupDialog()
@@ -194,8 +225,7 @@ describe('PostSignupDialog', () => {
 		})
 
 		it('becomes true when permission changes to granted after dialog creation', () => {
-			fakeCanShowFab = false
-			fakeIsIos = false
+			fakeCanShowInstallOption = false
 			fakeNotificationManager.permission = 'default'
 			sut = new PostSignupDialog()
 			expect(sut.isAllDone).toBe(false)

--- a/src/components/post-signup-dialog/post-signup-dialog.ts
+++ b/src/components/post-signup-dialog/post-signup-dialog.ts
@@ -1,4 +1,4 @@
-import { bindable, ILogger, resolve } from 'aurelia'
+import { bindable, ILogger, observable, resolve, watch } from 'aurelia'
 import { INotificationManager } from '../../services/notification-manager'
 import { IPromptCoordinator } from '../../services/prompt-coordinator'
 import { IPushService } from '../../services/push-service'
@@ -11,6 +11,13 @@ export class PostSignupDialog {
 	public notificationDone = false
 	public notificationError = false
 
+	// True when the native `beforeinstallprompt` prompt is available, so the
+	// install row can offer a one-tap install. Driven by an explicit `@watch`
+	// on `canShowFab` (see below) rather than a plain getter: `if.bind` on a
+	// getter that traverses an injected service's `@observable` is not
+	// guaranteed to update reactively.
+	@observable public canInstallNatively = false
+
 	private readonly logger = resolve(ILogger).scopeTo('PostSignupDialog')
 	public readonly notificationManager = resolve(INotificationManager)
 	private readonly pushService = resolve(IPushService)
@@ -18,15 +25,37 @@ export class PostSignupDialog {
 	private readonly promptCoordinator = resolve(IPromptCoordinator)
 
 	public get canInstallPwa(): boolean {
-		// On iOS, beforeinstallprompt never fires — hide the dialog row.
-		// iOS users use the persistent FAB with the instruction sheet instead.
-		return this.pwaInstall.canShowFab && !this.pwaInstall.isIos
+		// Show the install row whenever the browser supports PWA install, even
+		// if the native prompt has not been captured — a manual instruction
+		// fallback covers that case. iOS is excluded implicitly because it
+		// lacks `BeforeInstallPromptEvent` (`canShowInstallOption` is false).
+		return this.pwaInstall.canShowInstallOption
 	}
 
 	public get isAllDone(): boolean {
 		return (
-			!this.canInstallPwa && this.notificationManager.permission === 'granted'
+			!this.pwaInstall.canShowInstallOption &&
+			this.notificationManager.permission === 'granted'
 		)
+	}
+
+	// `@watch` does not fire on initial bind, so seed the value here.
+	public binding(): void {
+		this.syncCanInstallNatively()
+	}
+
+	// Upgrade the install row to the native button as soon as the deferred
+	// prompt arrives, even if the dialog is already open.
+	@watch((vm: PostSignupDialog) => vm.pwaInstall.canShowFab)
+	public canShowFabChanged(): void {
+		this.syncCanInstallNatively()
+	}
+
+	private syncCanInstallNatively(): void {
+		// A one-tap native install needs a captured prompt (`canShowFab`) and is
+		// never available on iOS (no `beforeinstallprompt`).
+		this.canInstallNatively =
+			this.pwaInstall.canShowFab && !this.pwaInstall.isIos
 	}
 
 	public activeChanged(): void {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -342,6 +342,10 @@
 		"notificationDenied": "Notifications are blocked in your browser settings. You can change this in your browser.",
 		"pwaLabel": "Add to home screen for a better experience",
 		"pwaInstall": "Add to home screen",
+		"pwaInstallGuide": "How to add",
+		"pwaGuideStep1": "Tap the menu (⋮) in your browser",
+		"pwaGuideStep2": "Select \"Add to Home Screen\"",
+		"pwaGuideStep3": "Tap \"Add\" to finish",
 		"defer": "Later",
 		"close": "Close"
 	},

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -342,6 +342,10 @@
 		"notificationDenied": "ブラウザの設定で通知が拒否されています。設定から変更できます。",
 		"pwaLabel": "ホーム画面に追加するとより快適に",
 		"pwaInstall": "ホーム画面に追加",
+		"pwaInstallGuide": "追加方法を見る",
+		"pwaGuideStep1": "ブラウザ右上のメニュー（⋮）をタップ",
+		"pwaGuideStep2": "「ホーム画面に追加」を選択",
+		"pwaGuideStep3": "「追加」をタップして完了",
 		"defer": "あとで",
 		"close": "閉じる"
 	},

--- a/src/services/pwa-install-service.spec.ts
+++ b/src/services/pwa-install-service.spec.ts
@@ -170,4 +170,60 @@ describe('PwaInstallService', () => {
 				.BeforeInstallPromptEvent
 		})
 	})
+
+	describe('browserSupportsPwa', () => {
+		it('returns true when BeforeInstallPromptEvent is in window', () => {
+			Object.defineProperty(window, 'BeforeInstallPromptEvent', {
+				value: class {},
+				configurable: true,
+			})
+			const sut = new PwaInstallService()
+
+			expect(sut.browserSupportsPwa).toBe(true)
+
+			delete (window as unknown as Record<string, unknown>)
+				.BeforeInstallPromptEvent
+		})
+
+		it('returns false when BeforeInstallPromptEvent is not in window', () => {
+			const sut = new PwaInstallService()
+
+			expect(sut.browserSupportsPwa).toBe(false)
+		})
+	})
+
+	describe('canShowInstallOption', () => {
+		it('is true when not installed and browser supports PWA', () => {
+			Object.defineProperty(window, 'BeforeInstallPromptEvent', {
+				value: class {},
+				configurable: true,
+			})
+			const sut = new PwaInstallService()
+
+			expect(sut.canShowInstallOption).toBe(true)
+
+			delete (window as unknown as Record<string, unknown>)
+				.BeforeInstallPromptEvent
+		})
+
+		it('is false when already installed even if browser supports PWA', () => {
+			Object.defineProperty(window, 'BeforeInstallPromptEvent', {
+				value: class {},
+				configurable: true,
+			})
+			localStorage.setItem(StorageKeys.pwaInstalled, 'true')
+			const sut = new PwaInstallService()
+
+			expect(sut.canShowInstallOption).toBe(false)
+
+			delete (window as unknown as Record<string, unknown>)
+				.BeforeInstallPromptEvent
+		})
+
+		it('is false when the browser does not support PWA install', () => {
+			const sut = new PwaInstallService()
+
+			expect(sut.canShowInstallOption).toBe(false)
+		})
+	})
 })

--- a/src/services/pwa-install-service.ts
+++ b/src/services/pwa-install-service.ts
@@ -40,10 +40,23 @@ export class PwaInstallService {
 	}
 
 	get isIos(): boolean {
-		if ('BeforeInstallPromptEvent' in window) return false
+		if (this.browserSupportsPwa) return false
 		if (/iphone|ipad|ipod/i.test(navigator.userAgent)) return true
 		// iPadOS 13+ reports a macOS desktop user-agent; detect via touch capability
 		return navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1
+	}
+
+	// True when the browser exposes the PWA install API (Chrome/Edge/Samsung
+	// Internet). False on iOS Safari and other browsers without it.
+	get browserSupportsPwa(): boolean {
+		return 'BeforeInstallPromptEvent' in window
+	}
+
+	// Whether the PostSignupDialog should offer an install path. Unlike
+	// `canShowFab`, this does not require the `beforeinstallprompt` event to
+	// have been captured — a manual instruction fallback covers that case.
+	get canShowInstallOption(): boolean {
+		return !this.installed && this.browserSupportsPwa
 	}
 
 	private listenForInstallPrompt(): void {

--- a/test/app-shell.spec.ts
+++ b/test/app-shell.spec.ts
@@ -6,6 +6,7 @@ import { IAnalyticsService } from '../src/lib/analytics/analytics-service'
 import { IAuthService } from '../src/services/auth-service'
 import { IErrorBoundaryService } from '../src/services/error-boundary-service'
 import { IOnboardingService } from '../src/services/onboarding-service'
+import { IPwaInstallService } from '../src/services/pwa-install-service'
 
 // Mock dynamic imports used by the @route decorator on AppShell.
 // Route modules are mocked to prevent vitest from loading the full
@@ -133,6 +134,13 @@ describe('app-shell', () => {
 					identify: vi.fn(),
 					reset: vi.fn(),
 					getFeatureFlag: vi.fn(),
+				}),
+				// AppShell eagerly resolves IPwaInstallService in its class body
+				// (to register the `beforeinstallprompt` listener before routing).
+				// Register a stub so DI does not jit-construct the real service,
+				// whose constructor reads `window.matchMedia` (absent in jsdom).
+				Registration.instance(IPwaInstallService, {
+					canShowFab: false,
 				}),
 			)
 			container.register(AppShell)

--- a/test/components/post-signup-dialog.spec.ts
+++ b/test/components/post-signup-dialog.spec.ts
@@ -30,6 +30,7 @@ describe('PostSignupDialog', () => {
 	let mockPwa: {
 		canShowFab: boolean
 		isIos: boolean
+		canShowInstallOption: boolean
 		install: ReturnType<typeof vi.fn>
 	}
 	let mockCoordinator: { markShown: ReturnType<typeof vi.fn> }
@@ -42,6 +43,7 @@ describe('PostSignupDialog', () => {
 		mockPwa = {
 			canShowFab: false,
 			isIos: false,
+			canShowInstallOption: false,
 			install: vi.fn().mockResolvedValue(undefined),
 		}
 		mockCoordinator = { markShown: vi.fn() }
@@ -114,18 +116,18 @@ describe('PostSignupDialog', () => {
 	})
 
 	describe('canInstallPwa', () => {
-		it('reflects pwaInstall.canShowFab (false when not eligible)', () => {
+		it('reflects pwaInstall.canShowInstallOption (false when not eligible)', () => {
 			expect(sut.canInstallPwa).toBe(false)
 		})
 
-		it('is true when canShowFab is true and not iOS', () => {
-			mockPwa.canShowFab = true
+		it('is true when canShowInstallOption is true even without a captured prompt', () => {
+			mockPwa.canShowInstallOption = true
+			mockPwa.canShowFab = false
 			expect(sut.canInstallPwa).toBe(true)
 		})
 
-		it('is false when canShowFab is true but iOS (iOS uses FAB sheet instead)', () => {
-			mockPwa.canShowFab = true
-			mockPwa.isIos = true
+		it('is false when canShowInstallOption is false (installed or iOS Safari)', () => {
+			mockPwa.canShowInstallOption = false
 			expect(sut.canInstallPwa).toBe(false)
 		})
 	})


### PR DESCRIPTION
## Summary

The PWA install row in the PostSignupDialog intermittently failed to appear after sign-up. This fixes both root causes and adds a manual-install fallback.

**Root causes**
1. **Construction race** — `PwaInstallService` was a lazily-resolved DI singleton, first constructed when `PwaInstallFab` binds. The FAB is gated by `if.bind="showNav"` (false during `/auth/callback`), so Chrome's `beforeinstallprompt`, fired during that page load, was silently lost.
2. **Over-restrictive condition** — the row only showed when `canShowFab` was true (a captured prompt), leaving PWA-capable browsers with no install path.

**Changes**
- `AppShell` eagerly resolves `PwaInstallService` so the `beforeinstallprompt` listener registers before any routing.
- New `PwaInstallService.browserSupportsPwa` / `canShowInstallOption` getters; the dialog row is driven off `canShowInstallOption` (browser support only).
- When the native prompt is unavailable, the row shows a native `<details>`/`<summary>` **"How to add"** disclosure (browser menu → Add to Home Screen). It upgrades reactively to the one-tap native button via an `@watch` on `canShowFab` if the prompt arrives while the dialog is open.
- iOS is excluded implicitly (no `BeforeInstallPromptEvent`); the persistent FAB still provides the iOS path. FAB / `canShowFab` semantics are unchanged.

## Testing
- `make check` green (Biome + stylelint + typecheck + 1278 unit tests + build + bundle-isolation).
- New/updated unit tests for `browserSupportsPwa`, `canShowInstallOption`, `canInstallNatively` watcher, and the `<details>` fallback condition.

## Manual verification (deferred to post-deploy)
Dev env is intentionally stopped; 7.2–7.4 (Chrome native prompt, fallback disclosure toggle, iOS no-row) to be confirmed in prod after rollout.

## Spec
Implements OpenSpec change `improve-pwa-install-signup` (frontend-only). The OpenSpec docs will be archived after ship.

Refs: #462