### PR TITLE
perf(live-highway): cache beam anchors and batch read/write per frame

### DIFF
--- a/src/components/live-highway/concert-highway.spec.ts
+++ b/src/components/live-highway/concert-highway.spec.ts
@@ -10,12 +10,30 @@ vi.mock('aurelia', async (importOriginal) => {
 	}
 })
 
-import type { DateGroup } from '../../entities/concert'
+import type { Concert, DateGroup } from '../../entities/concert'
 import { ConcertHighway } from './concert-highway'
 
 const fakeElement = {
-	querySelector: vi.fn(() => null),
-	querySelectorAll: vi.fn(() => []),
+	querySelector: vi.fn((): unknown => null),
+	querySelectorAll: vi.fn((_selector: string): unknown[] => []),
+}
+
+function makeConcert(overrides: Partial<Concert>): Concert {
+	return {
+		id: 'e1',
+		artistName: 'Artist',
+		artistId: 'a1',
+		venueName: 'Venue',
+		locationLabel: 'Tokyo',
+		date: new Date('2026-04-01'),
+		startTime: '18:00',
+		title: 'Live',
+		sourceUrl: '',
+		merchUrl: '',
+		hypeLevel: 'home',
+		matched: true,
+		...overrides,
+	}
 }
 
 describe('ConcertHighway', () => {
@@ -23,6 +41,7 @@ describe('ConcertHighway', () => {
 
 	beforeEach(() => {
 		fakeElement.querySelector.mockReturnValue(null)
+		fakeElement.querySelectorAll.mockReturnValue([])
 		sut = new ConcertHighway()
 	})
 
@@ -63,6 +82,97 @@ describe('ConcertHighway', () => {
 		})
 	})
 
+	describe('cached anchor-to-element resolution', () => {
+		function primeFrame(): FrameRequestCallback[] {
+			const frames: FrameRequestCallback[] = []
+			vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb) => {
+				frames.push(cb)
+				return frames.length
+			})
+			return frames
+		}
+
+		it('builds the anchor→element map from data-beam-index on dateGroups change and resolves cards from it', () => {
+			const frames = primeFrame()
+			const card = {
+				dataset: { beamIndex: '0' },
+				getBoundingClientRect: () => ({ top: 10, bottom: 100 }),
+			}
+			const beam = {
+				dataset: { beamAnchor: '0' },
+				style: { setProperty: vi.fn() },
+			}
+			fakeElement.querySelectorAll.mockImplementation((selector: string) => {
+				if (selector === '.laser-beam') return [beam]
+				if (selector === '[data-beam-index]') return [card]
+				return []
+			})
+
+			sut.dateGroups = [
+				{
+					label: '2026-04-01',
+					dateKey: '2026-04-01',
+					home: [makeConcert({ id: 'e1', matched: true })],
+					nearby: [],
+					away: [],
+				},
+			]
+			sut.attached()
+
+			// Run the frame scheduled by the beam-set rebuild.
+			for (const cb of frames.splice(0)) cb(0)
+
+			// The map was built once from a single [data-beam-index] query...
+			expect(fakeElement.querySelectorAll).toHaveBeenCalledWith(
+				'[data-beam-index]',
+			)
+			const cache = (sut as unknown as { beamElements: Map<number, unknown> })
+				.beamElements
+			expect(cache.get(0)).toBe(card)
+
+			// ...and no per-frame per-beam element query was issued.
+			expect(fakeElement.querySelector).not.toHaveBeenCalledWith(
+				expect.stringContaining('data-beam-index'),
+			)
+
+			// Card geometry resolved via the cache drove the beam write.
+			expect(beam.style.setProperty).toHaveBeenCalledWith('--beam-h', '100px')
+			expect(beam.style.setProperty).toHaveBeenCalledWith(
+				'--beam-top-pct',
+				'10%',
+			)
+		})
+
+		it('skips a beam whose anchor card is absent from the cache without error', () => {
+			const frames = primeFrame()
+			const beam = {
+				dataset: { beamAnchor: '0' },
+				style: { setProperty: vi.fn() },
+			}
+			fakeElement.querySelectorAll.mockImplementation((selector: string) => {
+				if (selector === '.laser-beam') return [beam]
+				// No matching [data-beam-index] card mounted yet.
+				return []
+			})
+
+			sut.dateGroups = [
+				{
+					label: '2026-04-01',
+					dateKey: '2026-04-01',
+					home: [makeConcert({ id: 'e1', matched: true })],
+					nearby: [],
+					away: [],
+				},
+			]
+			sut.attached()
+
+			expect(() => {
+				for (const cb of frames.splice(0)) cb(0)
+			}).not.toThrow()
+			expect(beam.style.setProperty).not.toHaveBeenCalled()
+		})
+	})
+
 	describe('detaching lifecycle', () => {
 		it('cancels animation frame and removes scroll listener', () => {
 			const cancelSpy = vi.spyOn(globalThis, 'cancelAnimationFrame')
@@ -72,6 +182,20 @@ describe('ConcertHighway', () => {
 
 			// Should not throw even without active rAF
 			expect(cancelSpy).toHaveBeenCalled()
+		})
+
+		it('clears the cached anchor→element map', () => {
+			const card = {
+				dataset: { beamIndex: '0' },
+				getBoundingClientRect: () => ({ top: 10, bottom: 100 }),
+			}
+			const cache = (sut as unknown as { beamElements: Map<number, unknown> })
+				.beamElements
+			cache.set(0, card)
+
+			sut.detaching()
+
+			expect(cache.size).toBe(0)
 		})
 	})
 })

