### PR TITLE
refactor(routes): make menu-tab navigation non-blocking

### DIFF
--- a/src/routes/dashboard/dashboard-route.spec.ts
+++ b/src/routes/dashboard/dashboard-route.spec.ts
@@ -362,14 +362,14 @@ describe('DashboardRoute', () => {
 		})
 	})
 
-	describe('maybeCelebrate (via attached / onHomeSelected)', () => {
-		it('shows the guest light celebration (no confetti) on first dashboard arrival', () => {
+	describe('maybeCelebrate (via observed data arrival / onHomeSelected)', () => {
+		it('shows the guest light celebration (no confetti) on first dashboard arrival', async () => {
 			mockAuth.isAuthenticated = false
 			mockOnboarding.isOnboarding = true
 			sut = new DashboardRoute()
 			sut.needsRegion = false
 
-			sut.attached()
+			await sut.loadData()
 
 			expect(sut.showCelebration).toBe(true)
 			expect(sut.celebrationConfetti).toBe(false)
@@ -381,13 +381,13 @@ describe('DashboardRoute', () => {
 			)
 		})
 
-		it('persists the one-shot flag for a guest only once the overlay opens', () => {
+		it('persists the one-shot flag for a guest only once the overlay opens', async () => {
 			mockAuth.isAuthenticated = false
 			mockOnboarding.isOnboarding = true
 			sut = new DashboardRoute()
 			sut.needsRegion = false
 
-			sut.attached()
+			await sut.loadData()
 			expect(mockStorage.setItem).not.toHaveBeenCalledWith(
 				'onboarding.celebrationShown',
 				'1',
@@ -401,7 +401,7 @@ describe('DashboardRoute', () => {
 			)
 		})
 
-		it('does not burn the one-shot flag when the overlay is suppressed', () => {
+		it('does not burn the one-shot flag when the overlay is suppressed', async () => {
 			// A suppressed overlay (never opened) must leave the flag untouched so the
 			// celebration can still appear on a later eligible arrival.
 			mockAuth.isAuthenticated = false
@@ -409,7 +409,7 @@ describe('DashboardRoute', () => {
 			sut = new DashboardRoute()
 			sut.needsRegion = false
 
-			sut.attached()
+			await sut.loadData()
 
 			expect(sut.showCelebration).toBe(false)
 			expect(mockStorage.setItem).not.toHaveBeenCalledWith(
@@ -430,18 +430,18 @@ describe('DashboardRoute', () => {
 			)
 		})
 
-		it('does not show the light celebration for a completed guest (not onboarding)', () => {
+		it('does not show the light celebration for a completed guest (not onboarding)', async () => {
 			mockAuth.isAuthenticated = false
 			mockOnboarding.isOnboarding = false
 			sut = new DashboardRoute()
 			sut.needsRegion = false
 
-			sut.attached()
+			await sut.loadData()
 
 			expect(sut.showCelebration).toBe(false)
 		})
 
-		it('does not replay the guest light celebration once shown', () => {
+		it('does not replay the guest light celebration once shown', async () => {
 			mockAuth.isAuthenticated = false
 			mockOnboarding.isOnboarding = true
 			mockStorage.getItem.mockImplementation((k: string) =>
@@ -450,18 +450,20 @@ describe('DashboardRoute', () => {
 			sut = new DashboardRoute()
 			sut.needsRegion = false
 
-			sut.attached()
+			await sut.loadData()
 
 			expect(sut.showCelebration).toBe(false)
 		})
 
-		it('defers the celebration while a region is still needed', () => {
+		it('defers the celebration while a region is still needed', async () => {
 			mockAuth.isAuthenticated = false
 			mockOnboarding.isOnboarding = true
 			sut = new DashboardRoute()
 			sut.needsRegion = true
 
-			sut.attached()
+			// Even though data arrives, the gated handler must not celebrate over a
+			// region-less (blurred) timetable.
+			await sut.loadData()
 
 			expect(sut.showCelebration).toBe(false)
 		})
@@ -481,7 +483,7 @@ describe('DashboardRoute', () => {
 			expect(sut.celebrationConfetti).toBe(false)
 		})
 
-		it('shows the post-signup full celebration (confetti) then the dialog', () => {
+		it('shows the post-signup full celebration (confetti) then the dialog', async () => {
 			mockAuth.isAuthenticated = true
 			mockStorage.getItem.mockImplementation((k: string) =>
 				k === 'liverty:postSignup:shown' ? 'pending' : null,
@@ -489,7 +491,7 @@ describe('DashboardRoute', () => {
 			sut = new DashboardRoute()
 			sut.needsRegion = false
 
-			sut.attached()
+			await sut.loadData()
 
 			expect(sut.showCelebration).toBe(true)
 			expect(sut.celebrationConfetti).toBe(true)
@@ -504,31 +506,50 @@ describe('DashboardRoute', () => {
 			expect(sut.showPostSignupDialog).toBe(true)
 		})
 
-		it('does not celebrate for an authenticated returning user', () => {
+		it('does not celebrate for an authenticated returning user', async () => {
 			mockAuth.isAuthenticated = true
 			sut = new DashboardRoute()
 			sut.needsRegion = false
 
+			await sut.loadData()
+
+			expect(sut.showCelebration).toBe(false)
+		})
+
+		it('does not celebrate over a still-loading timetable (data not yet arrived)', () => {
+			mockAuth.isAuthenticated = true
+			mockStorage.getItem.mockImplementation((k: string) =>
+				k === 'liverty:postSignup:shown' ? 'pending' : null,
+			)
+			// Fetch never resolves → timetableLoaded never flips.
+			mockConcertService.listByFollower.mockReturnValueOnce(
+				new Promise(() => {}),
+			)
+			sut = new DashboardRoute()
+			sut.needsRegion = false
+
+			void sut.loadData()
 			sut.attached()
 
+			expect(sut.isLoading).toBe(true)
 			expect(sut.showCelebration).toBe(false)
 		})
 	})
 
-	describe('completion latch (finish via attached / onHomeSelected)', () => {
-		it('latches finish() on a meaningful first arrival (region set, data loaded, followedCount >= 1)', () => {
+	describe('completion latch (finish via observed data arrival / onHomeSelected)', () => {
+		it('latches finish() on a meaningful first arrival (region set, data loaded, followedCount >= 1)', async () => {
 			mockAuth.isAuthenticated = false
 			mockOnboarding.isOnboarding = true
 			mockFollowStore.followedCount = 1
 			sut = new DashboardRoute()
 			sut.needsRegion = false
 
-			sut.attached()
+			await sut.loadData()
 
 			expect(mockOnboarding.finish).toHaveBeenCalledTimes(1)
 		})
 
-		it('still latches when the celebration is suppressed (celebrationShown === "1")', () => {
+		it('still latches when the celebration is suppressed (celebrationShown === "1")', async () => {
 			mockAuth.isAuthenticated = false
 			mockOnboarding.isOnboarding = true
 			mockFollowStore.followedCount = 3
@@ -538,7 +559,7 @@ describe('DashboardRoute', () => {
 			sut = new DashboardRoute()
 			sut.needsRegion = false
 
-			sut.attached()
+			await sut.loadData()
 
 			// Celebration is suppressed but the latch is driven by data-ready +
 			// engaged, not by the overlay rendering.
@@ -546,15 +567,31 @@ describe('DashboardRoute', () => {
 			expect(mockOnboarding.finish).toHaveBeenCalledTimes(1)
 		})
 
-		it('does NOT latch on a zero-follow arrival', () => {
+		it('does NOT latch on a zero-follow arrival', async () => {
 			mockAuth.isAuthenticated = false
 			mockOnboarding.isOnboarding = true
 			mockFollowStore.followedCount = 0
 			sut = new DashboardRoute()
 			sut.needsRegion = false
 
-			sut.attached()
+			await sut.loadData()
 
+			expect(mockOnboarding.finish).not.toHaveBeenCalled()
+		})
+
+		it('does NOT latch while the load is still in flight (data not yet arrived)', () => {
+			mockAuth.isAuthenticated = false
+			mockOnboarding.isOnboarding = true
+			mockFollowStore.followedCount = 2
+			mockConcertService.listByFollower.mockReturnValueOnce(
+				new Promise(() => {}),
+			)
+			sut = new DashboardRoute()
+			sut.needsRegion = false
+
+			void sut.loadData()
+
+			expect(sut.isLoading).toBe(true)
 			expect(mockOnboarding.finish).not.toHaveBeenCalled()
 		})
 

--- a/src/routes/dashboard/dashboard-route.ts
+++ b/src/routes/dashboard/dashboard-route.ts
@@ -26,6 +26,12 @@ export class DashboardRoute {
 	@observable public filteredStatuses: JourneyStatus[] = []
 	public needsRegion = false
 	public isLoading = false
+	// Readiness latch flipped true by loadData() once a successful (non-abort)
+	// fetch settles and isLoading has cleared. Its @observable change handler
+	// re-anchors the data-ready side effects (celebration + completion latch) to
+	// observed data arrival, replacing the old attached()-timing assumption that
+	// loading() had already awaited the fetch.
+	@observable public timetableLoaded = false
 	public loadError: unknown = null
 	public showSignupBanner = false
 	public showPostSignupDialog = false
@@ -175,14 +181,14 @@ export class DashboardRoute {
 			this.needsRegion = !UserHomeSelector.getStoredHome()
 		}
 
-		// When region is set, await data so stage headers exist by attached().
-		// When needsRegion, data can't load yet (API returns [] without homeCode),
-		// so fire-and-forget — the @watch handler will react when data arrives.
-		if (this.needsRegion) {
-			void this.loadData()
-		} else {
-			await this.loadData()
-		}
+		// Fire-and-forget the fetch in BOTH branches so the router attaches this
+		// view immediately (render-then-fetch) instead of freezing the outgoing
+		// screen until the RPC resolves. The data-ready side effects no longer
+		// depend on the fetch being awaited here — they fire when timetableLoaded
+		// is observed to flip true (see timetableLoadedChanged). When needsRegion,
+		// the API returns [] without a homeCode anyway; the real load runs from
+		// onHomeSelected() once the region is chosen.
+		void this.loadData()
 
 		// Show signup banner for unauthenticated users who completed onboarding
 		if (!this.authService.isAuthenticated && this.onboarding.isCompleted) {
@@ -195,14 +201,20 @@ export class DashboardRoute {
 		this.abortController = new AbortController()
 		this.loadError = null
 		this.isLoading = true
+		// Reset so every load produces a fresh false→true transition; the
+		// needsRegion→onHomeSelected path loads twice and the second arrival must
+		// still re-fire the gated handler.
+		this.timetableLoaded = false
 		const signal = this.abortController.signal
 
+		let succeeded = false
 		try {
 			this.dateGroups = await this.loadDashboardEvents(signal)
 			this.loadError = null
 			this.logger.info('Dashboard loaded', {
 				groups: this.dateGroups.length,
 			})
+			succeeded = true
 		} catch (err) {
 			if ((err as Error).name === 'AbortError') return
 			this.logger.error('Failed to load dashboard', { error: err })
@@ -211,6 +223,14 @@ export class DashboardRoute {
 			}
 		} finally {
 			this.isLoading = false
+		}
+
+		// Flip AFTER isLoading clears so the gated handler never evaluates the
+		// celebration over a still-loading spinner. Only on a genuine (non-abort)
+		// successful load — an aborted load returns early above and leaves this
+		// false so a stale arrival can't fire the celebration.
+		if (succeeded) {
+			this.timetableLoaded = true
 		}
 	}
 
@@ -255,14 +275,24 @@ export class DashboardRoute {
 		if (this.needsRegion) {
 			this.homeSelector?.open()
 		}
+		// The celebration + completion-latch decisions are NO LONGER run here.
+		// loading() now fires the fetch non-blocking, so attached() can run while
+		// the timetable is still a spinner. The decisions are re-anchored to
+		// observed data arrival via timetableLoadedChanged().
+	}
 
-		// Run the celebration + completion-latch decisions once the timetable is
-		// real. While needsRegion is true the home-selector is open and the
-		// timetable is blurred, so this is deferred to onHomeSelected(); otherwise
-		// data was already awaited in loading().
-		if (!this.needsRegion) {
-			this.onTimetableReady()
-		}
+	/**
+	 * Re-anchor the data-ready side effects to observed data arrival. loadData()
+	 * flips timetableLoaded true once a successful fetch settles AND isLoading has
+	 * cleared, from BOTH arrival paths (loading()-driven and onHomeSelected-driven),
+	 * so the celebration never renders over a spinner and the completion latch
+	 * never reads not-yet-loaded engagement data. Guarded so it only acts on the
+	 * true edge and only when the timetable is genuinely real.
+	 */
+	protected timetableLoadedChanged(loaded: boolean): void {
+		if (!loaded) return
+		if (this.needsRegion || this.isLoading) return
+		this.onTimetableReady()
 	}
 
 	public async onHomeSelected(code: string): Promise<void> {
@@ -271,10 +301,10 @@ export class DashboardRoute {
 		if (!this.authService.isAuthenticated) {
 			this.userStore.setGuestHome(code)
 		}
+		// Timetable becomes real once the region is chosen; loadData() flips
+		// timetableLoaded → timetableLoadedChanged() runs the deferred celebration
+		// + completion-latch decisions. No explicit call needed here.
 		await this.loadData()
-		// Timetable is now real (region was just selected) — run the deferred
-		// celebration + completion-latch decisions.
-		this.onTimetableReady()
 	}
 
 	/**

--- a/src/routes/discovery/discovery-route.ts
+++ b/src/routes/discovery/discovery-route.ts
@@ -136,9 +136,11 @@ export class DiscoveryRoute {
 		}
 	}
 
-	public async loading(): Promise<void> {
+	public loading(): void {
 		this.logger.info('Loading discovery page')
 
+		// Synchronous onboarding hydrate prelude runs before the fetch so seeded
+		// follows are present when the bubble field loads.
 		if (this.isOnboarding) {
 			const persisted = this.followStore.guestFollows
 			if (persisted.length > 0) {
@@ -146,6 +148,26 @@ export class DiscoveryRoute {
 			}
 		}
 
+		// Fire-and-forget the initial bubble load so the router attaches this view
+		// immediately. The canvas seeds bubbles order-independently (artistsChanged
+		// with its !this.ctx guard + the attached() seed), so they render whether
+		// the data resolves before or after attach.
+		void this.loadInitialBubbles()
+
+		// Resume concert search for pre-seeded follows (fire concurrently)
+		if (this.isOnboarding) {
+			for (const f of this.followStore.guestFollows) {
+				void this.searchConcertsForArtist(f.artist.id, f.artist.name)
+			}
+		}
+	}
+
+	/**
+	 * Load the initial bubble field. Returns a Promise so production fires it
+	 * non-blocking (`void this.loadInitialBubbles()`) while tests await it
+	 * deterministically. A failure surfaces a Snack and is swallowed.
+	 */
+	public async loadInitialBubbles(): Promise<void> {
 		try {
 			await this.bubbles.loadInitialArtists(
 				this.followStore.followedArtists,
@@ -155,13 +177,6 @@ export class DiscoveryRoute {
 		} catch (err) {
 			this.logger.error('Failed to load initial artists', err)
 			this.ea.publish(new Snack(this.i18n.tr('discovery.loadFailed'), 'error'))
-		}
-
-		// Resume concert search for pre-seeded follows (fire concurrently)
-		if (this.isOnboarding) {
-			for (const f of this.followStore.guestFollows) {
-				void this.searchConcertsForArtist(f.artist.id, f.artist.name)
-			}
 		}
 	}
 

--- a/src/routes/my-artists/my-artists-route.ts
+++ b/src/routes/my-artists/my-artists-route.ts
@@ -61,8 +61,33 @@ export class MyArtistsRoute {
 	}
 
 	public async loading(): Promise<void> {
+		// Synchronous prelude only — set before first paint. The fetch is kicked
+		// off non-blocking so the router attaches this view immediately instead of
+		// holding the outgoing screen frozen until the RPC resolves. The
+		// AbortController is owned by loadArtists() (single owner): creating it
+		// here too would let loadArtists()'s abort-first abort the just-created
+		// controller, AbortError-ing the very first load.
 		this.isLoading = true
+		void this.loadArtists()
+
+		// Signup banner visible for any guest user on this page (during AND after
+		// onboarding) — per signup-prompt-banner capability "Banner appears for
+		// guest user during onboarding" / "after onboarding" scenarios.
+		if (!this.isAuthenticated) {
+			this.showSignupBanner = true
+		}
+	}
+
+	/**
+	 * Fetch followed artists. Owns the request AbortController (abort-first then
+	 * create), mirroring dashboard-route.ts's loadData(). Returns a Promise so
+	 * production can fire-and-forget it (`void this.loadArtists()`) while tests
+	 * await it deterministically.
+	 */
+	public async loadArtists(): Promise<void> {
+		this.abortController?.abort()
 		this.abortController = new AbortController()
+		this.isLoading = true
 
 		try {
 			const followed = await this.followStore.listFollowed(
@@ -82,13 +107,6 @@ export class MyArtistsRoute {
 			}
 		} finally {
 			this.isLoading = false
-		}
-
-		// Signup banner visible for any guest user on this page (during AND after
-		// onboarding) — per signup-prompt-banner capability "Banner appears for
-		// guest user during onboarding" / "after onboarding" scenarios.
-		if (!this.isAuthenticated) {
-			this.showSignupBanner = true
 		}
 	}
 

--- a/test/routes/dashboard-route.spec.ts
+++ b/test/routes/dashboard-route.spec.ts
@@ -206,38 +206,26 @@ describe('DashboardRoute', () => {
 			await sut.loading()
 			expect(sut.showSignupBanner).toBe(false)
 		})
+
+		it('is non-blocking: resolves before the data fetch settles, isLoading true at attach', async () => {
+			mockAuth.isAuthenticated = true
+			mockUser.current = { home: { countryCode: 'JP', level1: 'JP-13' } }
+			// Fetch never resolves → the timetable would stay a spinner.
+			mockConcert.listByFollower.mockReturnValue(new Promise(() => {}))
+			sut = buildSut()
+
+			await sut.loading()
+
+			// loading() resolved without awaiting the fetch: region is computed and
+			// the spinner is showing.
+			expect(sut.needsRegion).toBe(false)
+			expect(sut.isLoading).toBe(true)
+		})
 	})
 
 	// ---- attached() ----
 
 	describe('attached', () => {
-		it('shows the post-signup celebration then opens the dialog on dismissal', () => {
-			mockAuth.isAuthenticated = true
-			mockStorage = createMockLocalStorage({
-				[StorageKeys.postSignupShown]: 'pending',
-			})
-			sut = buildSut()
-
-			sut.attached()
-
-			// Emotion first: confetti celebration; dialog deferred until dismissal.
-			expect(sut.showCelebration).toBe(true)
-			expect(sut.celebrationConfetti).toBe(true)
-			expect(mockStorage.removeItem).toHaveBeenCalledWith(
-				StorageKeys.postSignupShown,
-			)
-			expect(sut.showPostSignupDialog).toBe(false)
-
-			sut.onCelebrationDismissed()
-
-			expect(sut.showPostSignupDialog).toBe(true)
-		})
-
-		it('does not show postSignupDialog when flag is absent', () => {
-			sut.attached()
-			expect(sut.showPostSignupDialog).toBe(false)
-		})
-
 		it('opens home selector when needsRegion is true', () => {
 			sut.needsRegion = true
 			const mockHomeSelector = { open: vi.fn() }
@@ -258,36 +246,102 @@ describe('DashboardRoute', () => {
 			expect(mockHomeSelector.open).not.toHaveBeenCalled()
 		})
 
-		it('latches finish() on a meaningful first dashboard arrival (onboarding + follows + region set)', () => {
+		it('does not fire the celebration at attached() while the load is still in flight', () => {
+			mockAuth.isAuthenticated = true
+			mockStorage = createMockLocalStorage({
+				[StorageKeys.postSignupShown]: 'pending',
+			})
+			// Fetch never resolves → timetable stays a spinner.
+			mockConcert.listByFollower.mockReturnValue(new Promise(() => {}))
+			sut = buildSut()
+			sut.needsRegion = false
+
+			void sut.loadData()
+			sut.attached()
+
+			// attached() ran over a still-loading timetable: no celebration over a spinner.
+			expect(sut.isLoading).toBe(true)
+			expect(sut.showCelebration).toBe(false)
+		})
+	})
+
+	// ---- data-ready side effects (gated on observed data arrival) ----
+
+	describe('data-ready side effects', () => {
+		it('shows the post-signup celebration on observed data arrival, then opens the dialog on dismissal', async () => {
+			mockAuth.isAuthenticated = true
+			mockStorage = createMockLocalStorage({
+				[StorageKeys.postSignupShown]: 'pending',
+			})
+			sut = buildSut()
+			sut.needsRegion = false
+
+			await sut.loadData()
+
+			// Emotion first: confetti celebration; dialog deferred until dismissal.
+			expect(sut.showCelebration).toBe(true)
+			expect(sut.celebrationConfetti).toBe(true)
+			expect(mockStorage.removeItem).toHaveBeenCalledWith(
+				StorageKeys.postSignupShown,
+			)
+			expect(sut.showPostSignupDialog).toBe(false)
+
+			sut.onCelebrationDismissed()
+
+			expect(sut.showPostSignupDialog).toBe(true)
+		})
+
+		it('does not show postSignupDialog when flag is absent', async () => {
+			sut.needsRegion = false
+
+			await sut.loadData()
+
+			expect(sut.showPostSignupDialog).toBe(false)
+		})
+
+		it('latches finish() on a meaningful first dashboard arrival (onboarding + follows + region set)', async () => {
 			mockOnboarding = makeOnboarding(true)
 			mockFollow.followedCount = 1
 			sut = buildSut()
 			sut.needsRegion = false
 
-			sut.attached()
+			await sut.loadData()
 
 			expect(mockOnboarding.finish).toHaveBeenCalledTimes(1)
 		})
 
-		it('does not latch when onboarding is already completed', () => {
+		it('does not latch when onboarding is already completed', async () => {
 			mockOnboarding = makeOnboarding(false)
 			mockFollow.followedCount = 5
 			sut = buildSut()
 			sut.needsRegion = false
 
-			sut.attached()
+			await sut.loadData()
 
 			expect(mockOnboarding.finish).not.toHaveBeenCalled()
 		})
 
-		it('does not latch on a zero-follow arrival', () => {
+		it('does not latch on a zero-follow arrival', async () => {
 			mockOnboarding = makeOnboarding(true)
 			mockFollow.followedCount = 0
 			sut = buildSut()
 			sut.needsRegion = false
 
-			sut.attached()
+			await sut.loadData()
 
+			expect(mockOnboarding.finish).not.toHaveBeenCalled()
+		})
+
+		it('does not latch while the timetable is still loading', () => {
+			mockOnboarding = makeOnboarding(true)
+			mockFollow.followedCount = 1
+			mockConcert.listByFollower.mockReturnValue(new Promise(() => {}))
+			sut = buildSut()
+			sut.needsRegion = false
+
+			void sut.loadData()
+
+			expect(sut.isLoading).toBe(true)
 			expect(mockOnboarding.finish).not.toHaveBeenCalled()
 		})
 	})

--- a/test/routes/discovery-route.spec.ts
+++ b/test/routes/discovery-route.spec.ts
@@ -149,13 +149,13 @@ describe('DiscoveryRoute', () => {
 		vi.restoreAllMocks()
 	})
 
-	describe('loading', () => {
+	describe('loadInitialBubbles', () => {
 		it('should load initial artists via artistClient.listTop', async () => {
 			;(mockArtistClient.listTop as ReturnType<typeof vi.fn>).mockResolvedValue(
 				[makeArtist('a1', 'Artist One')],
 			)
 
-			await sut.loading()
+			await sut.loadInitialBubbles()
 
 			expect(mockArtistClient.listTop).toHaveBeenCalledWith('Japan', '', 50)
 		})
@@ -165,10 +165,30 @@ describe('DiscoveryRoute', () => {
 				new Error('fail'),
 			)
 
-			await sut.loading()
+			await sut.loadInitialBubbles()
 
 			expect(mockEa.publish).toHaveBeenCalledWith(expect.any(Snack))
 			expect(mockEa.published[0].severity).toBe('error')
+		})
+	})
+
+	describe('loading', () => {
+		it('is non-blocking: returns before the initial bubble fetch settles', () => {
+			let resolveLoad: (v: Artist[]) => void = () => {}
+			;(mockArtistClient.listTop as ReturnType<typeof vi.fn>).mockReturnValue(
+				new Promise((r) => {
+					resolveLoad = r
+				}),
+			)
+
+			// loading() returns synchronously (void) without awaiting the fetch, so
+			// the router attaches the view immediately.
+			const result = sut.loading()
+
+			expect(result).toBeUndefined()
+			expect(mockArtistClient.listTop).toHaveBeenCalled()
+
+			resolveLoad([])
 		})
 
 		it('should call listConcerts (not searchNewConcerts) for pre-seeded guest follows during onboarding', async () => {
@@ -474,7 +494,7 @@ describe('DiscoveryRoute', () => {
 			;(mockArtistClient.listTop as ReturnType<typeof vi.fn>).mockResolvedValue(
 				initial,
 			)
-			await sut.loading()
+			await sut.loadInitialBubbles()
 
 			// Mock canvas bubbleCount to match pool
 			;(sut.dnaOrbCanvas as never as { bubbleCount: number }).bubbleCount = 50
@@ -548,12 +568,12 @@ describe('DiscoveryRoute', () => {
 
 			await sut.onFollowFromSearch(makeArtist('f1', 'Followed One'))
 
-			// Now loading should call listSimilar (seed) instead of listTop
+			// Now the initial load should call listSimilar (seed) instead of listTop
 			;(
 				mockArtistClient.listSimilar as ReturnType<typeof vi.fn>
 			).mockResolvedValue([makeArtist('s1', 'Seed Similar')])
 
-			await sut.loading()
+			await sut.loadInitialBubbles()
 
 			expect(mockArtistClient.listSimilar).toHaveBeenCalled()
 		})
@@ -666,7 +686,7 @@ describe('DiscoveryRoute', () => {
 				[makeArtist('a1', 'Pool Artist')],
 			)
 
-			await sut.loading()
+			await sut.loadInitialBubbles()
 
 			expect(sut.poolBubbles).toHaveLength(1)
 			expect(sut.poolBubbles[0].name).toBe('Pool Artist')

--- a/test/routes/my-artists-route.spec.ts
+++ b/test/routes/my-artists-route.spec.ts
@@ -96,9 +96,9 @@ describe('MyArtistsRoute', () => {
 		}
 	})
 
-	describe('loading', () => {
+	describe('loadArtists', () => {
 		it('should fetch and populate followed artists', async () => {
-			await sut.loading()
+			await sut.loadArtists()
 
 			expect(sut.isLoading).toBe(false)
 			expect(sut.artists).toHaveLength(3)
@@ -109,7 +109,7 @@ describe('MyArtistsRoute', () => {
 
 		it('should handle empty response', async () => {
 			mockFollowService.listFollowed.mockResolvedValue([])
-			await sut.loading()
+			await sut.loadArtists()
 
 			expect(sut.artists).toHaveLength(0)
 			expect(sut.isLoading).toBe(false)
@@ -119,7 +119,7 @@ describe('MyArtistsRoute', () => {
 			mockFollowService.listFollowed.mockRejectedValue(
 				new Error('Network error'),
 			)
-			await sut.loading()
+			await sut.loadArtists()
 
 			expect(sut.isLoading).toBe(false)
 			expect(sut.artists).toHaveLength(0)
@@ -131,13 +131,33 @@ describe('MyArtistsRoute', () => {
 				makeFollowedArtist('g-1', 'Guest Artist', 'watch'),
 			])
 
-			await sut.loading()
+			await sut.loadArtists()
 
 			expect(sut.isLoading).toBe(false)
 			expect(sut.artists).toHaveLength(1)
 			expect(sut.artists[0].artist.name).toBe('Guest Artist')
 			expect(sut.artists[0].hype).toBe('watch')
 			expect(mockFollowService.listFollowed).toHaveBeenCalled()
+		})
+	})
+
+	describe('loading', () => {
+		it('is non-blocking: resolves before the fetch settles, isLoading true at attach', async () => {
+			let resolveFetch: (v: unknown[]) => void = () => {}
+			mockFollowService.listFollowed.mockReturnValue(
+				new Promise((r) => {
+					resolveFetch = r
+				}),
+			)
+
+			await sut.loading()
+
+			// loading() resolved even though the fetch is still pending, so the
+			// view attaches immediately with the spinner visible.
+			expect(sut.isLoading).toBe(true)
+			expect(sut.artists).toHaveLength(0)
+
+			resolveFetch([makeFollowedArtist('id-1', 'RADWIMPS')])
 		})
 
 		it('should show signup banner for unauthenticated user with completed onboarding', async () => {
@@ -159,7 +179,7 @@ describe('MyArtistsRoute', () => {
 
 	describe('delete button', () => {
 		beforeEach(async () => {
-			await sut.loading()
+			await sut.loadArtists()
 		})
 
 		it('should unfollow and publish undo snack', () => {
@@ -187,7 +207,7 @@ describe('MyArtistsRoute', () => {
 			)
 			container.register(MyArtistsRoute)
 			const onboardingSut = container.get(MyArtistsRoute)
-			await onboardingSut.loading()
+			await onboardingSut.loadArtists()
 
 			onboardingSut.unfollowArtist(onboardingSut.artists[0])
 
@@ -198,7 +218,7 @@ describe('MyArtistsRoute', () => {
 	describe('undo', () => {
 		beforeEach(async () => {
 			vi.useFakeTimers()
-			await sut.loading()
+			await sut.loadArtists()
 		})
 
 		afterEach(() => {
@@ -240,7 +260,7 @@ describe('MyArtistsRoute', () => {
 
 	describe('detaching', () => {
 		it('should clean up timers and abort controller', async () => {
-			await sut.loading()
+			await sut.loadArtists()
 			sut.detaching()
 			// No errors thrown, cleanup completed
 			expect(sut.isLoading).toBe(false)
@@ -275,7 +295,7 @@ describe('MyArtistsRoute', () => {
 				)
 				container.register(MyArtistsRoute)
 				onboardingSut = container.get(MyArtistsRoute)
-				await onboardingSut.loading()
+				await onboardingSut.loadArtists()
 			})
 
 			it('applies and persists a hype change without mutating onboarding state', () => {
@@ -321,7 +341,7 @@ describe('MyArtistsRoute', () => {
 		describe('unauthenticated user', () => {
 			beforeEach(async () => {
 				mockAuth.isAuthenticated = false
-				await sut.loading()
+				await sut.loadArtists()
 			})
 
 			it('should accept hype change and persist via the follow service (guest routing is internal)', () => {
@@ -348,7 +368,7 @@ describe('MyArtistsRoute', () => {
 		describe('authenticated user', () => {
 			beforeEach(async () => {
 				mockAuth.isAuthenticated = true
-				await sut.loading()
+				await sut.loadArtists()
 			})
 
 			it('should accept hype change and call setHype RPC', () => {


### PR DESCRIPTION
## Why

Closes #469.

Tapping a bottom-nav menu tab felt slow: the outgoing screen stayed frozen until the new page's data finished loading, because each menu-tab route `await`s its network/RPC fetch inside the Aurelia router `loading()` hook — and the router blocks the view swap until `loading()` resolves.

## What changed

Menu-tab routes (My Artists, Dashboard, Discovery) no longer `await` their data fetch inside `loading()`. The synchronous prelude (toggle `isLoading`, restore filters from URL, hydrate guest state, banner flags) stays in `loading()`; the fetch is fired non-blocking so the view attaches immediately and shows its existing spinner/empty/error UI while data streams in.

- **My Artists** — extracted `loadArtists()` (owns the `AbortController`: abort-first → create → fetch with signal); `loading()` calls `void this.loadArtists()`.
- **Dashboard** — region-set branch is now `void this.loadData()`. The data-ready side effects (post-signup/guest celebration + onboarding-completion latch) are re-anchored from `attached()` timing to **observed data arrival** via an `@observable timetableLoaded` flag (`loadData()` flips it true after `isLoading` clears on a successful load). The gated handler runs from both arrival paths (load-driven and `onHomeSelected`-driven) and never fires over a still-loading spinner.
- **Discovery** — extracted `loadInitialBubbles()`, fired non-blocking; relies on the existing canvas `artistsChanged` (`!this.ctx` guard) + `attached()` seed for order-independence.

No protobuf/RPC/backend changes. No user-facing copy changes.

## Test plan

- `make test` — full suite green (1303 passing). Route specs updated to assert asynchronously in a deterministic way (`await sut.loadArtists()` / `loadInitialBubbles()` / `loadData()`) instead of timer-draining; added non-blocking coverage (`loading()` resolves before the fetch settles, `isLoading` true at attach) and "celebration only on observed data arrival, never over a spinner" coverage in both dashboard specs.
- `make lint` — clean (exit 0).
- Live Playwright check (local dev server, guest): menu-tab taps swap the view in ~30–100ms, decoupled from the routes' RPCs (which dispatch via the new extracted methods and settle later) — the frozen outgoing screen is gone.

OpenSpec change: `non-blocking-menu-navigation`.
