### PR TITLE
feat(ui): add tap/press feedback to touch controls

### DIFF
--- a/src/components/bottom-nav-bar/bottom-nav-bar.css
+++ b/src/components/bottom-nav-bar/bottom-nav-bar.css
@@ -50,7 +50,18 @@
 
 			transition:
 				color var(--transition-normal),
-				box-shadow var(--transition-normal);
+				box-shadow var(--transition-normal),
+				transform var(--transition-normal);
+		}
+
+		/* Press cue at the moment of tap. The nav tabs are <a> elements the global
+		   <button> baseline cannot reach, so the press feedback is defined here.
+		   Distinct from the persistent [data-active] selected-tab state — this is
+		   transient on touch. Large-target scale magnitude (matches the FAB). */
+		.nav-tab:active {
+			/* Press-in phase: fast ease-in. */
+			transform: scale(0.92);
+			transition: transform 50ms ease-in;
 		}
 
 		.nav-icon {
@@ -98,6 +109,15 @@
 		.nav-tab[data-dimmed] {
 			opacity: 0.3;
 			transition: opacity var(--transition-normal);
+		}
+
+		/* Reduced motion: drop the press scale, acknowledge the tap with a brief
+		   accent-tinted background instead. */
+		@media (prefers-reduced-motion: reduce) {
+			.nav-tab:active {
+				transform: none;
+				background: oklch(from var(--color-brand-accent) l c h / 12%);
+			}
 		}
 	}
 }

--- a/src/routes/settings/settings-route.css
+++ b/src/routes/settings/settings-route.css
@@ -101,6 +101,15 @@
 			&:hover {
 				background: color-mix(in oklch, var(--_hover-bg) 5%, transparent);
 			}
+
+			/* A full-width row reads better with a background-deepen than a scale.
+			   transform: none suppresses the global <button> baseline scale so a
+			   <button>.settings-row and an <a>.settings-row feel identical. The
+			   background-deepen needs no scale to suppress under reduced motion. */
+			&:active {
+				transform: none;
+				background: color-mix(in oklch, var(--_hover-bg) 10%, transparent);
+			}
 		}
 
 		/* Column placement. Each property targets whichever element is a DIRECT

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -53,7 +53,18 @@
 
 		transition:
 			background-color var(--transition-fast) ease-out,
-			opacity var(--transition-fast) ease-out;
+			opacity var(--transition-fast) ease-out,
+			transform var(--transition-fast) ease-out;
+	}
+
+	/* App-wide press-feedback baseline: every native button acknowledges a touch
+	   on :active so no per-component code is needed. Wrapped in :where() for zero
+	   specificity so components that define their own :active in @layer block keep
+	   precedence; :not(:disabled) leaves disabled controls inert. */
+	:where(button:active:not(:disabled)) {
+		/* Press-in phase: fast ease-in, matching the existing component convention. */
+		transform: scale(0.97);
+		transition: transform 50ms ease-in;
 	}
 
 	:where(input, textarea, select) {
@@ -109,6 +120,15 @@
 		:where(svg) {
 			fill: CanvasText;
 			stroke: CanvasText;
+		}
+	}
+
+	/* Reduced motion: drop the button press scale but keep a non-motion
+	   acknowledgement so the tap still registers. */
+	@media (prefers-reduced-motion: reduce) {
+		:where(button:active:not(:disabled)) {
+			transform: none;
+			opacity: 0.7;
 		}
 	}
 }

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -151,10 +151,27 @@
 
 		background: var(--color-brand-primary);
 
-		transition: background-color 150ms ease-out;
+		transition:
+			background-color 150ms ease-out,
+			transform 150ms ease-out;
 
 		&:hover {
 			background: oklch(from var(--color-brand-primary) l c h / 80%);
+		}
+
+		/* The discover CTA is an <a> styled as a primary button, so the global
+		   <button> baseline cannot reach it — give it the same press cue here. */
+		&:active {
+			/* Press-in phase: fast ease-in, consistent with the button baseline. */
+			transform: scale(0.97);
+			transition: transform 50ms ease-in;
+		}
+
+		@media (prefers-reduced-motion: reduce) {
+			&:active {
+				transform: none;
+				opacity: 0.7;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

The app is a touch-first PWA, but tapping a button or tab gave no press feedback. `:hover` is rich yet inert on touch, most controls had no `:active` state, and the reset clears `-webkit-tap-highlight-color` — so even the browser's default tap flash was gone. Primary controls (bottom-nav tabs, the dashboard "Discover" CTA) felt dead on the exact devices the app targets.

This is a **CSS-only** change. No proto/backend/API change, no new dependencies, no breaking changes.

## Changes

- **`src/styles/global.css`** — app-wide press baseline: `:where(button:active:not(:disabled))` scale-down (`0.97`, ~50ms ease-in) so every native `<button>` responds with zero per-component code. Lives in `@layer global` at zero specificity, so the components that already define their own `:active` in `@layer block` keep precedence. `:not(:disabled)` keeps disabled controls inert. Reduced-motion fallback drops the scale, keeps an opacity cue.
- **`src/components/bottom-nav-bar/bottom-nav-bar.css`** — `.nav-tab:active` press cue (`scale(0.92)`, large-target magnitude), distinct from the persistent selected-tab state. These are `<a>` elements the button baseline cannot reach. Reduced-motion fallback uses a brief accent-tinted background.
- **`src/styles/utilities.css`** — `.discover-cta:active` press cue (the anchor-based primary CTA), with reduced-motion fallback.
- **`src/routes/settings/settings-route.css`** — `.settings-row:active` deepens the row background instead of scaling (`transform: none` suppresses the global scale), so button-rows and anchor-rows feel identical.

All cues reuse the existing project convention (`transform: scale(...)` + fast ~50ms ease-in) and honor `prefers-reduced-motion: reduce`.

## Testing

- `make lint` green (Biome + stylelint + typecheck + brand-vocabulary); 0 new stylelint warnings (verified against base).
- Cascade check: button baseline is zero-specificity in `@layer global`, so the 7 components with their own `:active` in `@layer block` are unchanged.

Closes #470
