### PR TITLE
feat(analytics): report notification opens and dismissals from the service worker

### DIFF
--- a/src/lib/analytics/analytics-service.ts
+++ b/src/lib/analytics/analytics-service.ts
@@ -16,6 +16,10 @@ import {
 import { ConsentChanged } from '../consent/consent-changed'
 import { IConsentService } from '../consent/consent-service'
 import {
+	NOTIFICATION_FLUSH_MESSAGE,
+	writeIdentitySnapshot,
+} from './notification-interaction'
+import {
 	type SanitizedProps,
 	sanitizeEventProps,
 } from './sensitive-property-filter'
@@ -129,6 +133,14 @@ export class AnalyticsService implements IAnalyticsService {
 	private initStarted = false
 	private readonly queue: QueuedCapture[] = []
 	private queueOverflowed = false
+
+	/**
+	 * Last distinct_id we identified, so the service-worker identity snapshot
+	 * can be refreshed on an opt-out toggle even before/without the SDK
+	 * resolving a distinct_id of its own. Notifications only reach signed-in
+	 * users, so this is the recipient's platform user id in practice.
+	 */
+	private lastDistinctId: string | null = null
 
 	/**
 	 * Buffers the most recent `identify()` request fired BEFORE PostHog
@@ -372,6 +384,11 @@ export class AnalyticsService implements IAnalyticsService {
 			// `capture` is attributed to the anonymous id first; identify then
 			// MERGES that history into the real user_id (no reset()).
 			this.replayPendingIdentifyIfAllowed()
+			// Publish the initial snapshot (covers the opted-out-at-boot and
+			// no-pending-identify cases) and flush any interactions the SW
+			// stashed while offline on a prior session.
+			this.syncIdentitySnapshot()
+			this.nudgeServiceWorkerFlush()
 		} catch (err) {
 			this.logger.warn(
 				'PostHog SDK failed to load; analytics disabled for this session',
@@ -465,6 +482,9 @@ export class AnalyticsService implements IAnalyticsService {
 			this.applyAnalyticsOptOutToSdk()
 			this.logger.debug('Analytics opted out — capture suppressed')
 		}
+		// Reflect the new opt-out posture into the service-worker snapshot so
+		// notificationclick / notificationclose honour it immediately.
+		this.syncIdentitySnapshot()
 		// Reassert the recording posture. This is a no-op enable in current
 		// scope (recording stays disabled per Decision 12) but keeps the
 		// single wiring point explicit for when replay ships.
@@ -542,14 +562,70 @@ export class AnalyticsService implements IAnalyticsService {
 		internal: boolean,
 	): void {
 		if (this.posthog === null) return
+		this.lastDistinctId = userId
 		if (!internal) {
 			this.posthog.identify(userId, properties)
+		} else {
+			this.posthog.identify(userId, { ...properties, internal_traffic: true })
+			// Super-property: stamps every future capture so event-level filters
+			// (not just person-level) can exclude internal traffic.
+			this.posthog.register({ internal_traffic: true })
+		}
+		// Refresh the service-worker identity snapshot so notificationclick /
+		// notificationclose can attribute interactions to this user and honour
+		// the current opt-out state.
+		this.syncIdentitySnapshot()
+	}
+
+	/**
+	 * Persists the `{ distinct_id, opted_out, api_host, project_key }` snapshot
+	 * the service worker reads to report notification opens / dismissals (the
+	 * SW cannot run posthog-js). Best-effort and fire-and-forget: a Cache write
+	 * failure only means the SW keeps the prior snapshot. Skipped in nil-config
+	 * mode or before any distinct_id is known.
+	 */
+	private syncIdentitySnapshot(): void {
+		if (!this.isEnabled()) return
+		// Prefer the SDK's live distinct_id; fall back to the last identify.
+		// Guard the call so a stubbed/partial SDK cannot throw here.
+		const fromSdk =
+			typeof this.posthog?.get_distinct_id === 'function'
+				? this.posthog.get_distinct_id()
+				: undefined
+		const distinctId = fromSdk ?? this.lastDistinctId
+		if (distinctId === null || distinctId === undefined || distinctId === '') {
 			return
 		}
-		this.posthog.identify(userId, { ...properties, internal_traffic: true })
-		// Super-property: stamps every future capture so event-level filters
-		// (not just person-level) can exclude internal traffic.
-		this.posthog.register({ internal_traffic: true })
+		const apiHost =
+			this.config.posthogApiHost && this.config.posthogApiHost.length > 0
+				? this.config.posthogApiHost
+				: 'https://eu.i.posthog.com'
+		void writeIdentitySnapshot({
+			distinctId,
+			optedOut: !this.consent.analytics,
+			apiHost,
+			projectKey: this.config.posthogProjectKey ?? '',
+		}).catch((err) => {
+			this.logger.debug('identity snapshot write failed', { error: err })
+		})
+	}
+
+	/**
+	 * Nudges the active service worker to flush any interactions it stashed
+	 * while offline. Called once on init so a reconnect-then-reopen delivers
+	 * queued opens / dismissals even on browsers without Background Sync.
+	 */
+	private nudgeServiceWorkerFlush(): void {
+		const nav = (globalThis as { navigator?: Navigator }).navigator
+		const container = nav?.serviceWorker
+		if (container === undefined) return
+		void container.ready
+			.then((registration) => {
+				registration.active?.postMessage({ type: NOTIFICATION_FLUSH_MESSAGE })
+			})
+			.catch(() => {
+				// No controlling SW yet (first load) — nothing to flush.
+			})
 	}
 
 	/**

--- a/src/lib/analytics/notification-interaction.ts
+++ b/src/lib/analytics/notification-interaction.ts
@@ -1,0 +1,360 @@
+/**
+ * Service-worker notification-interaction reporting.
+ *
+ * A service worker has no `window`, so it cannot run `posthog-js` and does not
+ * know the signed-in user. This module is the DOM-free seam shared by the app
+ * (which WRITES the identity snapshot) and `sw.ts` (which READS it and reports
+ * `notification.opened` / `notification.dismissed` interactions directly to
+ * PostHog's public `/capture` endpoint).
+ *
+ * Design (OpenSpec `emit-notification-analytics-events`, Decision 3):
+ *   - The app persists a tiny identity snapshot `{ distinctId, optedOut, ... }`
+ *     to the Cache API on identify / opt-out change; the SW reads it when an
+ *     interaction fires.
+ *   - `notificationclick` / `notificationclose` report the interaction AT
+ *     INTERACTION TIME via `event.waitUntil(fetch(...))`, keyed by the
+ *     `notification_id` carried in the notification.
+ *   - When the snapshot says `optedOut`, nothing is sent.
+ *   - A failed `fetch` (offline) is retried via the Background Sync API where
+ *     available; otherwise the interaction is written to a bounded IndexedDB
+ *     stash and flushed on the next SW activation / app open. The stable
+ *     per-interaction `uuid` (`$insert_id`) de-duplicates retries server-side.
+ *
+ * The module is intentionally free of Aurelia / DOM dependencies so the PWA
+ * service-worker bundle can import it without pulling in the app runtime.
+ */
+
+import type {
+	Events,
+	NotificationDismissedProps,
+	NotificationOpenedProps,
+} from '../../services/analytics-events'
+
+/**
+ * The identity + destination the service worker needs to post an interaction
+ * to PostHog. `distinctId` / `optedOut` are the identity half the app refreshes
+ * on identify and opt-out change; `apiHost` / `projectKey` are the (public)
+ * destination so the SW need not read `/config.json` on every interaction.
+ */
+export interface AnalyticsIdentitySnapshot {
+	/** PostHog distinct_id — the signed-in user's platform id once identified. */
+	distinctId: string
+	/** When true, the user opted out of analytics; the SW sends nothing. */
+	optedOut: boolean
+	/** PostHog ingestion host, e.g. `https://eu.i.posthog.com`. */
+	apiHost: string
+	/** Public PostHog project API key (already shipped in the web client). */
+	projectKey: string
+}
+
+/**
+ * One notification interaction awaiting delivery to PostHog. `event` is the
+ * catalogue name (`notification.opened` / `notification.dismissed`); `uuid` is
+ * the `$insert_id` reused across retries so a Background-Sync / stash resend is
+ * de-duplicated; `timestamp` is the ISO-8601 interaction time (NOT the send
+ * time) so events attribute to when the user acted.
+ */
+export interface NotificationInteraction {
+	event: typeof Events.NotificationOpened | typeof Events.NotificationDismissed
+	notificationId: string
+	uuid: string
+	timestamp: string
+}
+
+/** Cache name holding the single identity-snapshot entry. */
+const IDENTITY_CACHE = 'liverty-analytics-identity-v1'
+/**
+ * Synthetic request URL under which the snapshot Response is stored. The
+ * `__liverty__` prefix keeps it clear this is an internal, non-navigable key.
+ */
+const IDENTITY_KEY = '/__liverty__/analytics-identity'
+
+/** Background Sync tag used to retry a failed interaction send when offline. */
+export const NOTIFICATION_SYNC_TAG = 'flush-notification-analytics'
+/** postMessage type the app sends to nudge the SW to flush on app open. */
+export const NOTIFICATION_FLUSH_MESSAGE = 'flush-notification-analytics'
+
+// -- Push payload -------------------------------------------------------------
+
+/**
+ * Push message body. Client-passthrough metadata (`url`, `notification_id`)
+ * lives under `data`; `url` / `notification_id` also appear top-level in the
+ * legacy shape, read as a rollout compat fallback.
+ */
+export interface PushPayload {
+	title?: string
+	body?: string
+	tag?: string
+	data?: { url?: string; notification_id?: string }
+	url?: string
+	notification_id?: string
+}
+
+/**
+ * Resolves the client-passthrough metadata the SW maps into
+ * `showNotification` `options.data`, preferring the nested `data` and falling
+ * back to the legacy top-level fields so an in-flight old payload (or an old SW
+ * against a new payload) still navigates and correlates. `url` defaults to `/`;
+ * `notificationId` is `''` when absent (interaction reporting then skips).
+ */
+export function resolvePushMetadata(payload: PushPayload): {
+	url: string
+	notificationId: string
+} {
+	return {
+		url: payload.data?.url ?? payload.url ?? '/',
+		notificationId:
+			payload.data?.notification_id ?? payload.notification_id ?? '',
+	}
+}
+
+// -- IndexedDB offline stash --------------------------------------------------
+
+const STASH_DB = 'liverty-analytics'
+const STASH_STORE = 'notification-interactions'
+/**
+ * Upper bound on stashed interactions. When full, the oldest entry is dropped
+ * so a device that stays offline indefinitely cannot grow storage without
+ * bound — best-effort offline delivery, not a durable queue.
+ */
+const STASH_CAP = 100
+
+function openStashDB(): Promise<IDBDatabase> {
+	return new Promise((resolve, reject) => {
+		const req = indexedDB.open(STASH_DB, 1)
+		req.onupgradeneeded = () => {
+			const db = req.result
+			if (!db.objectStoreNames.contains(STASH_STORE)) {
+				// keyPath `uuid` makes the stable interaction id the primary key, so
+				// a re-stash of the same interaction overwrites rather than duplicates.
+				db.createObjectStore(STASH_STORE, { keyPath: 'uuid' })
+			}
+		}
+		req.onsuccess = () => resolve(req.result)
+		req.onerror = () => reject(req.error ?? new Error('open stash db failed'))
+	})
+}
+
+function promisifyRequest<T>(req: IDBRequest<T>): Promise<T> {
+	return new Promise((resolve, reject) => {
+		req.onsuccess = () => resolve(req.result)
+		req.onerror = () => reject(req.error ?? new Error('idb request failed'))
+	})
+}
+
+async function stashInteraction(
+	interaction: NotificationInteraction,
+): Promise<void> {
+	const db = await openStashDB()
+	try {
+		// Enforce the bound before inserting: drop the oldest keys until there is
+		// room for one more. Insertion order == chronological order because the
+		// uuid is generated at interaction time and never reused.
+		const existing = await promisifyRequest(
+			db
+				.transaction(STASH_STORE, 'readonly')
+				.objectStore(STASH_STORE)
+				.getAllKeys(),
+		)
+		const tx = db.transaction(STASH_STORE, 'readwrite')
+		const store = tx.objectStore(STASH_STORE)
+		const overflow = existing.length + 1 - STASH_CAP
+		for (let i = 0; i < overflow; i++) {
+			store.delete(existing[i])
+		}
+		store.put(interaction)
+		await promisifyRequest(
+			// A no-op request whose completion mirrors the transaction's.
+			store.count(),
+		)
+	} finally {
+		db.close()
+	}
+}
+
+async function readAllStashed(): Promise<NotificationInteraction[]> {
+	const db = await openStashDB()
+	try {
+		return await promisifyRequest(
+			db.transaction(STASH_STORE, 'readonly').objectStore(STASH_STORE).getAll(),
+		)
+	} finally {
+		db.close()
+	}
+}
+
+async function deleteStashed(uuid: string): Promise<void> {
+	const db = await openStashDB()
+	try {
+		const tx = db.transaction(STASH_STORE, 'readwrite')
+		tx.objectStore(STASH_STORE).delete(uuid)
+		await promisifyRequest(tx.objectStore(STASH_STORE).count())
+	} finally {
+		db.close()
+	}
+}
+
+// -- Identity snapshot (Cache API) --------------------------------------------
+
+/**
+ * Persists the identity snapshot for the service worker to read. Called by the
+ * app on identify and on analytics opt-out change. Overwrites atomically.
+ */
+export async function writeIdentitySnapshot(
+	snapshot: AnalyticsIdentitySnapshot,
+): Promise<void> {
+	const cache = await caches.open(IDENTITY_CACHE)
+	await cache.put(
+		IDENTITY_KEY,
+		new Response(JSON.stringify(snapshot), {
+			headers: { 'content-type': 'application/json' },
+		}),
+	)
+}
+
+/** Reads the identity snapshot, or null when the app has never written one. */
+export async function readIdentitySnapshot(): Promise<AnalyticsIdentitySnapshot | null> {
+	const cache = await caches.open(IDENTITY_CACHE)
+	const res = await cache.match(IDENTITY_KEY)
+	if (res === undefined) return null
+	try {
+		return (await res.json()) as AnalyticsIdentitySnapshot
+	} catch {
+		return null
+	}
+}
+
+// -- Capture body -------------------------------------------------------------
+
+/** Absolute PostHog `/capture` endpoint for the snapshot's host. */
+export function captureUrl(apiHost: string): string {
+	return `${apiHost.replace(/\/+$/, '')}/capture/`
+}
+
+/**
+ * Centralised PostHog `/capture` body builder — the single definition of the
+ * event shape (event name, `distinct_id`, `$insert_id`, explicit interaction
+ * `timestamp`) so the SW path stays aligned with the app SDK. Properties reuse
+ * the {@link NotificationOpenedProps} / {@link NotificationDismissedProps}
+ * typings (only `notification_id` is carried; `event_id` / `artist_id` are
+ * catalogue-optional and not threaded through the payload yet).
+ */
+export function buildCaptureBody(
+	snapshot: AnalyticsIdentitySnapshot,
+	interaction: NotificationInteraction,
+): Record<string, unknown> {
+	const properties: NotificationOpenedProps | NotificationDismissedProps = {
+		notification_id: interaction.notificationId,
+	}
+	return {
+		api_key: snapshot.projectKey,
+		event: interaction.event,
+		distinct_id: snapshot.distinctId,
+		timestamp: interaction.timestamp,
+		properties: {
+			...properties,
+			// $insert_id de-duplicates a Background-Sync / stash resend server-side.
+			$insert_id: interaction.uuid,
+		},
+	}
+}
+
+// -- Reporting ----------------------------------------------------------------
+
+/** POSTs one interaction to PostHog. Throws on network / non-2xx so callers can stash. */
+async function sendInteraction(
+	snapshot: AnalyticsIdentitySnapshot,
+	interaction: NotificationInteraction,
+): Promise<void> {
+	const res = await fetch(captureUrl(snapshot.apiHost), {
+		method: 'POST',
+		// keepalive lets the request outlive a short-lived SW activation.
+		keepalive: true,
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify(buildCaptureBody(snapshot, interaction)),
+	})
+	if (!res.ok) {
+		throw new Error(`posthog capture failed: ${res.status}`)
+	}
+}
+
+/**
+ * Best-effort registration of a Background Sync retry. Returns true when the
+ * platform accepted the registration (Chromium); false on Safari / Firefox
+ * where the API is absent — the caller then relies on the stash + activation /
+ * app-open flush instead.
+ */
+async function registerSyncRetry(
+	registration: ServiceWorkerRegistration,
+): Promise<boolean> {
+	const withSync = registration as ServiceWorkerRegistration & {
+		sync?: { register(tag: string): Promise<void> }
+	}
+	if (withSync.sync === undefined) return false
+	try {
+		await withSync.sync.register(NOTIFICATION_SYNC_TAG)
+		return true
+	} catch {
+		return false
+	}
+}
+
+/**
+ * Reports a notification interaction at interaction time. Reads the identity
+ * snapshot and:
+ *   - skips entirely when there is no snapshot, the user is opted out, or the
+ *     notification carries no `notification_id`;
+ *   - otherwise sends immediately; on failure stashes the interaction (bounded)
+ *     and registers a Background Sync retry where supported.
+ *
+ * `registration` is `self.registration` from the service worker, used only to
+ * register the Sync retry.
+ */
+export async function reportNotificationInteraction(
+	interaction: NotificationInteraction,
+	registration: ServiceWorkerRegistration,
+): Promise<void> {
+	if (interaction.notificationId === '') return
+	const snapshot = await readIdentitySnapshot()
+	if (snapshot === null || snapshot.optedOut || snapshot.projectKey === '') {
+		return
+	}
+	try {
+		await sendInteraction(snapshot, interaction)
+	} catch {
+		// Offline / transient failure: stash for a later flush and ask the
+		// platform to retry via Background Sync where available.
+		await stashInteraction(interaction)
+		await registerSyncRetry(registration)
+	}
+}
+
+/**
+ * Flushes every stashed interaction, sending each and deleting it only on a
+ * successful send (so a still-offline flush leaves the stash intact for the
+ * next attempt). Invoked on SW activation, on a `sync` event, and when the app
+ * signals it opened. Reads the snapshot once; if opted out, the stash is
+ * cleared without sending.
+ */
+export async function flushInteractionStash(): Promise<void> {
+	const stashed = await readAllStashed()
+	if (stashed.length === 0) return
+	const snapshot = await readIdentitySnapshot()
+	if (snapshot === null || snapshot.projectKey === '') return
+	if (snapshot.optedOut) {
+		// Opted out after stashing: discard rather than send.
+		for (const interaction of stashed) {
+			await deleteStashed(interaction.uuid)
+		}
+		return
+	}
+	for (const interaction of stashed) {
+		try {
+			await sendInteraction(snapshot, interaction)
+			await deleteStashed(interaction.uuid)
+		} catch {
+			// Still offline — stop and leave the rest for the next flush.
+			break
+		}
+	}
+}

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -8,6 +8,15 @@ import { ExpirationPlugin } from 'workbox-expiration'
 import { precacheAndRoute } from 'workbox-precaching'
 import { registerRoute } from 'workbox-routing'
 import { CacheFirst, NetworkOnly } from 'workbox-strategies'
+import {
+	flushInteractionStash,
+	NOTIFICATION_FLUSH_MESSAGE,
+	NOTIFICATION_SYNC_TAG,
+	type PushPayload,
+	reportNotificationInteraction,
+	resolvePushMetadata,
+} from './lib/analytics/notification-interaction'
+import { Events } from './services/analytics-events'
 
 // ---------------------------------------------------------------------------
 // Precache app shell assets injected by vite-plugin-pwa at build time.
@@ -147,53 +156,120 @@ registerRoute(
 // Push notification handler.
 // ---------------------------------------------------------------------------
 self.addEventListener('push', (event) => {
-	let data:
-		| { title?: string; body?: string; tag?: string; url?: string }
-		| undefined
+	let payload: PushPayload | undefined
 	try {
-		data = event.data?.json()
+		payload = event.data?.json()
 	} catch {
-		data = undefined
+		payload = undefined
 	}
-	data = data ?? { title: 'Liverty Music', body: 'New notification' }
+	payload = payload ?? { title: 'Liverty Music', body: 'New notification' }
+
+	// Compat shim (removed once both sides are deployed): resolve url /
+	// notification_id from the nested `data`, falling back to the legacy
+	// top-level fields.
+	const { url, notificationId } = resolvePushMetadata(payload)
 
 	const options: NotificationOptions = {
-		body: data.body,
+		body: payload.body,
 		icon: '/icons/icon-192x192.png',
 		badge: '/favicon-96x96.png',
-		tag: data.tag || 'liverty-default',
-		data: { url: data.url || '/' },
+		tag: payload.tag || 'liverty-default',
+		// Map the passthrough metadata straight into options.data so
+		// notificationclick/close read event.notification.data.{url,notification_id}.
+		data: { url, notification_id: notificationId },
 	}
 
 	event.waitUntil(
-		self.registration.showNotification(data.title || 'Liverty Music', options),
+		self.registration.showNotification(
+			payload.title || 'Liverty Music',
+			options,
+		),
 	)
 })
 
 self.addEventListener('notificationclick', (event) => {
 	event.notification.close()
-	const url: string = event.notification.data?.url || '/'
+	const data = (event.notification.data ?? {}) as {
+		url?: string
+		notification_id?: string
+	}
+	const url: string = data.url || '/'
+	const notificationId: string = data.notification_id ?? ''
 
 	event.waitUntil(
-		self.clients
-			.matchAll({ type: 'window', includeUncontrolled: true })
-			.then((clients) => {
-				let targetUrl: URL
-				try {
-					targetUrl = new URL(url, self.location.origin)
-				} catch {
-					targetUrl = new URL('/', self.location.origin)
+		(async () => {
+			// Report the open at interaction time (orthogonal to navigation). Kept
+			// first so the capture is issued even if focus/openWindow throws.
+			await reportNotificationInteraction(
+				{
+					event: Events.NotificationOpened,
+					notificationId,
+					uuid: crypto.randomUUID(),
+					timestamp: new Date().toISOString(),
+				},
+				self.registration,
+			)
+
+			const clients = await self.clients.matchAll({
+				type: 'window',
+				includeUncontrolled: true,
+			})
+			let targetUrl: URL
+			try {
+				targetUrl = new URL(url, self.location.origin)
+			} catch {
+				targetUrl = new URL('/', self.location.origin)
+			}
+			for (const client of clients) {
+				const clientUrl = new URL(client.url)
+				if (clientUrl.href === targetUrl.href && 'focus' in client) {
+					return client.focus()
 				}
-				for (const client of clients) {
-					const clientUrl = new URL(client.url)
-					if (clientUrl.href === targetUrl.href && 'focus' in client) {
-						return client.focus()
-					}
-				}
-				// Only open same-origin URLs to prevent external redirects.
-				const safeUrl =
-					targetUrl.origin === self.location.origin ? targetUrl.href : '/'
-				return self.clients.openWindow(safeUrl)
-			}),
+			}
+			// Only open same-origin URLs to prevent external redirects.
+			const safeUrl =
+				targetUrl.origin === self.location.origin ? targetUrl.href : '/'
+			return self.clients.openWindow(safeUrl)
+		})(),
 	)
+})
+
+self.addEventListener('notificationclose', (event) => {
+	const data = (event.notification.data ?? {}) as { notification_id?: string }
+	event.waitUntil(
+		reportNotificationInteraction(
+			{
+				event: Events.NotificationDismissed,
+				notificationId: data.notification_id ?? '',
+				uuid: crypto.randomUUID(),
+				timestamp: new Date().toISOString(),
+			},
+			self.registration,
+		),
+	)
+})
+
+// Offline fallback flush points: retry stashed interactions when the platform
+// fires a Background Sync, on SW activation, and when the app signals it opened.
+//
+// The `sync` event (Background Sync API) is not in the default TS SW lib types,
+// so it is registered via the untyped listener and narrowed locally.
+type SyncEventLike = ExtendableEvent & { tag: string }
+;(self as ServiceWorkerGlobalScope).addEventListener(
+	'sync' as keyof ServiceWorkerGlobalScopeEventMap,
+	((event: SyncEventLike) => {
+		if (event.tag === NOTIFICATION_SYNC_TAG) {
+			event.waitUntil(flushInteractionStash())
+		}
+	}) as EventListener,
+)
+
+self.addEventListener('activate', (event) => {
+	event.waitUntil(flushInteractionStash())
+})
+
+self.addEventListener('message', (event) => {
+	if (event.data?.type === NOTIFICATION_FLUSH_MESSAGE) {
+		event.waitUntil(flushInteractionStash())
+	}
 })

--- a/test/lib/analytics/notification-interaction.spec.ts
+++ b/test/lib/analytics/notification-interaction.spec.ts
@@ -1,0 +1,270 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+	type AnalyticsIdentitySnapshot,
+	buildCaptureBody,
+	captureUrl,
+	flushInteractionStash,
+	type NotificationInteraction,
+	reportNotificationInteraction,
+	resolvePushMetadata,
+	writeIdentitySnapshot,
+} from '../../../src/lib/analytics/notification-interaction'
+import { Events } from '../../../src/services/analytics-events'
+
+// ── In-memory Cache API fake ────────────────────────────────────────────────
+// jsdom provides no `caches`; back it with a Map keyed by request URL.
+
+class FakeCache {
+	// Store the body text, not the Response: a real cache.match returns a fresh
+	// Response each call, so the body is never consumed across reads.
+	private readonly store = new Map<string, string>()
+	async put(key: string, res: Response): Promise<void> {
+		this.store.set(key, await res.text())
+	}
+	async match(key: string): Promise<Response | undefined> {
+		const body = this.store.get(key)
+		return body === undefined ? undefined : new Response(body)
+	}
+}
+
+function installFakeCaches(): void {
+	const registry = new Map<string, FakeCache>()
+	;(globalThis as unknown as { caches: CacheStorage }).caches = {
+		open: async (name: string) => {
+			let cache = registry.get(name)
+			if (cache === undefined) {
+				cache = new FakeCache()
+				registry.set(name, cache)
+			}
+			return cache as unknown as Cache
+		},
+	} as CacheStorage
+}
+
+// ── In-memory IndexedDB fake ────────────────────────────────────────────────
+// Minimal subset used by the offline stash: a single keyPath store whose data
+// persists across open()/close() within a test (module-level `rows`).
+
+function installFakeIndexedDB(): void {
+	const dbs = new Map<string, Map<string, Map<string, unknown>>>()
+
+	function fireSuccess<T>(result: T): IDBRequest<T> {
+		const req = {
+			result,
+			onsuccess: null,
+			onerror: null,
+		} as unknown as IDBRequest<T> & {
+			onsuccess: (() => void) | null
+			onupgradeneeded: (() => void) | null
+		}
+		queueMicrotask(() => req.onsuccess?.())
+		return req
+	}
+
+	;(globalThis as unknown as { indexedDB: IDBFactory }).indexedDB = {
+		open(name: string) {
+			if (!dbs.has(name)) dbs.set(name, new Map())
+			const stores = dbs.get(name)!
+			const db = {
+				objectStoreNames: {
+					contains: (s: string) => stores.has(s),
+				},
+				createObjectStore: (s: string, _opts: { keyPath: string }) => {
+					if (!stores.has(s)) stores.set(s, new Map())
+				},
+				transaction: (storeName: string) => ({
+					objectStore: () => {
+						const rows = stores.get(storeName) ?? new Map<string, unknown>()
+						stores.set(storeName, rows)
+						return {
+							getAllKeys: () => fireSuccess([...rows.keys()]),
+							getAll: () => fireSuccess([...rows.values()]),
+							// keyPath is `uuid`, so a re-put with the same uuid overwrites.
+							put: (value: { uuid: string }) => {
+								rows.set(value.uuid, value)
+								return fireSuccess(undefined)
+							},
+							delete: (key: string) => {
+								rows.delete(key)
+								return fireSuccess(undefined)
+							},
+							count: () => fireSuccess(rows.size),
+						}
+					},
+				}),
+				close: () => {},
+			}
+			const req = {
+				result: db,
+				onsuccess: null,
+				onerror: null,
+				onupgradeneeded: null,
+			} as unknown as IDBOpenDBRequest & {
+				onupgradeneeded: (() => void) | null
+				onsuccess: (() => void) | null
+			}
+			queueMicrotask(() => {
+				req.onupgradeneeded?.()
+				req.onsuccess?.()
+			})
+			return req
+		},
+	} as unknown as IDBFactory
+}
+
+const SNAPSHOT: AnalyticsIdentitySnapshot = {
+	distinctId: 'user-123',
+	optedOut: false,
+	apiHost: 'https://eu.i.posthog.com',
+	projectKey: 'phc_test',
+}
+
+const OPENED: NotificationInteraction = {
+	event: Events.NotificationOpened,
+	notificationId: 'notif-1',
+	uuid: 'uuid-1',
+	timestamp: '2026-07-01T00:00:00.000Z',
+}
+
+const registration = {
+	sync: { register: vi.fn().mockResolvedValue(undefined) },
+} as unknown as ServiceWorkerRegistration
+
+describe('resolvePushMetadata', () => {
+	it('prefers nested data over legacy top-level fields', () => {
+		expect(
+			resolvePushMetadata({
+				data: { url: '/new', notification_id: 'n-new' },
+				url: '/legacy',
+				notification_id: 'n-legacy',
+			}),
+		).toEqual({ url: '/new', notificationId: 'n-new' })
+	})
+
+	it('falls back to legacy top-level fields when data is absent', () => {
+		expect(
+			resolvePushMetadata({ url: '/legacy', notification_id: 'n-legacy' }),
+		).toEqual({ url: '/legacy', notificationId: 'n-legacy' })
+	})
+
+	it('defaults url to / and notificationId to empty when nothing is present', () => {
+		expect(resolvePushMetadata({})).toEqual({ url: '/', notificationId: '' })
+	})
+})
+
+describe('buildCaptureBody / captureUrl', () => {
+	it('matches the PostHog capture shape (event, distinct_id, timestamp, $insert_id)', () => {
+		expect(buildCaptureBody(SNAPSHOT, OPENED)).toEqual({
+			api_key: 'phc_test',
+			event: 'notification.opened',
+			distinct_id: 'user-123',
+			timestamp: '2026-07-01T00:00:00.000Z',
+			properties: {
+				notification_id: 'notif-1',
+				$insert_id: 'uuid-1',
+			},
+		})
+	})
+
+	it('appends /capture/ without doubling the host slash', () => {
+		expect(captureUrl('https://eu.i.posthog.com')).toBe(
+			'https://eu.i.posthog.com/capture/',
+		)
+		expect(captureUrl('https://eu.i.posthog.com/')).toBe(
+			'https://eu.i.posthog.com/capture/',
+		)
+	})
+})
+
+describe('reportNotificationInteraction', () => {
+	let fetchMock: ReturnType<typeof vi.fn>
+
+	beforeEach(() => {
+		installFakeCaches()
+		installFakeIndexedDB()
+		fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }))
+		vi.stubGlobal('fetch', fetchMock)
+	})
+
+	afterEach(() => {
+		vi.unstubAllGlobals()
+		vi.clearAllMocks()
+	})
+
+	it('POSTs the interaction to /capture with the right event, id, timestamp and uuid', async () => {
+		await writeIdentitySnapshot(SNAPSHOT)
+		await reportNotificationInteraction(OPENED, registration)
+
+		expect(fetchMock).toHaveBeenCalledTimes(1)
+		const [url, init] = fetchMock.mock.calls[0]
+		expect(url).toBe('https://eu.i.posthog.com/capture/')
+		expect(init.method).toBe('POST')
+		expect(init.keepalive).toBe(true)
+		const body = JSON.parse(init.body as string)
+		expect(body.event).toBe('notification.opened')
+		expect(body.distinct_id).toBe('user-123')
+		expect(body.timestamp).toBe('2026-07-01T00:00:00.000Z')
+		expect(body.properties.notification_id).toBe('notif-1')
+		expect(body.properties.$insert_id).toBe('uuid-1')
+	})
+
+	it('sends nothing when the snapshot says the user opted out', async () => {
+		await writeIdentitySnapshot({ ...SNAPSHOT, optedOut: true })
+		await reportNotificationInteraction(OPENED, registration)
+		expect(fetchMock).not.toHaveBeenCalled()
+	})
+
+	it('sends nothing when there is no identity snapshot', async () => {
+		await reportNotificationInteraction(OPENED, registration)
+		expect(fetchMock).not.toHaveBeenCalled()
+	})
+
+	it('sends nothing when the notification carries no notification_id', async () => {
+		await writeIdentitySnapshot(SNAPSHOT)
+		await reportNotificationInteraction(
+			{ ...OPENED, notificationId: '' },
+			registration,
+		)
+		expect(fetchMock).not.toHaveBeenCalled()
+	})
+
+	it('stashes and registers a Background Sync retry on fetch failure, then flushes once reconnected without duplicating', async () => {
+		await writeIdentitySnapshot(SNAPSHOT)
+		fetchMock.mockRejectedValueOnce(new Error('offline'))
+
+		await reportNotificationInteraction(OPENED, registration)
+		// Failed send: no successful POST, stash written, sync registered.
+		expect(fetchMock).toHaveBeenCalledTimes(1)
+		expect(
+			(
+				registration as unknown as {
+					sync: { register: ReturnType<typeof vi.fn> }
+				}
+			).sync.register,
+		).toHaveBeenCalledWith('flush-notification-analytics')
+
+		// Reconnected: flush resends exactly once (the stash deduped by uuid).
+		fetchMock.mockResolvedValue(new Response(null, { status: 200 }))
+		await flushInteractionStash()
+		expect(fetchMock).toHaveBeenCalledTimes(2)
+
+		// A second flush finds an empty stash — no further sends.
+		await flushInteractionStash()
+		expect(fetchMock).toHaveBeenCalledTimes(2)
+	})
+
+	it('flush discards the stash without sending when the user has since opted out', async () => {
+		await writeIdentitySnapshot(SNAPSHOT)
+		fetchMock.mockRejectedValueOnce(new Error('offline'))
+		await reportNotificationInteraction(OPENED, registration)
+		expect(fetchMock).toHaveBeenCalledTimes(1)
+
+		await writeIdentitySnapshot({ ...SNAPSHOT, optedOut: true })
+		await flushInteractionStash()
+		// No new send; and a follow-up opt-in flush finds nothing left to send.
+		expect(fetchMock).toHaveBeenCalledTimes(1)
+		await writeIdentitySnapshot(SNAPSHOT)
+		await flushInteractionStash()
+		expect(fetchMock).toHaveBeenCalledTimes(1)
+	})
+})


