### PR TITLE
refactor(analytics): delete redundant concert event, standardise identifiers

### DIFF
--- a/src/components/live-highway/concert-highway.html
+++ b/src/components/live-highway/concert-highway.html
@@ -29,7 +29,6 @@
             event.bind="ev"
             lane="home"
             readonly.bind="isReadonly"
-            position.bind="$index"
             beam-index.bind="beamIndexMap[ev.id] ?? null"
           ></event-card>
         </li>
@@ -39,7 +38,6 @@
             event.bind="ev"
             lane="nearby"
             readonly.bind="isReadonly"
-            position.bind="$index"
             beam-index.bind="beamIndexMap[ev.id] ?? null"
           ></event-card>
         </li>
@@ -49,7 +47,6 @@
             event.bind="ev"
             lane="away"
             readonly.bind="isReadonly"
-            position.bind="$index"
             beam-index.bind="beamIndexMap[ev.id] ?? null"
           ></event-card>
         </li>

--- a/src/components/live-highway/event-card.ts
+++ b/src/components/live-highway/event-card.ts
@@ -4,20 +4,14 @@ import {
 	JOURNEY_STATUS_CONFIG_MAP,
 	type JourneyStatusConfig,
 } from '../../entities/ticket-journey'
-import {
-	Events,
-	IAnalyticsService,
-} from '../../lib/analytics/analytics-service'
 import type { LaneType, LiveEvent } from './live-event'
 
 export class EventCard {
 	@bindable public event!: LiveEvent
 	@bindable public lane: LaneType = 'home'
-	@bindable public position: number | null = null
 	public logoError = false
 
 	private readonly element = resolve(INode) as HTMLElement
-	private readonly analytics = resolve(IAnalyticsService)
 
 	public get logoUrl(): string | undefined {
 		return bestLogoUrl(this.event.artist)
@@ -56,15 +50,6 @@ export class EventCard {
 
 	public onClick(): void {
 		if (this.readonly) return
-		// Fire before dispatch — analytics must survive a downstream throw.
-		// Skip when position is null; emitting 0 there would skew CTR metrics.
-		if (this.position !== null) {
-			this.analytics.capture(Events.ConcertRecommendationClicked, {
-				concert_id: this.event.id,
-				artist_id: this.event.artistId,
-				position: this.position,
-			})
-		}
 		this.element.dispatchEvent(
 			new CustomEvent('event-selected', {
 				detail: { event: this.event },

--- a/src/components/live-highway/event-detail-sheet.ts
+++ b/src/components/live-highway/event-detail-sheet.ts
@@ -98,7 +98,7 @@ export class EventDetailSheet {
 
 		// Fire after the sheet state flips — listeners observe consistent state.
 		this.analytics.capture(Events.ConcertDetailViewed, {
-			concert_id: event.id,
+			event_id: event.id,
 			artist_id: event.artistId,
 			source,
 		})

--- a/src/routes/dashboard/dashboard-route.ts
+++ b/src/routes/dashboard/dashboard-route.ts
@@ -396,9 +396,9 @@ export class DashboardRoute {
 	}
 
 	public onEventSelected(event: CustomEvent<{ event: LiveEvent }>): void {
-		// The dashboard concert list IS the recommendation feed — tag the source
-		// so FE click events can be joined to the BE impression signal in PostHog.
-		this.detailSheet?.open(event.detail.event, 'recommendation')
+		// Tag the source as the dashboard so concert.detail.viewed events from
+		// the dashboard concert list are attributable to that surface in PostHog.
+		this.detailSheet?.open(event.detail.event, 'dashboard')
 	}
 
 	public onSignupRequested(): void {

--- a/src/services/analytics-events.ts
+++ b/src/services/analytics-events.ts
@@ -42,7 +42,7 @@ export type EventSource =
 	| 'page'
 	| 'artist_page'
 	| 'search_result'
-	| 'recommendation'
+	| 'dashboard'
 	| 'notification'
 	| 'discovery_orb'
 
@@ -78,15 +78,15 @@ export type PageViewedProps = {
 
 /**
  * The user clicked the signup CTA or otherwise entered the signup flow.
- * Paired with the backend `account.signup.completed` to measure the
- * signup funnel.
+ * Paired with the backend `user.created` to measure the signup funnel.
  */
 export type AccountSignupStartedProps = {
 	source: 'landing' | 'cta' | 'deep_link' | 'post_signup_dialog'
 }
 
 /**
- * Paired with `concert.recommendation.served` for impression measurement.
+ * Recorded when an artist surfaces in a discovery surface for impression
+ * measurement.
  */
 export type ArtistDiscoveryViewedProps = {
 	artist_id: string
@@ -109,19 +109,9 @@ export type ArtistFollowRequestedProps = {
 }
 
 export type ConcertDetailViewedProps = {
-	concert_id: string
+	event_id: string
 	artist_id: string
 	source: EventSource
-}
-
-/**
- * The user clicked a concert recommendation. Paired with the backend
- * `concert.recommendation.served` impression event.
- */
-export type ConcertRecommendationClickedProps = {
-	concert_id: string
-	artist_id: string
-	position: number
 }
 
 /**
@@ -129,7 +119,7 @@ export type ConcertRecommendationClickedProps = {
  * `ticket.lottery.entry.accepted` / `.rejected` events.
  */
 export type TicketLotteryEntrySubmittedProps = {
-	concert_id: string
+	event_id: string
 	lottery_round: number
 }
 
@@ -139,7 +129,7 @@ export type TicketLotteryEntrySubmittedProps = {
  */
 export type TicketPurchaseInitiatedProps = {
 	ticket_id: string
-	concert_id: string
+	event_id: string
 	price_bucket: string
 }
 
@@ -163,7 +153,7 @@ export type NotificationRequestedProps = {
 
 export type NotificationOpenedProps = {
 	notification_id: string
-	concert_id?: string
+	event_id?: string
 	artist_id?: string
 }
 
@@ -181,7 +171,7 @@ export type NotificationDismissedProps = {
  *
  *   analytics.capture(Events.ArtistFollowRequested, {
  *     artist_id: artist.id.value,
- *     source: 'recommendation',
+ *     source: 'dashboard',
  *   })
  */
 export const Events = {
@@ -191,7 +181,6 @@ export const Events = {
 	ArtistSearch: 'artist.search',
 	ArtistFollowRequested: 'artist.follow.requested',
 	ConcertDetailViewed: 'concert.detail.viewed',
-	ConcertRecommendationClicked: 'concert.recommendation.clicked',
 	TicketLotteryEntrySubmitted: 'ticket.lottery.entry.submitted',
 	TicketPurchaseInitiated: 'ticket.purchase.initiated',
 	EntryCheckinAttempted: 'entry.checkin.attempted',
@@ -215,7 +204,6 @@ export type EventPropsMap = {
 	'artist.search': ArtistSearchProps
 	'artist.follow.requested': ArtistFollowRequestedProps
 	'concert.detail.viewed': ConcertDetailViewedProps
-	'concert.recommendation.clicked': ConcertRecommendationClickedProps
 	'ticket.lottery.entry.submitted': TicketLotteryEntrySubmittedProps
 	'ticket.purchase.initiated': TicketPurchaseInitiatedProps
 	'entry.checkin.attempted': EntryCheckinAttemptedProps

--- a/test/components/live-highway/event-card.spec.ts
+++ b/test/components/live-highway/event-card.spec.ts
@@ -2,33 +2,16 @@ import { INode, Registration } from 'aurelia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { EventCard } from '../../../src/components/live-highway/event-card'
 import type { LiveEvent } from '../../../src/components/live-highway/live-event'
-import { IAnalyticsService } from '../../../src/lib/analytics/analytics-service'
 import { createTestContainer } from '../../helpers/create-container'
 
 describe('EventCard', () => {
 	let component: EventCard
 	let mockElement: HTMLElement
-	let mockAnalytics: {
-		capture: ReturnType<typeof vi.fn>
-		identify: ReturnType<typeof vi.fn>
-		reset: ReturnType<typeof vi.fn>
-		getFeatureFlag: ReturnType<typeof vi.fn>
-	}
 
 	beforeEach(() => {
 		mockElement = document.createElement('div')
-		mockAnalytics = {
-			capture: vi.fn(),
-			identify: vi.fn(),
-			reset: vi.fn(),
-			getFeatureFlag: vi.fn((_key: string, fallback: unknown) => fallback),
-		}
 		const container = createTestContainer(
 			Registration.instance(INode, mockElement),
-			// Stub IAnalyticsService so the onClick analytics emission
-			// can be asserted without spinning up the real PostHog
-			// adapter (which would also pull in IConsentService et al.).
-			Registration.instance(IAnalyticsService, mockAnalytics),
 		)
 		container.register(EventCard)
 		component = container.get(EventCard)
@@ -85,40 +68,16 @@ describe('EventCard', () => {
 			expect(customEvent.bubbles).toBe(true)
 		})
 
-		it('fires concert.recommendation.clicked when position is bound', () => {
+		it('does NOT dispatch event-selected when readonly is true', () => {
 			component.event = liveEvent
-			component.position = 2
-
-			component.onClick()
-
-			expect(mockAnalytics.capture).toHaveBeenCalledTimes(1)
-			expect(mockAnalytics.capture).toHaveBeenCalledWith(
-				'concert.recommendation.clicked',
-				{
-					concert_id: 'event-1',
-					artist_id: 'artist-1',
-					position: 2,
-				},
-			)
-		})
-
-		it('does NOT fire concert.recommendation.clicked when position is null', () => {
-			component.event = liveEvent
-			component.position = null
-
-			component.onClick()
-
-			expect(mockAnalytics.capture).not.toHaveBeenCalled()
-		})
-
-		it('does NOT fire concert.recommendation.clicked when readonly is true', () => {
-			component.event = liveEvent
-			component.position = 3
 			component.readonly = true
 
+			const eventSpy = vi.fn()
+			mockElement.addEventListener('event-selected', eventSpy)
+
 			component.onClick()
 
-			expect(mockAnalytics.capture).not.toHaveBeenCalled()
+			expect(eventSpy).not.toHaveBeenCalled()
 		})
 	})
 })

--- a/test/components/live-highway/event-detail-sheet.spec.ts
+++ b/test/components/live-highway/event-detail-sheet.spec.ts
@@ -174,15 +174,15 @@ describe('EventDetailSheet', () => {
 		it('fires concert.detail.viewed on open with the supplied source', () => {
 			const event = makeEvent()
 
-			sut.open(event, 'recommendation')
+			sut.open(event, 'dashboard')
 
 			expect(mockAnalytics.capture).toHaveBeenCalledTimes(1)
 			expect(mockAnalytics.capture).toHaveBeenCalledWith(
 				'concert.detail.viewed',
 				{
-					concert_id: 'c1',
+					event_id: 'c1',
 					artist_id: 'a1',
-					source: 'recommendation',
+					source: 'dashboard',
 				},
 			)
 		})


### PR DESCRIPTION
## 🔗 Related Issue

Refs liverty-music/specification#532 (part of the PostHog product-analytics epic; does not close it)

## 📝 Summary of Changes

Removes a redundant analytics event and grounds the catalogue's vocabulary in real concepts. Catalogue/spec changes live in `liverty-music/specification` (same branch); backend counterpart in `liverty-music/backend`.

- **Delete the `concert.recommendation.clicked` capture** (`ConcertRecommendationClicked` constant, `ConcertRecommendationClickedProps` type, props-map entry, and the `event-card.ts` call site). It was redundant: a dashboard card tap already fires `concert.detail.viewed` (the tap opens the detail sheet), duplicating concert/artist/source and adding only `position`. With its CTR denominator (the backend impression event) deleted as a phantom, `position` yields no rate — so the event and its now-dead `position` plumbing (`@bindable` + `concert-highway.html` bindings) are removed.
- **`EventSource` `'recommendation'` → `'dashboard'`** (still used by `concert.detail.viewed`), matching the actual route rather than a non-existent recommendation engine.
- **Standardise the underlying-event identifier on `event_id`** (`Concert` is a DTO whose `id` is an `EventId`): renamed `concert_id` → `event_id` on `ConcertDetailViewedProps`, `TicketLotteryEntrySubmittedProps`, `TicketPurchaseInitiatedProps`, and `NotificationOpenedProps`, and updated the only emitting call site (`concert.detail.viewed`). The three ticket/notification props are type-only today.
- Repointed the `account.signup.started` doc-comment pairing from the deleted `account.signup.completed` to `user.created`.

Behaviour change: a dashboard card tap no longer emits a separate click event; the conversion remains observable via `concert.detail.viewed` (`source = 'dashboard'`).

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have added or updated tests to cover my changes (`event-card.spec.ts`, `event-detail-sheet.spec.ts`).
- [x] I have updated the relevant documentation (catalogue + spec in the specification PR).
- [x] I have run `make check` (lint + typecheck + tests) locally and all checks have passed.
- [x] My code follows the architecture and style guidelines of the project.
