### PR TITLE
refactor(welcome): move scroll-affordance motion policy to CSS

### DIFF
--- a/src/routes/welcome/welcome-route.html
+++ b/src/routes/welcome/welcome-route.html
@@ -22,7 +22,12 @@
     </label>
   </fieldset>
 
-  <!-- With preview data: single scroll-affordance that reveals Screen 2 -->
+  <!-- With preview data: single scroll-affordance that reveals Screen 2. The
+       button only triggers the scroll; smooth vs instant motion is governed by
+       the scroll container's CSS `scroll-behavior` (and its reduced-motion
+       override), so no motion logic lives in JS. A native `<a href="#…">` was
+       rejected because the Aurelia router intercepts URL/hash changes and tears
+       the route down. -->
   <button
     if.bind="dateGroups.length > 0"
     click.trigger="scrollToPreview()"

--- a/src/routes/welcome/welcome-route.ts
+++ b/src/routes/welcome/welcome-route.ts
@@ -191,30 +191,17 @@ export class WelcomeRoute implements IRouteViewModel {
 	}
 
 	/**
-	 * Smooth-scrolls the viewport to Screen 2 (the preview section). Honors the
-	 * user's `prefers-reduced-motion` setting by jumping instantly instead. No-op
-	 * when Screen 2 is not rendered (i.e. `dateGroups` is empty).
+	 * Scrolls Screen 2 (the preview section) into view. Whether the scroll is
+	 * smooth or instant is decided entirely by the scroll container's CSS
+	 * `scroll-behavior` (`smooth`, overridden to `auto` under
+	 * `prefers-reduced-motion`) — no `behavior` is passed here, so motion policy
+	 * has a single source of truth in CSS. No-op when Screen 2 is not rendered
+	 * (i.e. `dateGroups` is empty).
 	 */
 	scrollToPreview(): void {
-		const target = this.host.querySelector('.welcome-screen-2')
-		if (!target) {
-			this.logger.debug('scrollToPreview invoked but preview section absent')
-			return
-		}
-
-		const prefersReducedMotion =
-			typeof window !== 'undefined' &&
-			typeof window.matchMedia === 'function' &&
-			window.matchMedia('(prefers-reduced-motion: reduce)').matches
-
-		this.logger.debug('Scroll affordance activated', {
-			reducedMotion: prefersReducedMotion,
-		})
-
-		target.scrollIntoView({
-			behavior: prefersReducedMotion ? 'auto' : 'smooth',
-			block: 'start',
-		})
+		this.host
+			.querySelector('.welcome-screen-2')
+			?.scrollIntoView({ block: 'start' })
 	}
 
 	async handleGetStarted(): Promise<void> {

--- a/test/routes/welcome-route.spec.ts
+++ b/test/routes/welcome-route.spec.ts
@@ -225,7 +225,6 @@ describe('WelcomeRoute', () => {
 	describe('scrollToPreview', () => {
 		let screen2: HTMLElement
 		let scrollIntoViewSpy: ReturnType<typeof vi.fn>
-		let matchMediaSpy: ReturnType<typeof vi.spyOn> | null
 
 		beforeEach(() => {
 			screen2 = document.createElement('section')
@@ -233,58 +232,16 @@ describe('WelcomeRoute', () => {
 			scrollIntoViewSpy = vi.fn()
 			screen2.scrollIntoView = scrollIntoViewSpy
 			host.appendChild(screen2)
-			matchMediaSpy = null
 		})
 
-		afterEach(() => {
-			matchMediaSpy?.mockRestore()
-		})
-
-		it('calls scrollIntoView with smooth behavior when reduced-motion is not set', () => {
-			matchMediaSpy = vi.spyOn(window, 'matchMedia').mockImplementation(
-				(query: string) =>
-					({
-						matches: false,
-						media: query,
-						onchange: null,
-						addListener: vi.fn(),
-						removeListener: vi.fn(),
-						addEventListener: vi.fn(),
-						removeEventListener: vi.fn(),
-						dispatchEvent: vi.fn(),
-					}) as unknown as MediaQueryList,
-			)
-
+		// No `behavior` is passed: smooth-vs-instant motion is governed by the
+		// scroll container's CSS `scroll-behavior` (with a `prefers-reduced-motion`
+		// override), so motion policy has a single source of truth in CSS.
+		it('scrolls the preview section into view without a behavior override', () => {
 			sut.scrollToPreview()
 
 			expect(scrollIntoViewSpy).toHaveBeenCalledOnce()
-			expect(scrollIntoViewSpy).toHaveBeenCalledWith({
-				behavior: 'smooth',
-				block: 'start',
-			})
-		})
-
-		it('uses auto behavior when prefers-reduced-motion is set', () => {
-			matchMediaSpy = vi.spyOn(window, 'matchMedia').mockImplementation(
-				(query: string) =>
-					({
-						matches: query === '(prefers-reduced-motion: reduce)',
-						media: query,
-						onchange: null,
-						addListener: vi.fn(),
-						removeListener: vi.fn(),
-						addEventListener: vi.fn(),
-						removeEventListener: vi.fn(),
-						dispatchEvent: vi.fn(),
-					}) as unknown as MediaQueryList,
-			)
-
-			sut.scrollToPreview()
-
-			expect(scrollIntoViewSpy).toHaveBeenCalledWith({
-				behavior: 'auto',
-				block: 'start',
-			})
+			expect(scrollIntoViewSpy).toHaveBeenCalledWith({ block: 'start' })
 		})
 
 		it('is a no-op when the preview section is not rendered', () => {


### PR DESCRIPTION
## Description

The welcome page's scroll affordance duplicated the scroll container's CSS scroll behavior in JavaScript. The container (`welcome-route` element) already declares `scroll-behavior: smooth` plus a `prefers-reduced-motion` → `auto` override in CSS, yet `scrollToPreview()` re-derived that policy imperatively — branching on `matchMedia('(prefers-reduced-motion: reduce)')` and passing an explicit `behavior` to `scrollIntoView`. Two sources of truth for the same motion policy can silently drift.

This makes CSS the single source of truth for motion: the method now calls `scrollIntoView({ block: 'start' })` with **no** `behavior`, so the container's `scroll-behavior` decides smooth-vs-instant.

## Type of Change

- [x] refactor: A code change that neither fixes a bug nor adds a feature

## Changes

- `scrollToPreview()` drops the `matchMedia` branch, the reduced-motion `behavior` selection, and the debug logging; it collapses to `this.host.querySelector('.welcome-screen-2')?.scrollIntoView({ block: 'start' })`.
- Updated the ViewModel and template comments to record that motion policy lives in CSS.
- Rewrote the `scrollToPreview` unit tests: the two `matchMedia`-driven cases are replaced by one asserting `scrollIntoView` is called with `{ block: 'start' }` (no behavior); the no-op-when-absent case is kept.

Net: **20 insertions, 71 deletions** across 3 files.

## Why

- **Single source of truth**: reduced-motion / smooth-scroll policy is declared once, in CSS. No drift risk between a CSS media query and a JS `matchMedia` branch.
- **Less imperative code**: removes the `matchMedia` feature-detection boilerplate and the explicit behavior selection.

## What was rejected, and why

The original goal was a fully JS-free native `<a href="#welcome-preview">` fragment link (Screen 2 gaining an `id` + `tabindex`). That was implemented and **rejected after E2E revealed it does not work with this router**:

- `@aurelia/router` intercepts `<a href>` clicks as route navigations. Adding the router's `external` opt-out fixed that (the hash updates natively)...
- ...but the resulting hash change makes the router re-evaluate routing and **tear the `welcome-route` component down** (confirmed via a scroll-position/`location.hash` probe: after the click `location.hash === '#welcome-preview'` but the `welcome-route` element is gone).

Because the Aurelia router owns the URL, native in-page fragment scrolling is not viable here. Keeping a `<button>` + a one-line `scrollIntoView()` — with motion delegated to CSS — captures the real win (no duplicated motion policy) without fighting the router.

## Verification

### Automated Tests
- [x] `npx vitest run test/routes/welcome-route.spec.ts` — 12 passed (incl. the rewritten `scrollToPreview` tests).
- [x] `npx playwright test --project=onboarding onboarding-flow.spec.ts -g "Tapping See how it works"` — passed locally; the CSS-driven smooth scroll brings Screen 2 into the viewport.
- [x] `npx tsc --noEmit` — clean across `src/`.
- [x] `npx biome lint` — clean on the changed files.

### Manual Verification
- Confirmed via an instrumented E2E probe that the scroll container scrolls into view on tap (`scroll-behavior: smooth` governs it) and that the native-anchor variant instead unmounted the route.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

close: #478
