### PR TITLE
feat(admin): group approval-queue by artist and series

### DIFF
--- a/admin/approval-queue/approval-queue-route.css
+++ b/admin/approval-queue/approval-queue-route.css
@@ -82,6 +82,60 @@
 			white-space: pre-wrap;
 		}
 
+		.approval-queue-artist-group {
+			--flow-space: var(--space-s);
+		}
+
+		.approval-queue-artist {
+			font-size: var(--step-1);
+			color: var(--color-text-primary);
+		}
+
+		.approval-queue-series {
+			overflow: clip;
+			border: 1px solid var(--_border);
+			border-radius: var(--_radius);
+
+			& + & {
+				margin-block-start: var(--space-xs);
+			}
+		}
+
+		.approval-queue-series-summary {
+			cursor: pointer;
+
+			display: flex;
+			flex-wrap: wrap;
+			gap: var(--space-xs) var(--space-m);
+			align-items: baseline;
+			justify-content: space-between;
+
+			padding: var(--space-s) var(--space-m);
+
+			font-weight: 600;
+			color: var(--color-text-primary);
+
+			&:hover {
+				background: var(--_surface-raised);
+			}
+		}
+
+		.approval-queue-series-meta {
+			display: flex;
+			flex-wrap: wrap;
+			gap: var(--space-xs);
+			align-items: baseline;
+
+			font-size: var(--step--1);
+			font-weight: 400;
+			color: var(--color-text-secondary);
+		}
+
+		.approval-queue-unresolved-badge {
+			font-weight: 700;
+			color: var(--color-error);
+		}
+
 		.approval-queue-table {
 			border-collapse: collapse;
 			inline-size: 100%;

--- a/admin/approval-queue/approval-queue-route.html
+++ b/admin/approval-queue/approval-queue-route.html
@@ -35,112 +35,131 @@
     <p>No concerts awaiting review.</p>
   </section>
 
-  <table if.bind="phase === 'ready' && rows.length" class="approval-queue-table">
-    <thead>
-      <tr>
-        <th scope="col">Artist</th>
-        <th scope="col">Title</th>
-        <th scope="col">Local date</th>
-        <th scope="col">Start time</th>
-        <th scope="col">Listed venue</th>
-        <th scope="col">Resolved venue</th>
-        <th scope="col">Source</th>
-        <th scope="col">Discovered</th>
-        <th scope="col">Actions</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr repeat.for="row of rows" data-busy.bind="row.busy">
-        <td>${row.performerName}</td>
-        <td>${row.title}</td>
-        <td>${row.localDate}</td>
-        <td>${row.startTime}</td>
-        <td>${row.listedVenueName}</td>
-        <td>
-          <span if.bind="row.hasResolvedVenue">
-            ${row.resolvedVenueName}
-            <small class="approval-queue-admin-area">${row.resolvedAdminArea}</small>
-          </span>
-          <span else class="approval-queue-unresolved" data-state="unresolved">
-            Unresolved venue — review
-          </span>
-        </td>
-        <td>
-          <a
-            if.bind="sanitizeUrl(row.sourceUrl)"
-            href.bind="sanitizeUrl(row.sourceUrl)"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="approval-queue-source-link"
-          >
-            Open source
-          </a>
-          <span else>${'—'}</span>
-        </td>
-        <td>${row.discoveredTime}</td>
-        <td class="approval-queue-actions">
-          <div if.bind="!row.rejecting" class="[ approval-queue-action-bar ] [ cluster ]">
-            <button
-              type="button"
-              class="approval-queue-btn"
-              data-variant="approve"
-              disabled.bind="row.busy"
-              click.trigger="approve(row)"
-            >
-              Approve
-            </button>
-            <button
-              type="button"
-              class="approval-queue-btn"
-              data-variant="reject"
-              disabled.bind="row.busy"
-              click.trigger="startReject(row)"
-            >
-              Reject
-            </button>
-          </div>
+  <section
+    repeat.for="group of groups"
+    class="[ approval-queue-artist-group ] [ flow ]"
+  >
+    <h2 class="approval-queue-artist">${group.artistName}</h2>
 
-          <form
-            else
-            class="[ approval-queue-reject-form ] [ flow ]"
-            submit.trigger="confirmReject(row)"
-          >
-            <label class="approval-queue-reject-label">
-              Rejection reason
-              <input
-                type="text"
-                class="approval-queue-reject-input"
-                value.bind="row.rejectReason"
-                placeholder="Why is this concert being rejected?"
-                disabled.bind="row.busy"
-                aria-label="Rejection reason"
-              />
-            </label>
-            <div class="[ approval-queue-action-bar ] [ cluster ]">
-              <button
-                type="submit"
-                class="approval-queue-btn"
-                data-variant="reject"
-                disabled.bind="row.busy"
-              >
-                Confirm reject
-              </button>
-              <button
-                type="button"
-                class="approval-queue-btn"
-                disabled.bind="row.busy"
-                click.trigger="cancelReject(row)"
-              >
-                Cancel
-              </button>
-            </div>
-          </form>
+    <details
+      repeat.for="series of group.series"
+      class="approval-queue-series"
+    >
+      <summary class="approval-queue-series-summary">
+        <span class="approval-queue-series-title">${series.seriesTitle}</span>
+        <span class="approval-queue-series-meta">
+          ${series.rows.length} ${series.rows.length === 1 ? 'date' : 'dates'}
+          <span
+            if.bind="series.unresolvedCount > 0"
+            class="approval-queue-unresolved-badge"
+          >⚠ ${series.unresolvedCount} unresolved</span>
+        </span>
+      </summary>
 
-          <p if.bind="row.actionError" class="approval-queue-row-error" role="alert">
-            ${row.actionError}
-          </p>
-        </td>
-      </tr>
-    </tbody>
-  </table>
+      <table class="approval-queue-table">
+        <thead>
+          <tr>
+            <th scope="col">Local date</th>
+            <th scope="col">Start time</th>
+            <th scope="col">Listed venue</th>
+            <th scope="col">Resolved venue</th>
+            <th scope="col">Source</th>
+            <th scope="col">Discovered</th>
+            <th scope="col">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr repeat.for="row of series.rows" data-busy.bind="row.busy">
+            <td>${row.localDate}</td>
+            <td>${row.startTime}</td>
+            <td>${row.listedVenueName}</td>
+            <td>
+              <span if.bind="row.hasResolvedVenue">
+                ${row.resolvedVenueName}
+                <small class="approval-queue-admin-area">${row.resolvedAdminArea}</small>
+              </span>
+              <span else class="approval-queue-unresolved" data-state="unresolved">
+                Unresolved venue — review
+              </span>
+            </td>
+            <td>
+              <a
+                if.bind="sanitizeUrl(row.sourceUrl)"
+                href.bind="sanitizeUrl(row.sourceUrl)"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="approval-queue-source-link"
+              >
+                Open source
+              </a>
+              <span else>${'—'}</span>
+            </td>
+            <td>${row.discoveredTime}</td>
+            <td class="approval-queue-actions">
+              <div if.bind="!row.rejecting" class="[ approval-queue-action-bar ] [ cluster ]">
+                <button
+                  type="button"
+                  class="approval-queue-btn"
+                  data-variant="approve"
+                  disabled.bind="row.busy"
+                  click.trigger="approve(group, series, row)"
+                >
+                  Approve
+                </button>
+                <button
+                  type="button"
+                  class="approval-queue-btn"
+                  data-variant="reject"
+                  disabled.bind="row.busy"
+                  click.trigger="startReject(row)"
+                >
+                  Reject
+                </button>
+              </div>
+
+              <form
+                else
+                class="[ approval-queue-reject-form ] [ flow ]"
+                submit.trigger="confirmReject(group, series, row)"
+              >
+                <label class="approval-queue-reject-label">
+                  Rejection reason
+                  <input
+                    type="text"
+                    class="approval-queue-reject-input"
+                    value.bind="row.rejectReason"
+                    placeholder="Why is this concert being rejected?"
+                    disabled.bind="row.busy"
+                    aria-label="Rejection reason"
+                  />
+                </label>
+                <div class="[ approval-queue-action-bar ] [ cluster ]">
+                  <button
+                    type="submit"
+                    class="approval-queue-btn"
+                    data-variant="reject"
+                    disabled.bind="row.busy"
+                  >
+                    Confirm reject
+                  </button>
+                  <button
+                    type="button"
+                    class="approval-queue-btn"
+                    disabled.bind="row.busy"
+                    click.trigger="cancelReject(row)"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </form>
+
+              <p if.bind="row.actionError" class="approval-queue-row-error" role="alert">
+                ${row.actionError}
+              </p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </details>
+  </section>
 </main>

--- a/admin/approval-queue/approval-queue-route.ts
+++ b/admin/approval-queue/approval-queue-route.ts
@@ -33,7 +33,22 @@ export interface QueueRow {
 	actionError: string
 }
 
+/** All pending concerts for one tour/show title within one artist bucket. */
+export interface PendingSeriesGroup {
+	readonly seriesTitle: string
+	rows: QueueRow[]
+	unresolvedCount: number
+}
+
+/** All series grouped under a single performing artist. */
+export interface PendingArtistGroup {
+	readonly artistName: string
+	series: PendingSeriesGroup[]
+}
+
 const EMPTY = '—'
+const UNKNOWN_ARTIST = 'Unknown artist'
+const UNTITLED_SERIES = 'Untitled series'
 
 function formatLocalDate(concert: PendingConcert): string {
 	const d = concert.localDate?.value
@@ -90,16 +105,58 @@ function toRow(concert: PendingConcert): QueueRow {
 }
 
 /**
+ * Groups a flat pending-concert list into Artist → Series. Uses
+ * `performer.name` as the artist key and `title.value` as the series proxy
+ * (no `series.id` exists on `PendingConcert` until approval). First-seen order
+ * is preserved; `unresolvedCount` tracks rows lacking a resolved venue so the
+ * collapsed summary can surface triage priority.
+ */
+function groupQueueByArtistAndSeries(
+	concerts: PendingConcert[],
+): PendingArtistGroup[] {
+	const groups: PendingArtistGroup[] = []
+	const artistByName = new Map<string, PendingArtistGroup>()
+	const seriesByKey = new Map<string, PendingSeriesGroup>()
+
+	for (const concert of concerts) {
+		const artistName = concert.performer?.name?.value ?? UNKNOWN_ARTIST
+		let artist = artistByName.get(artistName)
+		if (!artist) {
+			artist = { artistName, series: [] }
+			artistByName.set(artistName, artist)
+			groups.push(artist)
+		}
+
+		const seriesTitle = concert.title?.value ?? UNTITLED_SERIES
+		// Null byte separator prevents "A\0B" vs "AB\0" key collisions.
+		const seriesKey = `${artistName}\0${seriesTitle}`
+		let series = seriesByKey.get(seriesKey)
+		if (!series) {
+			series = { seriesTitle, rows: [], unresolvedCount: 0 }
+			seriesByKey.set(seriesKey, series)
+			artist.series.push(series)
+		}
+
+		const row = toRow(concert)
+		series.rows.push(row)
+		if (!row.hasResolvedVenue) series.unresolvedCount++
+	}
+
+	return groups
+}
+
+/**
  * Concert approval-queue screen. Loads the pending queue on attach and lets a
- * reviewer approve or reject each discovered concert. Approve/reject run
- * against the admin-local {@link IConcertClient}; on success the row
- * is removed from the list, on failure a per-row error is surfaced and the row
- * stays put so the action can be retried.
+ * reviewer approve or reject each discovered concert, grouped by artist then
+ * series title. Approve/reject run against the admin-local
+ * {@link IConcertClient}; on success the row is removed and empty
+ * series/artist headings are pruned, on failure a per-row error is surfaced
+ * and the row stays put so the action can be retried.
  */
 export class ApprovalQueueRoute {
 	public phase: LoadPhase = 'loading'
 	public loadError = ''
-	public rows: QueueRow[] = []
+	public groups: PendingArtistGroup[] = []
 
 	private readonly client = resolve(IConcertClient)
 	private readonly logger = resolve(ILogger).scopeTo('ApprovalQueueRoute')
@@ -121,7 +178,7 @@ export class ApprovalQueueRoute {
 		this.loadError = ''
 		try {
 			const pending = await this.client.listPending()
-			this.rows = pending.map(toRow)
+			this.groups = groupQueueByArtistAndSeries(pending)
 			this.phase = 'ready'
 		} catch (err) {
 			this.loadError =
@@ -133,13 +190,17 @@ export class ApprovalQueueRoute {
 		}
 	}
 
-	public async approve(row: QueueRow): Promise<void> {
+	public async approve(
+		group: PendingArtistGroup,
+		series: PendingSeriesGroup,
+		row: QueueRow,
+	): Promise<void> {
 		if (row.busy) return
 		row.busy = true
 		row.actionError = ''
 		try {
 			await this.client.approve(row.stagedId)
-			this.removeRow(row)
+			this.removeRow(group, series, row)
 		} catch (err) {
 			row.actionError =
 				err instanceof Error ? err.message : 'Approval failed. Try again.'
@@ -160,7 +221,11 @@ export class ApprovalQueueRoute {
 		row.rejectReason = ''
 	}
 
-	public async confirmReject(row: QueueRow): Promise<void> {
+	public async confirmReject(
+		group: PendingArtistGroup,
+		series: PendingSeriesGroup,
+		row: QueueRow,
+	): Promise<void> {
 		if (row.busy) return
 		const reason = row.rejectReason.trim()
 		if (reason.length === 0) {
@@ -171,7 +236,7 @@ export class ApprovalQueueRoute {
 		row.actionError = ''
 		try {
 			await this.client.reject(row.stagedId, reason)
-			this.removeRow(row)
+			this.removeRow(group, series, row)
 		} catch (err) {
 			row.actionError =
 				err instanceof Error ? err.message : 'Rejection failed. Try again.'
@@ -181,11 +246,26 @@ export class ApprovalQueueRoute {
 	}
 
 	public get isEmpty(): boolean {
-		return this.phase === 'ready' && this.rows.length === 0
+		return this.phase === 'ready' && this.groups.length === 0
 	}
 
-	private removeRow(row: QueueRow): void {
-		const idx = this.rows.indexOf(row)
-		if (idx !== -1) this.rows.splice(idx, 1)
+	private removeRow(
+		group: PendingArtistGroup,
+		series: PendingSeriesGroup,
+		row: QueueRow,
+	): void {
+		if (!row.hasResolvedVenue) series.unresolvedCount--
+		const rowIdx = series.rows.indexOf(row)
+		if (rowIdx !== -1) series.rows.splice(rowIdx, 1)
+		// Drop the series heading once its last concert is gone...
+		if (series.rows.length === 0) {
+			const sIdx = group.series.indexOf(series)
+			if (sIdx !== -1) group.series.splice(sIdx, 1)
+		}
+		// ...and the artist heading once its last series is gone.
+		if (group.series.length === 0) {
+			const gIdx = this.groups.indexOf(group)
+			if (gIdx !== -1) this.groups.splice(gIdx, 1)
+		}
 	}
 }

--- a/test/admin/approval-queue/approval-queue-route.spec.ts
+++ b/test/admin/approval-queue/approval-queue-route.spec.ts
@@ -51,39 +51,63 @@ function createMockClient(overrides: Partial<MockClient> = {}): MockClient {
 	}
 }
 
-function resolvedConcert(): PendingConcert {
+function makeConcert(opts: {
+	stagedId: string
+	artist: string
+	title: string
+	year: number
+	month: number
+	day: number
+	resolvedVenue?: { name: string; adminArea: string }
+	sourceUrl?: string
+}): PendingConcert {
 	return new PendingConcert({
-		stagedId: new StagedConcertId({ value: 'staged-1' }),
+		stagedId: new StagedConcertId({ value: opts.stagedId }),
 		performer: new Artist({
-			name: new ArtistName({ value: 'The Resolved Band' }),
+			name: new ArtistName({ value: opts.artist }),
 		}),
-		title: new Title({ value: 'Summer Tour' }),
+		title: new Title({ value: opts.title }),
 		localDate: new LocalDate({
-			value: new GoogleDate({ year: 2026, month: 7, day: 4 }),
+			value: new GoogleDate({
+				year: opts.year,
+				month: opts.month,
+				day: opts.day,
+			}),
 		}),
-		startTime: undefined,
-		listedVenueName: new ListedVenueName({ value: 'budokan hall' }),
-		resolvedVenue: new ResolvedVenue({
-			name: new VenueName({ value: 'Nippon Budokan' }),
-			adminArea: new AdminArea({ value: 'JP-13' }),
-		}),
-		sourceUrl: new Url({ value: 'https://example.com/show/1' }),
+		listedVenueName: new ListedVenueName({ value: 'listed venue' }),
+		resolvedVenue: opts.resolvedVenue
+			? new ResolvedVenue({
+					name: new VenueName({ value: opts.resolvedVenue.name }),
+					adminArea: new AdminArea({ value: opts.resolvedVenue.adminArea }),
+				})
+			: undefined,
+		sourceUrl: opts.sourceUrl ? new Url({ value: opts.sourceUrl }) : undefined,
 		discoveredTime: Timestamp.fromDate(new Date('2026-06-01T12:00:00Z')),
 	})
 }
 
+function resolvedConcert(): PendingConcert {
+	return makeConcert({
+		stagedId: 'staged-1',
+		artist: 'The Resolved Band',
+		title: 'Summer Tour',
+		year: 2026,
+		month: 7,
+		day: 4,
+		resolvedVenue: { name: 'Nippon Budokan', adminArea: 'JP-13' },
+		sourceUrl: 'https://example.com/show/1',
+	})
+}
+
 function unresolvedConcert(): PendingConcert {
-	return new PendingConcert({
-		stagedId: new StagedConcertId({ value: 'staged-2' }),
-		performer: new Artist({ name: new ArtistName({ value: 'No Venue Act' }) }),
-		title: new Title({ value: 'Mystery Gig' }),
-		localDate: new LocalDate({
-			value: new GoogleDate({ year: 2026, month: 8, day: 9 }),
-		}),
-		listedVenueName: new ListedVenueName({ value: 'some unknown place' }),
-		resolvedVenue: undefined,
-		sourceUrl: new Url({ value: 'https://example.com/show/2' }),
-		discoveredTime: Timestamp.fromDate(new Date('2026-06-02T12:00:00Z')),
+	return makeConcert({
+		stagedId: 'staged-2',
+		artist: 'No Venue Act',
+		title: 'Mystery Gig',
+		year: 2026,
+		month: 8,
+		day: 9,
+		sourceUrl: 'https://example.com/show/2',
 	})
 }
 
@@ -109,142 +133,339 @@ describe('ApprovalQueueRoute', () => {
 		vi.clearAllMocks()
 	})
 
-	it('renders reviewable fields for resolved and unresolved rows', async () => {
-		const client = createMockClient({
-			listPending: vi
-				.fn()
-				.mockResolvedValue([resolvedConcert(), unresolvedConcert()]),
-		})
-		const fixture = await build(client)
+	describe('grouping', () => {
+		it('groups concerts by artist and then by title', async () => {
+			const client = createMockClient({
+				listPending: vi.fn().mockResolvedValue([
+					makeConcert({
+						stagedId: 's1',
+						artist: 'Band A',
+						title: 'Tour X',
+						year: 2026,
+						month: 7,
+						day: 1,
+						resolvedVenue: { name: 'Venue 1', adminArea: 'JP-13' },
+					}),
+					makeConcert({
+						stagedId: 's2',
+						artist: 'Band A',
+						title: 'Tour X',
+						year: 2026,
+						month: 7,
+						day: 2,
+						resolvedVenue: { name: 'Venue 2', adminArea: 'JP-14' },
+					}),
+					makeConcert({
+						stagedId: 's3',
+						artist: 'Band A',
+						title: 'Tour Y',
+						year: 2026,
+						month: 8,
+						day: 1,
+					}),
+					makeConcert({
+						stagedId: 's4',
+						artist: 'Band B',
+						title: 'Festival',
+						year: 2026,
+						month: 9,
+						day: 1,
+						resolvedVenue: { name: 'Venue 3', adminArea: 'JP-27' },
+					}),
+				]),
+			})
+			const fixture = await build(client)
+			const vm = routeOf(fixture)
 
-		const text = fixture.appHost.textContent ?? ''
-		// Resolved row: performer, title, local date, listed + resolved venue, area.
-		expect(text).toContain('The Resolved Band')
-		expect(text).toContain('Summer Tour')
-		expect(text).toContain('2026-07-04')
-		expect(text).toContain('budokan hall')
-		expect(text).toContain('Nippon Budokan')
-		expect(text).toContain('JP-13')
-		// Unresolved row is clearly flagged for review.
-		expect(text).toContain('Unresolved venue — review')
-		// Source link renders with the raw URL.
-		const links = Array.from(
-			fixture.appHost.querySelectorAll<HTMLAnchorElement>(
+			expect(vm.groups).toHaveLength(2)
+
+			const bandA = vm.groups[0]
+			expect(bandA.artistName).toBe('Band A')
+			expect(bandA.series).toHaveLength(2)
+			expect(bandA.series[0].seriesTitle).toBe('Tour X')
+			expect(bandA.series[0].rows).toHaveLength(2)
+			expect(bandA.series[1].seriesTitle).toBe('Tour Y')
+			expect(bandA.series[1].rows).toHaveLength(1)
+
+			const bandB = vm.groups[1]
+			expect(bandB.artistName).toBe('Band B')
+			expect(bandB.series).toHaveLength(1)
+			expect(bandB.series[0].seriesTitle).toBe('Festival')
+		})
+
+		it('computes unresolvedCount for concerts without a resolved venue', async () => {
+			const client = createMockClient({
+				listPending: vi.fn().mockResolvedValue([
+					makeConcert({
+						stagedId: 's1',
+						artist: 'Band A',
+						title: 'Tour X',
+						year: 2026,
+						month: 7,
+						day: 1,
+						resolvedVenue: { name: 'Venue 1', adminArea: 'JP-13' },
+					}),
+					makeConcert({
+						stagedId: 's2',
+						artist: 'Band A',
+						title: 'Tour X',
+						year: 2026,
+						month: 7,
+						day: 2,
+					}),
+					makeConcert({
+						stagedId: 's3',
+						artist: 'Band A',
+						title: 'Tour X',
+						year: 2026,
+						month: 7,
+						day: 3,
+					}),
+				]),
+			})
+			const fixture = await build(client)
+			const vm = routeOf(fixture)
+
+			const series = vm.groups[0].series[0]
+			expect(series.rows).toHaveLength(3)
+			expect(series.unresolvedCount).toBe(2)
+		})
+	})
+
+	describe('rendering', () => {
+		it('renders reviewable fields for resolved and unresolved rows', async () => {
+			const client = createMockClient({
+				listPending: vi
+					.fn()
+					.mockResolvedValue([resolvedConcert(), unresolvedConcert()]),
+			})
+			const fixture = await build(client)
+
+			const text = fixture.appHost.textContent ?? ''
+			// Artist and title appear as group headers.
+			expect(text).toContain('The Resolved Band')
+			expect(text).toContain('Summer Tour')
+			// Per-row fields are still shown in expanded rows.
+			expect(text).toContain('2026-07-04')
+			expect(text).toContain('listed venue')
+			expect(text).toContain('Nippon Budokan')
+			expect(text).toContain('JP-13')
+			// Unresolved row is clearly flagged for review.
+			expect(text).toContain('Unresolved venue — review')
+			// Source link renders with the raw URL.
+			const links = Array.from(
+				fixture.appHost.querySelectorAll<HTMLAnchorElement>(
+					'a.approval-queue-source-link',
+				),
+			)
+			expect(links.map((a) => a.href)).toContain('https://example.com/show/1')
+		})
+
+		it('shows unresolved badge in series summary when unresolvedCount > 0', async () => {
+			const client = createMockClient({
+				listPending: vi.fn().mockResolvedValue([unresolvedConcert()]),
+			})
+			const fixture = await build(client)
+
+			expect(fixture.appHost.textContent).toContain('⚠')
+			expect(fixture.appHost.textContent).toContain('unresolved')
+		})
+
+		it('does not render a source link for a javascript: URL (XSS guard)', async () => {
+			const malicious = makeConcert({
+				stagedId: 'staged-xss',
+				artist: 'Sketchy Act',
+				title: 'Suspicious Show',
+				year: 2026,
+				month: 9,
+				day: 1,
+				// AI-sourced URL carrying a script payload — must be neutralised.
+				sourceUrl: 'javascript:alert(document.cookie)',
+			})
+			const client = createMockClient({
+				listPending: vi.fn().mockResolvedValue([malicious]),
+			})
+			const fixture = await build(client)
+
+			// sanitizeUrl() reduces the javascript: scheme to '', so if.bind hides
+			// the anchor entirely — no dangerous href reaches the DOM.
+			const links = fixture.appHost.querySelectorAll(
 				'a.approval-queue-source-link',
-			),
-		)
-		expect(links.map((a) => a.href)).toContain('https://example.com/show/1')
+			)
+			expect(links).toHaveLength(0)
+		})
+
+		it('renders the empty state when no concerts are pending', async () => {
+			const client = createMockClient({
+				listPending: vi.fn().mockResolvedValue([]),
+			})
+			const fixture = await build(client)
+
+			expect(fixture.appHost.textContent).toContain(
+				'No concerts awaiting review',
+			)
+		})
+
+		it('shows the error state when the initial list fails', async () => {
+			const client = createMockClient({
+				listPending: vi.fn().mockRejectedValue(new Error('boom')),
+			})
+			const fixture = await build(client)
+			const vm = routeOf(fixture)
+
+			expect(vm.phase).toBe('error')
+			expect(fixture.appHost.textContent).toContain(
+				'Could not load the approval queue',
+			)
+			expect(fixture.appHost.textContent).toContain('boom')
+		})
 	})
 
-	it('does not render a source link for a javascript: URL (XSS guard)', async () => {
-		const malicious = new PendingConcert({
-			stagedId: new StagedConcertId({ value: 'staged-xss' }),
-			performer: new Artist({ name: new ArtistName({ value: 'Sketchy Act' }) }),
-			title: new Title({ value: 'Suspicious Show' }),
-			localDate: new LocalDate({
-				value: new GoogleDate({ year: 2026, month: 9, day: 1 }),
-			}),
-			listedVenueName: new ListedVenueName({ value: 'somewhere' }),
-			// AI-sourced URL carrying a script payload — must be neutralised.
-			sourceUrl: new Url({ value: 'javascript:alert(document.cookie)' }),
-			discoveredTime: Timestamp.fromDate(new Date('2026-06-03T12:00:00Z')),
-		})
-		const client = createMockClient({
-			listPending: vi.fn().mockResolvedValue([malicious]),
-		})
-		const fixture = await build(client)
+	describe('approve', () => {
+		it('calls approve(id) and removes the row, pruning empty series and artist groups', async () => {
+			const client = createMockClient({
+				listPending: vi.fn().mockResolvedValue([resolvedConcert()]),
+			})
+			const fixture = await build(client)
+			const vm = routeOf(fixture)
 
-		// sanitizeUrl() reduces the javascript: scheme to '', so if.bind hides
-		// the anchor entirely — no dangerous href reaches the DOM.
-		const links = fixture.appHost.querySelectorAll(
-			'a.approval-queue-source-link',
-		)
-		expect(links).toHaveLength(0)
+			const group = vm.groups[0]
+			const series = group.series[0]
+			const row = series.rows[0]
+			expect(series.rows).toHaveLength(1)
+
+			await vm.approve(group, series, row)
+
+			expect(client.approve).toHaveBeenCalledWith('staged-1')
+			// Row removed → series pruned → artist group pruned.
+			expect(vm.groups).toHaveLength(0)
+		})
+
+		it('decrements unresolvedCount when an unresolved row is approved', async () => {
+			const client = createMockClient({
+				listPending: vi.fn().mockResolvedValue([
+					makeConcert({
+						stagedId: 's1',
+						artist: 'Band A',
+						title: 'Tour',
+						year: 2026,
+						month: 7,
+						day: 1,
+					}),
+					makeConcert({
+						stagedId: 's2',
+						artist: 'Band A',
+						title: 'Tour',
+						year: 2026,
+						month: 7,
+						day: 2,
+					}),
+				]),
+			})
+			const fixture = await build(client)
+			const vm = routeOf(fixture)
+
+			const group = vm.groups[0]
+			const series = group.series[0]
+			expect(series.unresolvedCount).toBe(2)
+
+			await vm.approve(group, series, series.rows[0])
+
+			expect(series.unresolvedCount).toBe(1)
+			expect(series.rows).toHaveLength(1)
+		})
+
+		it('surfaces a per-row error and keeps the row when approve fails', async () => {
+			const client = createMockClient({
+				listPending: vi.fn().mockResolvedValue([resolvedConcert()]),
+				approve: vi.fn().mockRejectedValue(new Error('approve failed')),
+			})
+			const fixture = await build(client)
+			const vm = routeOf(fixture)
+
+			const group = vm.groups[0]
+			const series = group.series[0]
+			const row = series.rows[0]
+			await vm.approve(group, series, row)
+
+			expect(row.actionError).toContain('approve failed')
+			expect(row.busy).toBe(false)
+			expect(series.rows).toHaveLength(1)
+		})
+
+		it('prunes only the empty series, not the artist group, when another series remains', async () => {
+			const client = createMockClient({
+				listPending: vi.fn().mockResolvedValue([
+					makeConcert({
+						stagedId: 's1',
+						artist: 'Band A',
+						title: 'Tour X',
+						year: 2026,
+						month: 7,
+						day: 1,
+						resolvedVenue: { name: 'Venue', adminArea: 'JP-13' },
+					}),
+					makeConcert({
+						stagedId: 's2',
+						artist: 'Band A',
+						title: 'Tour Y',
+						year: 2026,
+						month: 8,
+						day: 1,
+						resolvedVenue: { name: 'Venue', adminArea: 'JP-14' },
+					}),
+				]),
+			})
+			const fixture = await build(client)
+			const vm = routeOf(fixture)
+
+			const group = vm.groups[0]
+			const seriesX = group.series[0]
+			await vm.approve(group, seriesX, seriesX.rows[0])
+
+			// Tour X is pruned but Band A remains with Tour Y.
+			expect(vm.groups).toHaveLength(1)
+			expect(vm.groups[0].series).toHaveLength(1)
+			expect(vm.groups[0].series[0].seriesTitle).toBe('Tour Y')
+		})
 	})
 
-	it('renders the empty state when no concerts are pending', async () => {
-		const client = createMockClient({
-			listPending: vi.fn().mockResolvedValue([]),
+	describe('reject', () => {
+		it('requires a reason before calling reject', async () => {
+			const client = createMockClient({
+				listPending: vi.fn().mockResolvedValue([resolvedConcert()]),
+			})
+			const fixture = await build(client)
+			const vm = routeOf(fixture)
+
+			const group = vm.groups[0]
+			const series = group.series[0]
+			const row = series.rows[0]
+			vm.startReject(row)
+			row.rejectReason = '   '
+			await vm.confirmReject(group, series, row)
+
+			expect(client.reject).not.toHaveBeenCalled()
+			expect(row.actionError).toContain('reason is required')
+			expect(series.rows).toHaveLength(1)
 		})
-		const fixture = await build(client)
 
-		expect(fixture.appHost.textContent).toContain('No concerts awaiting review')
-	})
+		it('calls reject(id, reason) and removes the row, pruning empty groups', async () => {
+			const client = createMockClient({
+				listPending: vi.fn().mockResolvedValue([resolvedConcert()]),
+			})
+			const fixture = await build(client)
+			const vm = routeOf(fixture)
 
-	it('shows the error state when the initial list fails', async () => {
-		const client = createMockClient({
-			listPending: vi.fn().mockRejectedValue(new Error('boom')),
+			const group = vm.groups[0]
+			const series = group.series[0]
+			const row = series.rows[0]
+			vm.startReject(row)
+			row.rejectReason = 'wrong date'
+			await vm.confirmReject(group, series, row)
+
+			expect(client.reject).toHaveBeenCalledWith('staged-1', 'wrong date')
+			expect(vm.groups).toHaveLength(0)
 		})
-		const fixture = await build(client)
-		const vm = routeOf(fixture)
-
-		expect(vm.phase).toBe('error')
-		expect(fixture.appHost.textContent).toContain(
-			'Could not load the approval queue',
-		)
-		expect(fixture.appHost.textContent).toContain('boom')
-	})
-
-	it('approve calls approve(id) and removes the row', async () => {
-		const client = createMockClient({
-			listPending: vi.fn().mockResolvedValue([resolvedConcert()]),
-		})
-		const fixture = await build(client)
-		const vm = routeOf(fixture)
-
-		expect(vm.rows).toHaveLength(1)
-		await vm.approve(vm.rows[0])
-
-		expect(client.approve).toHaveBeenCalledWith('staged-1')
-		expect(vm.rows).toHaveLength(0)
-	})
-
-	it('reject requires a reason before calling reject', async () => {
-		const client = createMockClient({
-			listPending: vi.fn().mockResolvedValue([resolvedConcert()]),
-		})
-		const fixture = await build(client)
-		const vm = routeOf(fixture)
-
-		const row = vm.rows[0]
-		vm.startReject(row)
-		row.rejectReason = '   '
-		await vm.confirmReject(row)
-
-		expect(client.reject).not.toHaveBeenCalled()
-		expect(row.actionError).toContain('reason is required')
-		expect(vm.rows).toHaveLength(1)
-	})
-
-	it('reject with a reason calls reject(id, reason) and removes the row', async () => {
-		const client = createMockClient({
-			listPending: vi.fn().mockResolvedValue([resolvedConcert()]),
-		})
-		const fixture = await build(client)
-		const vm = routeOf(fixture)
-
-		const row = vm.rows[0]
-		vm.startReject(row)
-		row.rejectReason = 'wrong date'
-		await vm.confirmReject(row)
-
-		expect(client.reject).toHaveBeenCalledWith('staged-1', 'wrong date')
-		expect(vm.rows).toHaveLength(0)
-	})
-
-	it('surfaces a per-row error and keeps the row when approve fails', async () => {
-		const client = createMockClient({
-			listPending: vi.fn().mockResolvedValue([resolvedConcert()]),
-			approve: vi.fn().mockRejectedValue(new Error('approve failed')),
-		})
-		const fixture = await build(client)
-		const vm = routeOf(fixture)
-
-		const row = vm.rows[0]
-		await vm.approve(row)
-
-		expect(row.actionError).toContain('approve failed')
-		expect(row.busy).toBe(false)
-		expect(vm.rows).toHaveLength(1)
 	})
 })


### PR DESCRIPTION
## Summary

Group pending concerts in the admin approval-queue by performing artist and then by series title, matching the grouping pattern already in use on the approved-concerts screen.

- Each artist is rendered as a section heading
- Each series is a collapsible `<details>` element (collapsed by default)
- The series summary shows: title · date count · `⚠ N unresolved` badge when any concerts lack a resolved venue
- Artist and Title columns removed from the inner table (promoted to group headers); all other reviewable fields and per-row Approve / Reject actions are unchanged

## Changes

- `admin/approval-queue/approval-queue-route.ts` — `PendingSeriesGroup` / `PendingArtistGroup` interfaces; `groupQueueByArtistAndSeries()` function; updated action methods to accept `(group, series, row)` and prune empty groups on success
- `admin/approval-queue/approval-queue-route.html` — artist `<section>` / series `<details>` / inner `<table>` layout replacing the flat table
- `admin/approval-queue/approval-queue-route.css` — styles for artist heading, series disclosure, series summary, and unresolved-venue badge
- `test/admin/approval-queue/approval-queue-route.spec.ts` — updated and expanded tests covering grouping, `unresolvedCount` computation, row-removal pruning, and all action/error scenarios (13 tests)

## Testing

- Unit tests: 13/13 pass (`vitest run`)
- Biome lint: no issues
- Manual checklist (post-deploy): artist grouping, series expand/collapse, unresolved badge, approve/reject row removal with group pruning

Refs: #628
