### PR TITLE
feat(analytics): tag internal/E2E traffic (15.1/15.2 SDK-level)

### DIFF
--- a/shared/config/app-config.ts
+++ b/shared/config/app-config.ts
@@ -47,6 +47,18 @@ export interface AppConfig {
 	 * serves `/config.json` will populate this in a follow-up PR.
 	 */
 	readonly posthogProjectKey?: string
+	/**
+	 * Allowlist of internal platform `UserId`s whose analytics should be
+	 * tagged with `internal_traffic: true` so production funnels / retention
+	 * can filter out staff / E2E sessions WITHOUT discarding the data. This is
+	 * the STABLE internal-identity marker mandated by the product-analytics
+	 * spec — an explicit configured list of user ids, NOT a heuristic.
+	 *
+	 * Populated per-environment by ops via `config.json`. Defaults to an empty
+	 * array when absent: a missing field is a strict no-op (no user is ever
+	 * tagged), never a crash.
+	 */
+	readonly internalTrafficUserIds: readonly string[]
 }
 
 export const IAppConfig = DI.createInterface<AppConfig>('IAppConfig')
@@ -217,6 +229,14 @@ function validateAppConfig(parsed: unknown): AppConfig {
 	const posthogApiHost = readOptionalString(o, 'posthogApiHost')
 	const posthogProjectKey = readOptionalString(o, 'posthogProjectKey')
 
+	// Optional internal-traffic allowlist. Absent from every existing
+	// ConfigMap until ops populates it per-environment; a missing field
+	// defaults to an empty array so no user is ever tagged (strict no-op).
+	const internalTrafficUserIds = readOptionalStringArray(
+		o,
+		'internalTrafficUserIds',
+	)
+
 	// Optional: present only in the admin console's ConfigMap. Absent from the
 	// consumer ConfigMap, so admin clients fall back to apiBaseUrl until the
 	// cutover sets it.
@@ -240,6 +260,7 @@ function validateAppConfig(parsed: unknown): AppConfig {
 		logLevel: logLevel as AppConfig['logLevel'],
 		...(posthogApiHost !== undefined ? { posthogApiHost } : {}),
 		...(posthogProjectKey !== undefined ? { posthogProjectKey } : {}),
+		internalTrafficUserIds,
 	}
 }
 
@@ -286,6 +307,32 @@ function requireStringArray(
 	key: string,
 ): readonly string[] {
 	const v = o[key]
+	if (!Array.isArray(v)) {
+		throw new Error(`config.json field '${key}' must be an array`)
+	}
+	for (const item of v) {
+		if (typeof item !== 'string') {
+			throw new Error(
+				`config.json field '${key}' contains a non-string element`,
+			)
+		}
+	}
+	return v as string[]
+}
+
+/**
+ * Returns the array when present, or an empty array when the key is absent
+ * or null. Rejects a present-but-non-array value, and any non-string element,
+ * loudly so a malformed ConfigMap surfaces during boot. A missing field is a
+ * deliberate no-op default — never a crash — which is the required behaviour
+ * for the optional `internalTrafficUserIds` allowlist.
+ */
+function readOptionalStringArray(
+	o: Record<string, unknown>,
+	key: string,
+): readonly string[] {
+	const v = o[key]
+	if (v === undefined || v === null) return []
 	if (!Array.isArray(v)) {
 		throw new Error(`config.json field '${key}' must be an array`)
 	}

--- a/src/config/app-config.spec.ts
+++ b/src/config/app-config.spec.ts
@@ -18,6 +18,7 @@ const validConfig: AppConfig = {
 	previewArtistIds: ['019c8655-7a05-71ef-82b4-a4ac2494e29f'],
 	previewArtistNames: ['Mrs. GREEN APPLE'],
 	logLevel: 'debug',
+	internalTrafficUserIds: [],
 }
 
 function mockFetchJson(body: unknown, ok = true, status = 200): void {
@@ -118,6 +119,37 @@ describe('app-config', () => {
 			mockFetchJson({ ...validConfig, circuitBaseUrl: '' })
 			const result = await loadAppConfig()
 			expect(result.circuitBaseUrl).toBe('')
+		})
+
+		it('defaults internalTrafficUserIds to an empty array when the field is absent', async () => {
+			const partial = { ...validConfig } as Record<string, unknown>
+			delete partial.internalTrafficUserIds
+			mockFetchJson(partial)
+			const result = await loadAppConfig()
+			expect(result.internalTrafficUserIds).toEqual([])
+		})
+
+		it('passes through a populated internalTrafficUserIds allowlist', async () => {
+			mockFetchJson({
+				...validConfig,
+				internalTrafficUserIds: ['staff-1', 'staff-2'],
+			})
+			const result = await loadAppConfig()
+			expect(result.internalTrafficUserIds).toEqual(['staff-1', 'staff-2'])
+		})
+
+		it('throws when internalTrafficUserIds is present but not an array', async () => {
+			mockFetchJson({ ...validConfig, internalTrafficUserIds: 'staff-1' })
+			await expect(loadAppConfig()).rejects.toThrow(
+				/internalTrafficUserIds.*must be an array/,
+			)
+		})
+
+		it('throws when internalTrafficUserIds contains a non-string element', async () => {
+			mockFetchJson({ ...validConfig, internalTrafficUserIds: ['staff-1', 42] })
+			await expect(loadAppConfig()).rejects.toThrow(
+				/internalTrafficUserIds.*non-string element/,
+			)
 		})
 	})
 

