### PR TITLE
fix(auth): restore session on cold start and disable monitorSession

### DIFF
--- a/shared/services/auth-service.ts
+++ b/shared/services/auth-service.ts
@@ -28,10 +28,13 @@ function createSettings(config: AppConfig): UserManagerSettings {
 		loadUserInfo: true,
 		// Use localStorage instead of sessionStorage for better compatibility with Playwright storageState
 		userStore: new WebStorageStateStore({ store: window.localStorage }),
-		// Disable session monitor in dev: Zitadel's check_session_iframe returns
-		// frame-ancestors 'none', causing oidc-client-ts to fire userUnloaded
-		// repeatedly (~10s) which re-bootstraps the entire Aurelia app.
-		monitorSession: !import.meta.env.DEV,
+		// Disable session monitor in all environments: the self-hosted Zitadel
+		// serves check_session_iframe with frame-ancestors 'none', so the hidden
+		// iframe cannot load and oidc-client-ts fires spurious userUnloaded events
+		// (~10s) that re-bootstrap the entire Aurelia app. Session-change detection
+		// degrades to next-token-refresh detection (<=30m), the standard posture
+		// for SPAs against a Zitadel that blocks iframe embedding.
+		monitorSession: false,
 	}
 }
 
@@ -60,11 +63,31 @@ export class AuthService {
 
 		this.userManager.events.addUserLoaded((user) => this.updateState(user))
 		this.userManager.events.addUserUnloaded(() => this.updateState(null))
-		this.userManager.getUser().then((user) => {
+		this.restoreSession().then((user) => {
 			this.updateState(user)
-			// Resolve the ready promise after initial user state is loaded
+			// Resolve the ready promise only after the boot-time renewal attempt
+			// (if any) has settled, so route guards observe a stable auth state.
 			this.readyResolve?.()
 		})
+	}
+
+	// Restore the session on cold start. oidc-client-ts issue #2012: when the app
+	// boots with an already-expired access token, automaticSilentRenew drops the
+	// renewal timer based on the access token alone and never consults the still-
+	// valid refresh token, leaving the user unauthenticated. Work around it by
+	// explicitly calling signinSilent() when the stored user is expired, so a
+	// valid refresh token transparently restores the session.
+	private async restoreSession(): Promise<User | null> {
+		const user = await this.userManager.getUser()
+		if (user?.expired) {
+			try {
+				return await this.userManager.signinSilent()
+			} catch (err) {
+				this.logger.info('Silent session restore failed; signing out', err)
+				return null
+			}
+		}
+		return user
 	}
 
 	public user: User | null = null

--- a/test/auth-service.spec.ts
+++ b/test/auth-service.spec.ts
@@ -17,6 +17,7 @@ interface MockUserManagerEvents {
 interface MockUserManager {
 	signinRedirect: ReturnType<typeof vi.fn>
 	signinCallback: ReturnType<typeof vi.fn>
+	signinSilent: ReturnType<typeof vi.fn>
 	signoutRedirect: ReturnType<typeof vi.fn>
 	getUser: ReturnType<typeof vi.fn>
 	events: MockUserManagerEvents
@@ -32,6 +33,7 @@ describe('AuthService', () => {
 			signinCallback: vi.fn().mockResolvedValue({
 				profile: { preferred_username: 'test-user' },
 			}),
+			signinSilent: vi.fn().mockResolvedValue(null),
 			signoutRedirect: vi.fn(),
 			getUser: vi.fn().mockResolvedValue(null),
 			events: {
@@ -84,6 +86,61 @@ describe('AuthService', () => {
 	it('ready resolves after initial getUser completes', async () => {
 		await sut.ready
 		expect(userManagerMock.getUser).toHaveBeenCalledOnce()
+	})
+
+	// Build a fresh AuthService after the getUser/signinSilent mocks have been
+	// arranged, so the constructor's boot-time restore observes them.
+	const buildSut = (): IAuthService => {
+		const container = createTestContainer()
+		container.register(AuthService)
+		return container.get(IAuthService)
+	}
+
+	it('restores the session via signinSilent when the stored access token is expired', async () => {
+		const renewedUser = {
+			expired: false,
+			profile: { preferred_username: 'renewed-user' },
+		}
+		userManagerMock.getUser.mockResolvedValue({
+			expired: true,
+			profile: { preferred_username: 'stale-user' },
+		})
+		userManagerMock.signinSilent.mockResolvedValue(renewedUser)
+
+		const freshSut = buildSut()
+		await freshSut.ready
+
+		expect(userManagerMock.signinSilent).toHaveBeenCalledOnce()
+		expect(freshSut.isAuthenticated).toBe(true)
+		expect(freshSut.user?.profile.preferred_username).toBe('renewed-user')
+	})
+
+	it('ends unauthenticated when signinSilent fails for an expired token', async () => {
+		userManagerMock.getUser.mockResolvedValue({
+			expired: true,
+			profile: { preferred_username: 'stale-user' },
+		})
+		userManagerMock.signinSilent.mockRejectedValue(new Error('refresh failed'))
+
+		const freshSut = buildSut()
+		await freshSut.ready
+
+		expect(userManagerMock.signinSilent).toHaveBeenCalledOnce()
+		expect(freshSut.isAuthenticated).toBe(false)
+		expect(freshSut.user).toBeNull()
+	})
+
+	it('does not call signinSilent when the stored access token is still valid', async () => {
+		userManagerMock.getUser.mockResolvedValue({
+			expired: false,
+			profile: { preferred_username: 'valid-user' },
+		})
+
+		const freshSut = buildSut()
+		await freshSut.ready
+
+		expect(userManagerMock.signinSilent).not.toHaveBeenCalled()
+		expect(freshSut.isAuthenticated).toBe(true)
 	})
 
 	it('signIn calls signinRedirect', async () => {


### PR DESCRIPTION
## Why

Users who installed the PWA were signed out when reopening it the next day, despite a still-valid 30-day refresh token. Root cause: oidc-client-ts [#2012](https://github.com/authts/oidc-client-ts/issues/2012) drops the silent-renew timer on a cold start with an already-expired access token without consulting the refresh token, so the user lands unauthenticated. Compounding it, `monitorSession` was enabled in prod where Zitadel's `check_session_iframe` returns `frame-ancestors 'none'`, firing spurious `userUnloaded` events.

## What changed

- **Boot-time session restoration** (`shared/services/auth-service.ts`): on cold start, if the stored user's access token is expired, attempt `signinSilent()` (refresh-token grant) and only resolve the `ready` promise after it settles, so a valid refresh token transparently restores the session. On failure, fall back to signed-out.
- **`monitorSession: false` in all environments**: removes the `frame-ancestors 'none'` iframe conflict that spuriously unloads the user. Session-change detection degrades to next-token-refresh (≤30m).
- **Unit tests**: expired + valid refresh → `signinSilent` invoked, ends authenticated; expired + failed refresh → unauthenticated; valid token → no `signinSilent`.

Pairs with cloud-provisioning PR adding explicit OIDC token lifetimes (access 30m / refresh idle 30d / absolute 90d).

`make check` passes locally (lint + all unit tests).

Refs: #648