--- a/src/components/live-highway/concert-highway.ts
+++ b/src/components/live-highway/concert-highway.ts
@@ -25,6 +25,14 @@ export class ConcertHighway {
 	private scrollContainer: Element | null = null
 	private readonly onScroll = (): void => this.scheduleBeamUpdate()
 
+	/**
+	 * Cached anchor→card element map, keyed by beam-anchor index. Rebuilt only
+	 * when the beam set changes, so the per-frame update resolves each beam's
+	 * card from this map instead of a per-frame `querySelector`.
+	 */
+	private readonly beamElements = new Map<number, HTMLElement>()
+	private beamElementsDirty = false
+
 	public dateGroupsChanged(): void {
 		if (this.isAttached) {
 			this.buildBeamIndexMap()
@@ -47,6 +55,8 @@ export class ConcertHighway {
 			cancelAnimationFrame(this.beamRafId)
 			this.beamRafId = 0
 		}
+		this.beamElements.clear()
+		this.beamElementsDirty = true
 	}
 
 	/** Assign sequential beam indices to matched events across all groups. */
@@ -82,7 +92,24 @@ export class ConcertHighway {
 
 		this.beamIndexMap = map
 		this.laserBeams = beams
+		// The beam set changed; the cached anchor→element map must be rebuilt.
+		// The actual DOM query is deferred to the scheduled rAF, where Aurelia
+		// has already flushed the new `data-beam-index` attributes.
+		this.beamElementsDirty = true
 		this.scheduleBeamUpdate()
+	}
+
+	/** Rebuild the anchor→card element map from the current DOM. */
+	private rebuildBeamElements(): void {
+		this.beamElements.clear()
+		const cards =
+			this.element.querySelectorAll<HTMLElement>('[data-beam-index]')
+		for (const card of cards) {
+			const idx = card.dataset.beamIndex
+			if (idx == null) continue
+			this.beamElements.set(Number(idx), card)
+		}
+		this.beamElementsDirty = false
 	}
 
 	/** Wire scroll listener for JS-based beam height tracking. */
@@ -105,14 +132,20 @@ export class ConcertHighway {
 
 	/** Set beam dimensions so triangle wraps card diagonally (bottom-left to top-right). */
 	private updateBeamPositions(): void {
+		if (this.beamElementsDirty) {
+			this.rebuildBeamElements()
+		}
 		const beamEls = this.element.querySelectorAll<HTMLElement>('.laser-beam')
 		const vh = window.innerHeight
+
+		// Read phase: collect every beam's geometry before mutating any style,
+		// so no layout read follows a style write within this frame.
+		const writes: { beamEl: HTMLElement; height: string; topPct?: string }[] =
+			[]
 		for (const beamEl of beamEls) {
 			const idx = beamEl.dataset.beamAnchor
 			if (idx == null) continue
-			const card = this.element.querySelector<HTMLElement>(
-				`[data-beam-index="${idx}"]`,
-			)
+			const card = this.beamElements.get(Number(idx))
 			if (!card) continue
 			const rect = card.getBoundingClientRect()
 			const visible = rect.bottom > 0 && rect.top < vh
@@ -120,10 +153,17 @@ export class ConcertHighway {
 				const bottom = Math.max(0, rect.bottom)
 				const topPct =
 					bottom > 0 ? `${(Math.max(0, rect.top) / bottom) * 100}%` : '80%'
-				beamEl.style.setProperty('--beam-h', `${bottom}px`)
-				beamEl.style.setProperty('--beam-top-pct', topPct)
+				writes.push({ beamEl, height: `${bottom}px`, topPct })
 			} else {
-				beamEl.style.setProperty('--beam-h', '0')
+				writes.push({ beamEl, height: '0' })
+			}
+		}
+
+		// Write phase: apply all style writes after every read has completed.
+		for (const { beamEl, height, topPct } of writes) {
+			beamEl.style.setProperty('--beam-h', height)
+			if (topPct != null) {
+				beamEl.style.setProperty('--beam-top-pct', topPct)
 			}
 		}
 	}

--- a/src/components/live-highway/event-card.css
+++ b/src/components/live-highway/event-card.css
@@ -196,19 +196,6 @@
 		   Keyframes
 		   ============================================= */
 
-		/* Beam descends from above — scroll-triggered (GPU-composited) */
-		@keyframes beam-descend {
-			from {
-				transform: scaleY(0);
-				opacity: 0;
-			}
-
-			to {
-				transform: scaleY(1);
-				opacity: 1;
-			}
-		}
-
 		/* Contact glow fades in after beam arrives */
 		@keyframes contact-glow {
 			from {


### PR DESCRIPTION
## Why

The `<concert-highway>` laser-beam scroll tracking is the heaviest runtime JS on the dashboard and Welcome-preview hot path. Each `requestAnimationFrame` update did a per-beam `querySelector('[data-beam-index=...]')` to re-resolve stable card elements, and interleaved layout reads (`getBoundingClientRect`) with style writes (`setProperty`) in one loop — the canonical layout-thrash shape — adding INP cost on mobile for no visual benefit.

## What

- **Cached anchor→element map**: each beam's anchor card is resolved from a `Map<number, HTMLElement>` rebuilt only when the beam set changes (same `buildBeamIndexMap` triggers). The DOM query is deferred to the scheduled rAF so Aurelia has flushed the new `data-beam-index` attributes; a missing entry degrades gracefully exactly as the old null-guard did.
- **Two-phase read-before-write per frame**: a read phase collects every beam's geometry, then a write phase applies all `--beam-h` / `--beam-top-pct` writes — no interleave.
- **Dead-code removal**: dropped the unused `@keyframes beam-descend` from `event-card.css` (never referenced by any `animation:`).

Computed beam values are **byte-identical** — same formulas, only reordered. A full CSS scroll-driven-animation rewrite was evaluated and deferred (non-linear beam geometry, dynamic per-card timelines, mandatory iOS/Safari `@supports` fallback).

## Testing

- Extended `concert-highway.spec.ts`: asserts the anchor→element map is built from a single `[data-beam-index]` query on `dateGroups` change, that `updateBeamPositions` resolves cards from it (no per-frame query), graceful skip on a missing card, and cache-clear on detach.
- `make check` (Biome lint + templates + Vitest + bundle-isolation) green.
- Beam rendering guarded by the `mobile-visual` E2E project in CI. Live beam behavior to be confirmed on prod post-release.

OpenSpec change: `optimize-concert-highway-beam-tracking`.

Closes #480