--- a/src/lib/analytics/analytics-service.spec.ts
+++ b/src/lib/analytics/analytics-service.spec.ts
@@ -13,6 +13,7 @@ const posthogStub = {
 	opt_in_capturing: vi.fn(),
 	opt_out_capturing: vi.fn(),
 	set_config: vi.fn(),
+	register: vi.fn(),
 }
 
 vi.mock('posthog-js', () => ({
@@ -150,9 +151,11 @@ describe('AnalyticsService', () => {
 		posthogStub.opt_in_capturing.mockReset()
 		posthogStub.opt_out_capturing.mockReset()
 		posthogStub.set_config.mockReset()
+		posthogStub.register.mockReset()
 		mockConfig.current = {
 			posthogProjectKey: 'phc_test_key',
 			posthogApiHost: 'https://eu.i.posthog.com',
+			internalTrafficUserIds: [],
 		}
 		mockConsent.analytics = true
 		mockConsent.sessionReplay = true
@@ -359,6 +362,123 @@ describe('AnalyticsService', () => {
 
 			expect(posthogStub.identify).toHaveBeenCalledTimes(1)
 			expect(posthogStub.identify).toHaveBeenCalledWith('user-xyz', undefined)
+			expect(posthogStub.reset).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('internal-traffic tagging', () => {
+		it('tags an allowlisted user: internal_traffic person property + register super-property', async () => {
+			mockConfig.current = {
+				...mockConfig.current,
+				internalTrafficUserIds: ['staff-1', 'staff-2'],
+			}
+			const sut = new AnalyticsService()
+			await sut._waitForInitForTests()
+
+			sut.identify('staff-2', { plan: 'pro' })
+
+			// Person-level: identify carries internal_traffic alongside the
+			// original (sanitized) properties.
+			expect(posthogStub.identify).toHaveBeenCalledTimes(1)
+			expect(posthogStub.identify).toHaveBeenCalledWith('staff-2', {
+				plan: 'pro',
+				internal_traffic: true,
+			})
+			// Event-level: super-property stamps every future capture.
+			expect(posthogStub.register).toHaveBeenCalledTimes(1)
+			expect(posthogStub.register).toHaveBeenCalledWith({
+				internal_traffic: true,
+			})
+			// Merge contract preserved — no reset() on the identify path.
+			expect(posthogStub.reset).not.toHaveBeenCalled()
+		})
+
+		it('tags an allowlisted user with no identify properties', async () => {
+			mockConfig.current = {
+				...mockConfig.current,
+				internalTrafficUserIds: ['staff-1'],
+			}
+			const sut = new AnalyticsService()
+			await sut._waitForInitForTests()
+
+			sut.identify('staff-1')
+
+			expect(posthogStub.identify).toHaveBeenCalledWith('staff-1', {
+				internal_traffic: true,
+			})
+			expect(posthogStub.register).toHaveBeenCalledWith({
+				internal_traffic: true,
+			})
+		})
+
+		it('does NOT tag a non-internal user (id absent from a populated allowlist)', async () => {
+			mockConfig.current = {
+				...mockConfig.current,
+				internalTrafficUserIds: ['staff-1', 'staff-2'],
+			}
+			const sut = new AnalyticsService()
+			await sut._waitForInitForTests()
+
+			sut.identify('user-123', { plan: 'pro' })
+
+			// Normal user: identify carries only the original props, no marker.
+			expect(posthogStub.identify).toHaveBeenCalledTimes(1)
+			expect(posthogStub.identify).toHaveBeenCalledWith('user-123', {
+				plan: 'pro',
+			})
+			expect(posthogStub.register).not.toHaveBeenCalled()
+		})
+
+		it('does NOT tag any user when the allowlist is empty', async () => {
+			mockConfig.current = { ...mockConfig.current, internalTrafficUserIds: [] }
+			const sut = new AnalyticsService()
+			await sut._waitForInitForTests()
+
+			sut.identify('user-123')
+
+			expect(posthogStub.identify).toHaveBeenCalledWith('user-123', undefined)
+			expect(posthogStub.register).not.toHaveBeenCalled()
+		})
+
+		it('treats a missing internalTrafficUserIds config field as empty (no crash, no tagging)', async () => {
+			// Simulate the loader default: a `config.json` without the field is
+			// normalised to an empty array, so the service must not crash and
+			// must not tag anyone.
+			mockConfig.current = {
+				posthogProjectKey: 'phc_test_key',
+				posthogApiHost: 'https://eu.i.posthog.com',
+				internalTrafficUserIds: [],
+			}
+			const sut = new AnalyticsService()
+			await sut._waitForInitForTests()
+
+			expect(() => sut.identify('user-123')).not.toThrow()
+			expect(posthogStub.identify).toHaveBeenCalledWith('user-123', undefined)
+			expect(posthogStub.register).not.toHaveBeenCalled()
+		})
+
+		it('tags a pre-init (buffered) identify for an internal user once the SDK loads', async () => {
+			mockConfig.current = {
+				...mockConfig.current,
+				internalTrafficUserIds: ['staff-1'],
+			}
+			const sut = new AnalyticsService()
+
+			// identify fires BEFORE init resolves — the marker must survive the
+			// buffered/replay path.
+			sut.identify('staff-1', { plan: 'pro' })
+			expect(posthogStub.identify).not.toHaveBeenCalled()
+
+			await sut._waitForInitForTests()
+
+			expect(posthogStub.identify).toHaveBeenCalledTimes(1)
+			expect(posthogStub.identify).toHaveBeenCalledWith('staff-1', {
+				plan: 'pro',
+				internal_traffic: true,
+			})
+			expect(posthogStub.register).toHaveBeenCalledWith({
+				internal_traffic: true,
+			})
 			expect(posthogStub.reset).not.toHaveBeenCalled()
 		})
 	})

--- a/src/lib/analytics/analytics-service.ts
+++ b/src/lib/analytics/analytics-service.ts
@@ -140,6 +140,7 @@ export class AnalyticsService implements IAnalyticsService {
 	private pendingIdentify: {
 		userId: string
 		properties?: Readonly<Record<string, unknown>>
+		internal: boolean
 	} | null = null
 
 	/**
@@ -205,19 +206,25 @@ export class AnalyticsService implements IAnalyticsService {
 			properties === undefined
 				? undefined
 				: sanitizeEventProps('identify', properties, this.logger)
-		this.pendingIdentify = { userId, properties: safeProps }
+		// Resolve the STABLE internal-identity marker: a user whose id is in
+		// the configured allowlist is tagged `internal_traffic: true` so
+		// production funnels / retention can filter the session out without
+		// discarding it. NOT a heuristic — purely the configured list.
+		const internal = this.isInternalUserId(userId)
+		this.pendingIdentify = { userId, properties: safeProps, internal }
 
 		if (this.posthog === null) {
 			// Pre-init identify is intentionally dropped from the SDK path
 			// rather than queued; the pendingIdentify buffer carries the
-			// request and `init()` consults it after the SDK loads.
+			// request (and its internal flag) and `init()` consults it after
+			// the SDK loads, so a pre-init internal identify is still tagged.
 			this.logger.debug('identify deferred to SDK init', { userId })
 			return
 		}
 		// IMPORTANT: no preceding reset() — the anonymous pre-identification
 		// history MERGES into the identified profile so pre-signup discovery
 		// stays connected to post-signup conversion.
-		this.posthog.identify(userId, safeProps)
+		this.applyIdentify(userId, safeProps, internal)
 	}
 
 	public reset(): void {
@@ -513,7 +520,45 @@ export class AnalyticsService implements IAnalyticsService {
 		const buffered = this.pendingIdentify
 		if (buffered === null) return
 		this.pendingIdentify = null
-		this.posthog.identify(buffered.userId, buffered.properties)
+		this.applyIdentify(buffered.userId, buffered.properties, buffered.internal)
+	}
+
+	/**
+	 * The single place that calls `posthog.identify`. Applies the
+	 * `internal_traffic` marker for an allowlisted (internal) user:
+	 *   - adds `internal_traffic: true` as a PERSON property on the identify
+	 *     call (person-level dashboard filters), AND
+	 *   - registers it as a SUPER property so every subsequently captured
+	 *     event also carries `internal_traffic: true` (event-level filters).
+	 *
+	 * The flag is a plain boolean — not PII — so it intentionally bypasses the
+	 * 要配慮 sensitive-property filter (which only touches event payloads) and
+	 * survives into PostHog unchanged. A non-internal user takes the
+	 * unchanged path: no extra property, no register call.
+	 */
+	private applyIdentify(
+		userId: string,
+		properties: Readonly<Record<string, unknown>> | undefined,
+		internal: boolean,
+	): void {
+		if (this.posthog === null) return
+		if (!internal) {
+			this.posthog.identify(userId, properties)
+			return
+		}
+		this.posthog.identify(userId, { ...properties, internal_traffic: true })
+		// Super-property: stamps every future capture so event-level filters
+		// (not just person-level) can exclude internal traffic.
+		this.posthog.register({ internal_traffic: true })
+	}
+
+	/**
+	 * True iff `userId` is in the configured internal-traffic allowlist. The
+	 * empty / missing-config case (the normal production user) returns false,
+	 * so no marker is applied.
+	 */
+	private isInternalUserId(userId: string): boolean {
+		return this.config.internalTrafficUserIds.includes(userId)
 	}
 
 	/**

--- a/test/helpers/mock-app-config.ts
+++ b/test/helpers/mock-app-config.ts
@@ -16,6 +16,7 @@ export function createMockAppConfig(overrides?: Partial<AppConfig>): AppConfig {
 		previewArtistIds: [],
 		previewArtistNames: [],
 		logLevel: 'warn',
+		internalTrafficUserIds: [],
 		...overrides,
 	}
 }


### PR DESCRIPTION
## Description

Implements the SDK-level part of OpenSpec tasks **15.1 / 15.2** — tag known-internal (E2E / staff) users so production funnels & retention dashboards can filter them out, based on a **stable marker** (a configured allowlist of platform `UserId`s), not heuristics.

- **`AppConfig.internalTrafficUserIds`** — new runtime `config.json` field, ops-populated per environment. A missing/`null` field normalizes to an empty list (strict no-op; nobody tagged, no crash); a malformed value throws loudly at boot, matching the existing config posture.
- **`AnalyticsService.identify`** — for an allowlisted user, tags `internal_traffic: true` as a PostHog **person property** AND a registered **super-property** (so both person- and event-level dashboard filters can exclude them). Non-internal users and the empty default are unchanged — no extra property, no `register` call. The buffered/pre-init identify path carries the flag too. No `reset()` added (anonymous→identified merge preserved).

Tagging (not suppression) retains the data while keeping it filterable, per the `product-analytics` spec. PostHog-side dashboard filtering + the actual ID population are documented in the runbook (task 15.3, separate spec PR).

## Type of Change
- [x] feat: A new feature

## Verification
- [x] `make check` passed (lint + typecheck + stylelint + test + build + bundle-isolation).
- [x] Tests: internal id → identify(internal_traffic:true) + register; non-internal / empty list → neither; missing config field → empty (no crash); buffered pre-init internal identify tagged on replay.

## Self-Checklist
- [x] Follows project TS/Aurelia conventions; minimal change.
- [x] Self-reviewed; no new warnings in touched files.