### PR DESCRIPTION
## What
Report `notification.opened` / `notification.dismissed` (FE) at interaction time, correlated by `notification_id`, honoring analytics opt-out.

- A service worker has no `window` (cannot run `posthog-js`), so the app persists a small identity snapshot `{ distinct_id, opted_out, api_host, project_key }` to the Cache API on `identify` and on analytics opt-out change.
- `notificationclick` / `notificationclose` report via `event.waitUntil(fetch(POSTHOG_CAPTURE_URL, { keepalive: true }))` — stamped with the interaction `timestamp` and a per-interaction `uuid` (`$insert_id`) for dedup. **Send is skipped entirely when the snapshot says `opted_out`.**
- Offline fallback: bounded IndexedDB stash retried via Background Sync where available, flushed on SW activation / app open; the reused `uuid` de-duplicates resends server-side.
- `push` handler maps the payload `data` object straight into `showNotification` `options.data`, reading `url` / `notification_id` from **both** the new nested `data` and the legacy top-level location during rollout (compat shim).

## Testing
New `notification-interaction.spec.ts` (11 tests): push metadata resolution (compat shim), capture body shape, opted-out ⇒ no fetch, no-snapshot / no-id ⇒ no fetch, fetch-failure ⇒ stash + Background Sync retry, flush-once-reconnected without duplicating, opt-out-after-stash discards. `make check` passes.

## Why
Pairs with the backend `notification.delivered`; satisfies the descoped `introduce-analytics-tool` task 5.7.

Refs #675